### PR TITLE
ci: enable github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+on:
+  push:
+    branches: [ 'main' ]
+    pull_request: [ 'main' ]
+    schedule:
+      - cron: '17 3 * * 0'
+
+jobs:
+  flake8:
+    name: Linting (flake8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # matches compat target in setup.py
+          python-version: '3.8'
+      - name: "Main Script"
+        run: |
+          export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
+
+          curl -L -O https://tiker.net/ci-support-v0
+          . ci-support-v0
+
+          build_py_project_in_conda_env
+          install_and_run_flake8 "$(get_proj_name)" examples/*.py test/*.py benchmarks/*.py
+
+  pytest:
+    name: Testing (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: "Main Script"
+        run: |
+          export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
+          export PYTEST_FLAGS="--cov=volumential"
+
+          curl -L -O https://tiker.net/ci-support-v0
+          . ci-support-v0
+
+          build_py_project_in_conda_env
+          test_py_project
+
+  pytest_mac:
+    name: Testing (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: "Main Script"
+        run: |
+          export LC_ALL=en_US.UTF-8
+          export LANG=en_US.UTF-8
+
+          export CONDA_ENVIRONMENT=.test-conda-env-py3-macos.yml
+          export PYTEST_FLAGS="--cov=volumential"
+
+          curl -L -O https://tiker.net/ci-support-v0
+          . ci-support-v0
+
+          build_py_project_in_conda_env
+          test_py_project
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: "Main Script"
+        run: |
+          export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
+
+          curl -L -O https://tiker.net/ci-support-v0
+          . ci-support-v0
+
+          build_py_project_in_conda_env
+          build_docs
+
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: "Main Script"
+        run: |
+          export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
+
+          curl -L -O https://tiker.net/ci-support-v0
+          . ci-support-v0
+          build_py_project_in_conda_env
+          run_examples
+
+# vim: sw=2

--- a/.test-conda-env-py3-macos.yml
+++ b/.test-conda-env-py3-macos.yml
@@ -3,37 +3,37 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - git
-  - python>=3.8
-  - dealii
-  - pocl
-  - pyopencl
-  - pyfmmlib
-  - scipy
-  - numpy
-  - sympy
-  - symengine
-  - python-symengine
-  - cython
-  - cgen
-  - toml
-  - py
-  - pluggy
-  - packaging
-  - iniconfig
   - attrs
-  - genpy
+  - cgen
+  - clangdev
+  - cmake
   - colorama
-  - islpy
-  - pyrsistent
+  - cython
+  - dealii
+  - genpy
+  - git
   - h5py
+  - iniconfig
+  - islpy
+  - numpy
+  - openmp
+  - packaging
+  - pluggy
+  - pocl
+  - py
   - pyevtk
+  - pyfmmlib
+  - pyopencl
+  - pyrsistent
   - pytest
   - pytest-cov
-  - cmake
-  # enable openmp on osx
-  - openmp
-  - clangdev
+  - python-symengine
+  - python>=3.8
+  - pyvkfft
+  - scipy
+  - symengine
+  - sympy
+  - toml
 
   - pip
   - pip:

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -3,35 +3,36 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - git
-  - python>=3.8
-  - dealii
-  - pocl
-  - pyopencl
-  - pyfmmlib
-  - scipy
-  - numpy
-  - sympy
-  - matplotlib-base
-  - cgen
-  - cython
-  - toml
-  - py
-  - pluggy
-  - packaging
-  - iniconfig
   - attrs
-  - genpy
+  - cgen
+  - cmake
   - colorama
-  - islpy
-  - pyrsistent
+  - cython
+  - dealii
+  - genpy
+  - git
   - h5py
+  - iniconfig
+  - islpy
+  - matplotlib-base
+  - numpy
+  - packaging
+  - pluggy
+  - pocl
+  - py
   - pyevtk
+  - pyfmmlib
+  - pyopencl
+  - pyrsistent
   - pytest
   - pytest-cov
-  - cmake
-  - symengine
   - python-symengine
+  - python>=3.8
+  - pyvkfft
+  - scipy
+  - symengine
+  - sympy
+  - toml
 
   - pip
   - pip:


### PR DESCRIPTION
This sets up the Github Actions CI and mostly mimics the `gitlab-ci.yml`, with some caveats:
* Only conda builds are used
* There's no Intel job
* There's no Firedrake job
* The documentation job just builds the docs, but doesn't upload them like the Gitlab CI does.

This seems to be working as expected, i.e. the build works, but the tests are failing
https://github.com/alexfikl/volumential/actions/runs/8220696697
I would say it's worth merging even if it's not complete, since the CI doesn't run if it's not on `main`. We can then improve it piece by piece.