### PR TITLE
style: enable and fix many flake8 issues

### DIFF
--- a/benchmarks/scalar_field.py
+++ b/benchmarks/scalar_field.py
@@ -139,7 +139,7 @@ knl = source_eval.get_kernel()
 # needed for using loopy.statistics
 knl = lp.add_and_infer_dtypes(
         knl,
-        dict(x0=np.float64, x1=np.float64, x2=np.float64))
+        {"x0": np.float64, "x1": np.float64, "x2": np.float64})
 knl = lp.set_options(knl, ignore_boostable_into=True)
 
 # {{{ wall time
@@ -178,7 +178,7 @@ print("Wall time w/t tag g.0:", t3 - t2)
 op_map = lp.get_op_map(knl, subgroup_size=ncpus, count_redundant_work=True,
         count_within_subscripts=True)
 
-params = dict(n_targets=pts.shape[1])
+params = {"n_targets": pts.shape[1]}
 print('Operation counts:')
 total_ops = 0
 for op in op_map.keys():

--- a/benchmarks/scalar_field.py
+++ b/benchmarks/scalar_field.py
@@ -23,14 +23,18 @@ THE SOFTWARE.
 import os
 import time
 import warnings
-import pyopencl as cl
-import pyopencl.clrandom
+
 import numpy as np
+
 import loopy as lp
 import pymbolic as pmbl
 import pymbolic.primitives as primitives
-from pymbolic.functions import sin, cos, exp, tan, log  # noqa: F401
+import pyopencl as cl
+import pyopencl.clrandom
+from pymbolic.functions import cos, exp, log, sin, tan  # noqa: F401
+
 from volumential.tools import ScalarFieldExpressionEvaluation
+
 
 # {{{ math functions
 

--- a/benchmarks/scalar_field.py
+++ b/benchmarks/scalar_field.py
@@ -80,7 +80,7 @@ def math_func_mangler(target, name, arg_dtypes):
                         arg_dtype)
 
             return lp.CallMangleInfo(
-                   target_name="%s_%s" % (tpname, fname),
+                   target_name=f"{tpname}_{fname}",
                    result_dtypes=(arg_dtype,),
                    arg_dtypes=(arg_dtype,))
 

--- a/benchmarks/scalar_field.py
+++ b/benchmarks/scalar_field.py
@@ -66,7 +66,7 @@ def math_func_mangler(target, name, arg_dtypes):
 
         fname = name.name
         if not (isinstance(name.aggregate, pmbl.primitives.Variable)
-                and name.aggregate.name == 'math'):
+                and name.aggregate.name == "math"):
             raise RuntimeError("unexpected aggregate '%s'" %
                     str(name.aggregate))
 
@@ -179,12 +179,12 @@ op_map = lp.get_op_map(knl, subgroup_size=ncpus, count_redundant_work=True,
         count_within_subscripts=True)
 
 params = {"n_targets": pts.shape[1]}
-print('Operation counts:')
+print("Operation counts:")
 total_ops = 0
 for op in op_map.keys():
     sub_count = op_map[op].eval_with_dict(params)
     total_ops += sub_count
-    print('\t', op.name, op_map[op], sub_count)
+    print("\t", op.name, op_map[op], sub_count)
 print("Total:", total_ops)
 
 # TODO: weight each operation by running micro-benchmarks

--- a/benchmarks/table_build.py
+++ b/benchmarks/table_build.py
@@ -25,7 +25,7 @@ import pyopencl as cl
 from volumential.table_manager import NearFieldInteractionTableManager
 
 import logging
-logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s')
+logging.basicConfig(format="%(name)s:%(levelname)s: %(message)s")
 
 
 def bench_table_build(queue):
@@ -68,5 +68,5 @@ def main():
     bench_table_build(queue)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/benchmarks/table_build.py
+++ b/benchmarks/table_build.py
@@ -20,11 +20,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import logging
 import time
+
 import pyopencl as cl
+
 from volumential.table_manager import NearFieldInteractionTableManager
 
-import logging
+
 logging.basicConfig(format="%(name)s:%(levelname)s: %(message)s")
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Volumential documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct 23 10:27:37 2017.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,7 +21,7 @@ import sys
 from datetime import datetime
 import volumential.version as __version__
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # -- General configuration ------------------------------------------------
@@ -34,18 +34,18 @@ sys.path.insert(0, os.path.abspath('..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-        'sphinx.ext.autodoc',
-        'sphinx.ext.todo',
-        'sphinx.ext.autosummary',
-        'sphinx.ext.coverage',
-        'sphinx.ext.mathjax',
-        'sphinx.ext.ifconfig',
-        'sphinx.ext.viewcode',
-        'sphinx.ext.intersphinx',
-        'sphinx.ext.githubpages']
+        "sphinx.ext.autodoc",
+        "sphinx.ext.todo",
+        "sphinx.ext.autosummary",
+        "sphinx.ext.coverage",
+        "sphinx.ext.mathjax",
+        "sphinx.ext.ifconfig",
+        "sphinx.ext.viewcode",
+        "sphinx.ext.intersphinx",
+        "sphinx.ext.githubpages"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # Set the mathjax CDN
 mathjax_path = (
@@ -57,15 +57,15 @@ mathjax_path = (
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'Volumential'
-copyright = '%s, Xiaoyu Wei' % str(datetime.today().year)
-author = 'Xiaoyu Wei'
+project = "Volumential"
+copyright = "%s, Xiaoyu Wei" % str(datetime.today().year)
+author = "Xiaoyu Wei"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -90,7 +90,7 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
@@ -101,7 +101,7 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -112,7 +112,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -120,9 +120,9 @@ html_static_path = ['_static']
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
+    "**": [
+        "relations.html",  # needs 'show_related': True theme option to display
+        "searchbox.html",
     ]
 }
 
@@ -130,7 +130,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Volumentialdoc'
+htmlhelp_basename = "Volumentialdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -156,8 +156,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Volumential.tex', 'Volumential Documentation',
-     'Xiaoyu Wei', 'manual'),
+    (master_doc, "Volumential.tex", "Volumential Documentation",
+     "Xiaoyu Wei", "manual"),
 ]
 
 
@@ -166,7 +166,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'volumential', 'Volumential Documentation',
+    (master_doc, "volumential", "Volumential Documentation",
      [author], 1)
 ]
 
@@ -177,7 +177,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Volumential', 'Volumential Documentation',
-     author, 'Volumential', 'One line description of project.',
-     'Miscellaneous'),
+    (master_doc, "Volumential", "Volumential Documentation",
+     author, "Volumential", "One line description of project.",
+     "Miscellaneous"),
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,7 +48,10 @@ extensions = [
 templates_path = ['_templates']
 
 # Set the mathjax CDN
-mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+mathjax_path = (
+    "https://cdnjs.cloudflare.com/ajax/libs/"
+    "mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+)
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,7 +19,9 @@
 import os
 import sys
 from datetime import datetime
+
 import volumential.version as __version__
+
 
 sys.path.insert(0, os.path.abspath(".."))
 

--- a/examples/laplace2d.py
+++ b/examples/laplace2d.py
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 import logging
 
+
 logger = logging.getLogger(__name__)
 
 if 1:
@@ -35,12 +36,14 @@ else:
     # clean
     logging.basicConfig(level=logging.CRITICAL)
 
+from functools import partial
+
 import numpy as np
-import pyopencl as cl
-from volumential.tools import ScalarFieldExpressionEvaluation as Eval
 
 import pymbolic as pmbl
-from functools import partial
+import pyopencl as cl
+
+from volumential.tools import ScalarFieldExpressionEvaluation as Eval
 
 
 def main():
@@ -204,8 +207,9 @@ def main():
 
     # {{{ build near field potential table
 
-    from volumential.table_manager import NearFieldInteractionTableManager
     import os
+
+    from volumential.table_manager import NearFieldInteractionTableManager
 
     if download_table and (not os.path.isfile(table_filename)):
         import json
@@ -279,9 +283,7 @@ def main():
     exclude_self = True
 
     from volumential.expansion_wrangler_fpnd import (
-            FPNDExpansionWranglerCodeContainer,
-            FPNDExpansionWrangler
-            )
+        FPNDExpansionWrangler, FPNDExpansionWranglerCodeContainer)
 
     wcc = FPNDExpansionWranglerCodeContainer(
         ctx,
@@ -316,9 +318,9 @@ def main():
 
     # {{{ conduct fmm computation
 
-    from volumential.volume_fmm import drive_volume_fmm
-
     import time
+
+    from volumential.volume_fmm import drive_volume_fmm
     queue.finish()
 
     t0 = time.time()

--- a/examples/laplace2d.py
+++ b/examples/laplace2d.py
@@ -387,8 +387,8 @@ def main():
         from mpl_toolkits.mplot3d import Axes3D
 
         plt3d = plt.figure()
-        ax = Axes3D(plt3d)  # noqa
-        surf = ax.plot_surface(oxx, oyy, opot.reshape(oxx.shape))  # noqa
+        ax = Axes3D(plt3d)
+        surf = ax.plot_surface(oxx, oyy, opot.reshape(oxx.shape))  # noqa: F841
         # ax.scatter(x, y, src.get())
         # ax.set_zlim(-0.25, 0.25)
 

--- a/examples/laplace2d.py
+++ b/examples/laplace2d.py
@@ -1,7 +1,6 @@
 """ This example evaluates the volume potential over
     [-1,1]^2 with the Laplace kernel.
 """
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
@@ -210,7 +209,7 @@ def main():
 
     if download_table and (not os.path.isfile(table_filename)):
         import json
-        with open("table_urls.json", 'r') as fp:
+        with open("table_urls.json") as fp:
             urls = json.load(fp)
 
         print("Downloading table from %s" % urls['Laplace2D'])

--- a/examples/laplace2d.py
+++ b/examples/laplace2d.py
@@ -212,9 +212,9 @@ def main():
         with open("table_urls.json") as fp:
             urls = json.load(fp)
 
-        print("Downloading table from %s" % urls['Laplace2D'])
+        print("Downloading table from %s" % urls["Laplace2D"])
         import subprocess
-        subprocess.call(["wget", "-q", urls['Laplace2D'], table_filename])
+        subprocess.call(["wget", "-q", urls["Laplace2D"], table_filename])
 
     tm = NearFieldInteractionTableManager(
         table_filename, root_extent=root_table_source_extent,
@@ -471,7 +471,7 @@ def main():
     # }}} End postprocess and plot
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
 
 

--- a/examples/laplace3d.py
+++ b/examples/laplace3d.py
@@ -25,15 +25,16 @@ THE SOFTWARE.
 """
 
 import logging
+from functools import partial
 
 import numpy as np
-import pyopencl as cl
 
 import pymbolic as pmbl
 import pymbolic.functions
+import pyopencl as cl
+
 from volumential.tools import ScalarFieldExpressionEvaluation as Eval
 
-from functools import partial
 
 verbose = True
 logger = logging.getLogger(__name__)
@@ -214,8 +215,9 @@ def main():
 
     # {{{ build near field potential table
 
-    from volumential.table_manager import NearFieldInteractionTableManager
     import os
+
+    from volumential.table_manager import NearFieldInteractionTableManager
 
     if download_table and (not os.path.isfile(table_filename)):
         import json
@@ -292,8 +294,7 @@ def main():
 
     exclude_self = True
     from volumential.expansion_wrangler_fpnd import (
-            FPNDExpansionWrangler,
-            FPNDExpansionWranglerCodeContainer)
+        FPNDExpansionWrangler, FPNDExpansionWranglerCodeContainer)
 
     wcc = FPNDExpansionWranglerCodeContainer(
         ctx,
@@ -328,9 +329,9 @@ def main():
 
     # {{{ conduct fmm computation
 
-    from volumential.volume_fmm import drive_volume_fmm
-
     import time
+
+    from volumential.volume_fmm import drive_volume_fmm
     queue.finish()
 
     t0 = time.time()
@@ -424,11 +425,10 @@ def main():
         from meshmode.mesh.io import read_gmsh
 
         modemesh = read_gmsh("box_grid.msh", force_ambient_dim=None)
-        from meshmode.discretization.poly_element import (
-            LegendreGaussLobattoTensorProductGroupFactory,
-        )
         from meshmode.array_context import PyOpenCLArrayContext
         from meshmode.discretization import Discretization
+        from meshmode.discretization.poly_element import (
+            LegendreGaussLobattoTensorProductGroupFactory)
 
         actx = PyOpenCLArrayContext(queue)
         box_discr = Discretization(

--- a/examples/laplace3d.py
+++ b/examples/laplace3d.py
@@ -222,9 +222,9 @@ def main():
         with open("table_urls.json") as fp:
             urls = json.load(fp)
 
-        print("Downloading table from %s" % urls['Laplace3D'])
+        print("Downloading table from %s" % urls["Laplace3D"])
         import subprocess
-        subprocess.call(["wget", "-q", urls['Laplace3D'], table_filename])
+        subprocess.call(["wget", "-q", urls["Laplace3D"], table_filename])
 
     tm = NearFieldInteractionTableManager(
         table_filename, root_extent=root_table_source_extent,
@@ -489,7 +489,7 @@ def main():
     # }}} End postprocess and plot
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
 
 

--- a/examples/laplace3d.py
+++ b/examples/laplace3d.py
@@ -1,7 +1,6 @@
 """ This example evaluates the volume potential over
     [-1,1]^3 with the Laplace kernel.
 """
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
@@ -220,7 +219,7 @@ def main():
 
     if download_table and (not os.path.isfile(table_filename)):
         import json
-        with open("table_urls.json", 'r') as fp:
+        with open("table_urls.json") as fp:
             urls = json.load(fp)
 
         print("Downloading table from %s" % urls['Laplace3D'])

--- a/experiments/sep.py
+++ b/experiments/sep.py
@@ -391,8 +391,8 @@ def main():
         from mpl_toolkits.mplot3d import Axes3D
 
         plt3d = plt.figure()
-        ax = Axes3D(plt3d)  # noqa
-        surf = ax.plot_surface(oxx, oyy, opot.reshape(oxx.shape))  # noqa
+        ax = Axes3D(plt3d)
+        surf = ax.plot_surface(oxx, oyy, opot.reshape(oxx.shape))  # noqa: F841
         # ax.scatter(x, y, src.get())
         # ax.set_zlim(-0.25, 0.25)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,11 @@
 ignore = E126,E127,E128,E123,E226,E241,E242,E265,E402,W503
 max-line-length=85
 
+inline-quotes = "
+docstring-quotes = """
+multiline-quotes = """
+
+# enable-flake8-bugbear
+
 [pycodestyle]
 max-line-length=85

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,15 @@ docstring-quotes = """
 multiline-quotes = """
 
 # enable-flake8-bugbear
+# enable-flake8-isort
 
 [pycodestyle]
 max-line-length=85
+
+[isort]
+known_firstparty=pytools,pyopencl,loopy,modepy,pymbolic,boxtree,pytential,sumpy,meshmode
+known_local_folder=volumential
+line_length = 85
+lines_after_imports = 2
+combine_as_imports = True
+multi_line_output = 4

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 
 __copyright__ = "Copyright (C) 2017 Xiaoyu Wei"
 
@@ -47,8 +46,7 @@ def find_git_revision(tree_root):
     (git_rev, _) = p.communicate()
 
     import sys
-    if sys.version_info >= (3,):
-        git_rev = git_rev.decode()
+    git_rev = git_rev.decode()
 
     git_rev = git_rev.rstrip()
 
@@ -79,7 +77,7 @@ def main():
     init_filename = "volumential/version.py"
     os.environ["AKPYTHON_EXEC_FROM_WITHIN_WITHIN_SETUP_PY"] = "1"
     exec(compile(
-        open(init_filename, "r").read(), init_filename, "exec"),
+        open(init_filename).read(), init_filename, "exec"),
         version_dict)
 
     write_git_revision("volumential")

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def write_git_revision(package_name):
     git_rev = find_git_revision(dn)
 
     with open(join(dn, package_name, "_git_rev.py"), "w") as outf:
-        outf.write("GIT_REVISION = %s\n" % repr(git_rev))
+        outf.write(f'GIT_REVISION = "{git_rev}"\n')
 
 
 # }}}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,7 @@ import pytest
 from filelock import FileLock
 
 # setup the ctx_factory fixture
-from pyopencl.tools import (  # NOQA
+from pyopencl.tools import (  # noqa: F401
     pytest_generate_tests_for_pyopencl as pytest_generate_tests)
 
 from volumential.table_manager import NearFieldInteractionTableManager as NFTManager

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,18 +21,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import subprocess
 import glob
+import subprocess
+
+import pytest
 from filelock import FileLock
-import pytest  # noqa: F401
 
 # setup the ctx_factory fixture
 from pyopencl.tools import (  # NOQA
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests,
-)
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests)
 
-from volumential.table_manager import \
-    NearFieldInteractionTableManager as NFTManager
+from volumential.table_manager import NearFieldInteractionTableManager as NFTManager
 
 
 def pytest_addoption(parser):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,17 +41,17 @@ def pytest_addoption(parser):
     --longrun  Skip expensive tests unless told otherwise.
 
     """
-    parser.addoption('--longrun', action='store_true', dest="longrun",
+    parser.addoption("--longrun", action="store_true", dest="longrun",
                      default=False, help="enable longrundecorated tests")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def longrun(request):
     if not request.config.option.longrun:
         pytest.skip("needs --longrun option to run")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def requires_pypvfmm(request):
     try:
         import pypvfmm  # noqa: F401
@@ -59,14 +59,14 @@ def requires_pypvfmm(request):
         pytest.skip("needs pypvfmm to run")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def table_2d_order1(tmp_path_factory, worker_id):
     if not worker_id:
         # not executing in with multiple workers, just produce the data and let
         # pytest's fixture caching do its job
         with NFTManager("nft.hdf5", progress_bar=True) as table_manager:
             table, _ = table_manager.get_table(2, "Laplace", q_order=1)
-        subprocess.check_call(['rm', '-f', 'nft.hdf5'])
+        subprocess.check_call(["rm", "-f", "nft.hdf5"])
         return table
 
     # get the temp directory shared by all workers
@@ -83,4 +83,4 @@ def table_2d_order1(tmp_path_factory, worker_id):
 def pytest_sessionfinish(session, exitstatus):
     # remove table caches
     for table_file in glob.glob("*.hdf5"):
-        subprocess.call(['rm', '-f', table_file])
+        subprocess.call(["rm", "-f", table_file])

--- a/test/test_cahn_hilliard.py
+++ b/test/test_cahn_hilliard.py
@@ -1,4 +1,3 @@
-
 __copyright__ = "Copyright (C) 2017 Xiaoyu Wei"
 
 __license__ = """
@@ -50,7 +49,7 @@ def test_patch_cahn_hilliard():
 
     import random
 
-    for r in range(rep):
+    for _ in range(rep):
         center_x = random.uniform(-1, 1)
         center_y = random.uniform(-1, 1)
         center = [center_x, center_y]
@@ -118,7 +117,7 @@ def test_cahn_hilliard_same_box_on_patch(longrun):
     # inside the box
     import random
 
-    for r in range(rep):
+    for _ in range(rep):
         center_x = random.uniform(size / 2, 1 - size / 2)
         center_y = random.uniform(size / 2, 1 - size / 2)
         center = [center_x, center_y]

--- a/test/test_cahn_hilliard.py
+++ b/test/test_cahn_hilliard.py
@@ -21,8 +21,10 @@ THE SOFTWARE.
 """
 
 import numpy as np
-import volumential.nearfield_potential_table as npt
+
 from sumpy.point_calculus import CalculusPatch
+
+import volumential.nearfield_potential_table as npt
 
 
 dim = 2

--- a/test/test_cahn_hilliard.py
+++ b/test/test_cahn_hilliard.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 Xiaoyu Wei"
 

--- a/test/test_droste.py
+++ b/test/test_droste.py
@@ -49,7 +49,7 @@ def drive_test_cheb_poly(queue, deg, nnodes):
                     results[f0, i] = basis_eval0
                 end
             end
-            """.replace('EVAL_CHEB_POINT', code)],
+            """.replace("EVAL_CHEB_POINT", code)],
             lang_version=(2018, 2)
             )
 

--- a/test/test_droste.py
+++ b/test/test_droste.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
 

--- a/test/test_droste.py
+++ b/test/test_droste.py
@@ -21,12 +21,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import pytest
-import loopy as lp
 import numpy as np
-import pyopencl as cl
-from volumential.droste import DrosteReduced
+import pytest
 from numpy.polynomial.chebyshev import chebval
+
+import loopy as lp
+import pyopencl as cl
+
+from volumential.droste import DrosteReduced
 
 
 def drive_test_cheb_poly(queue, deg, nnodes):
@@ -153,7 +155,8 @@ def drive_test_cheb_tables_laplace3d(requires_pypvfmm, ctx_factory, q_order):
 
 def drive_test_cheb_tables_grad_laplace3d(
         requires_pypvfmm, ctx_factory, q_order, axis):
-    from sumpy.kernel import LaplaceKernel, AxisTargetDerivative
+    from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
+
     from volumential.list1_symmetry import Flip, Swap
 
     cl_ctx = ctx_factory()

--- a/test/test_expansion_wrangler_interface.py
+++ b/test/test_expansion_wrangler_interface.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_expansion_wrangler_interface.py
+++ b/test/test_expansion_wrangler_interface.py
@@ -28,95 +28,80 @@ def test_interface_allocation():
     # make the interface instantiable by overriding its set of abstract methods
     ewi.ExpansionWranglerInterface.__abstractmethods__ = frozenset()
     wrglr = ewi.ExpansionWranglerInterface()
-    try:
-        wrglr.multipole_expansion_zeros()
-        wrglr.local_expansion_zeros()
-        wrglr.output_zeros()
-    except NotImplementedError:
-        assert False
-    assert True
+
+    wrglr.multipole_expansion_zeros()
+    wrglr.local_expansion_zeros()
+    wrglr.output_zeros()
 
 
 def test_interface_utilities():
     # make the interface instantiable by overriding its set of abstract methods
     ewi.ExpansionWranglerInterface.__abstractmethods__ = frozenset()
     wrglr = ewi.ExpansionWranglerInterface()
-    try:
-        wrglr.reorder_sources(None)
-        wrglr.reorder_potentials(None)
-        wrglr.finalize_potentials(None)
-    except NotImplementedError:
-        assert False
-    assert True
+
+    wrglr.reorder_sources(None)
+    wrglr.reorder_potentials(None)
+    wrglr.finalize_potentials(None)
 
 
 def test_interface_multipole_formation():
     # make the interface instantiable by overriding its set of abstract methods
     ewi.ExpansionWranglerInterface.__abstractmethods__ = frozenset()
     wrglr = ewi.ExpansionWranglerInterface()
-    try:
-        wrglr.form_multipoles(
-            level_start_source_box_nrs=None, source_boxes=None, src_weights=None
-        )
-        wrglr.form_locals(
-            level_start_target_or_target_parent_box_nrs=None,
-            target_or_target_parent_boxes=None,
-            starts=None,
-            lists=None,
-            src_weights=None,
-        )
-    except NotImplementedError:
-        assert False
-    assert True
+
+    wrglr.form_multipoles(
+        level_start_source_box_nrs=None, source_boxes=None, src_weights=None
+    )
+    wrglr.form_locals(
+        level_start_target_or_target_parent_box_nrs=None,
+        target_or_target_parent_boxes=None,
+        starts=None,
+        lists=None,
+        src_weights=None,
+    )
 
 
 def test_interface_multipole_evaluation():
     # make the interface instantiable by overriding its set of abstract methods
     ewi.ExpansionWranglerInterface.__abstractmethods__ = frozenset()
     wrglr = ewi.ExpansionWranglerInterface()
-    try:
-        wrglr.eval_direct(
-            target_boxes=None,
-            neighbor_sources_starts=None,
-            neighbor_sources_lists=None
-        )
-        wrglr.eval_locals(
-            level_start_target_box_nrs=None, target_boxes=None, local_exps=None
-        )
-        wrglr.eval_multipoles(
-            level_start_target_box_nrs=None,
-            target_boxes=None,
-            starts=None,
-            lists=None,
-            mpole_exps=None,
-        )
-    except NotImplementedError:
-        assert False
-    assert True
+
+    wrglr.eval_direct(
+        target_boxes=None,
+        neighbor_sources_starts=None,
+        neighbor_sources_lists=None
+    )
+    wrglr.eval_locals(
+        level_start_target_box_nrs=None, target_boxes=None, local_exps=None
+    )
+    wrglr.eval_multipoles(
+        level_start_target_box_nrs=None,
+        target_boxes=None,
+        starts=None,
+        lists=None,
+        mpole_exps=None,
+    )
 
 
 def test_interface_multipole_manipulation():
     # make the interface instantiable by overriding its set of abstract methods
     ewi.ExpansionWranglerInterface.__abstractmethods__ = frozenset()
     wrglr = ewi.ExpansionWranglerInterface()
-    try:
-        wrglr.coarsen_multipoles(
-            level_start_source_parent_box_nrs=None,
-            source_parent_boxes=None,
-            mpoles=None,
-        )
-        wrglr.multipole_to_local(
-            level_start_target_or_target_parent_box_nrs=None,
-            target_or_target_parent_boxes=None,
-            starts=None,
-            lists=None,
-            mpole_exps=None,
-        )
-        wrglr.refine_locals(
-            level_start_target_or_target_parent_box_nrs=None,
-            target_or_target_parent_boxes=None,
-            local_exps=None,
-        )
-    except NotImplementedError:
-        assert False
-    assert True
+
+    wrglr.coarsen_multipoles(
+        level_start_source_parent_box_nrs=None,
+        source_parent_boxes=None,
+        mpoles=None,
+    )
+    wrglr.multipole_to_local(
+        level_start_target_or_target_parent_box_nrs=None,
+        target_or_target_parent_boxes=None,
+        starts=None,
+        lists=None,
+        mpole_exps=None,
+    )
+    wrglr.refine_locals(
+        level_start_target_or_target_parent_box_nrs=None,
+        target_or_target_parent_boxes=None,
+        local_exps=None,
+    )

--- a/test/test_function_extension.py
+++ b/test/test_function_extension.py
@@ -21,20 +21,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import pytest
-from volumential.function_extension import compute_harmonic_extension
 import numpy as np
-
 import numpy.linalg as la
+import pytest
+
 import pyopencl as cl
 import pyopencl.clmath  # noqa
-
 from meshmode.discretization import Discretization
-from meshmode.discretization.poly_element import \
-        InterpolatoryQuadratureSimplexGroupFactory
-
-from pytential import bind, sym, norm  # noqa
+from meshmode.discretization.poly_element import (
+    InterpolatoryQuadratureSimplexGroupFactory)
 from pytential.target import PointsTarget
+
+from volumential.function_extension import compute_harmonic_extension
 
 
 @pytest.mark.skip(reason="this test needs to be updated to use GeometryCollection")

--- a/test/test_function_extension.py
+++ b/test/test_function_extension.py
@@ -26,7 +26,7 @@ import numpy.linalg as la
 import pytest
 
 import pyopencl as cl
-import pyopencl.clmath  # noqa
+import pyopencl.clmath
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import (
     InterpolatoryQuadratureSimplexGroupFactory)

--- a/test/test_function_extension.py
+++ b/test/test_function_extension.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
 

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -23,10 +23,4 @@ THE SOFTWARE.
 
 
 def test_import():
-    try:
-        # Silence flake8 on this import
-        import volumential  # NOQA
-
-        assert True
-    except ImportError:
-        assert False
+    import volumential  # noqa: F401

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -19,20 +19,20 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
-import pytest
 import numpy as np
-import pyopencl as cl
+import pytest
 
+import pyopencl as cl
 from meshmode.array_context import PyOpenCLArrayContext
+from meshmode.discretization import Discretization
+from meshmode.discretization.poly_element import PolynomialWarpAndBlendGroupFactory
 from meshmode.dof_array import flatten, thaw
 from meshmode.mesh.generation import generate_regular_rect_mesh
-from meshmode.discretization import Discretization
-from meshmode.discretization.poly_element import (
-        PolynomialWarpAndBlendGroupFactory)
-from volumential.interpolation import (
-        ElementsToSourcesLookupBuilder, LeavesToNodesLookupBuilder,
-        interpolate_from_meshmode, interpolate_to_meshmode)
+
 from volumential.geometry import BoundingBoxFactory, BoxFMMGeometryFactory
+from volumential.interpolation import (
+    ElementsToSourcesLookupBuilder, LeavesToNodesLookupBuilder,
+    interpolate_from_meshmode, interpolate_to_meshmode)
 
 
 # {{{ test data

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -75,7 +75,7 @@ def eval_func_on_discr_nodes(queue, discr, func):
 def drive_test_from_meshmode_interpolation(
         cl_ctx, queue, dim,
         degree, nel_1d, n_levels, q_order,
-        a=-0.5, b=0.5, seed=0, test_case='exact'):
+        a=-0.5, b=0.5, seed=0, test_case="exact"):
     """
     meshmode mesh control: nel_1d, degree
     volumential mesh control: n_levels, q_order
@@ -99,10 +99,10 @@ def drive_test_from_meshmode_interpolation(
             cl_ctx, tree=boxgeo.tree, discr=discr)
     lookup, evt = lookup_fac(queue)
 
-    if test_case == 'exact':
+    if test_case == "exact":
         # algebraically exact interpolation
         func = random_polynomial_func(dim, degree, seed)
-    elif test_case == 'non-exact':
+    elif test_case == "non-exact":
         if dim == 2:
             def func(pts):
                 x, y = pts
@@ -122,7 +122,7 @@ def drive_test_from_meshmode_interpolation(
     tree = boxgeo.tree.get(queue)
     ref = func(np.vstack(tree.sources))
 
-    if test_case == 'exact':
+    if test_case == "exact":
         return np.allclose(ref, res)
 
     resid = np.linalg.norm(ref - res, ord=np.inf)
@@ -132,7 +132,7 @@ def drive_test_from_meshmode_interpolation(
 def drive_test_to_meshmode_interpolation(
         cl_ctx, queue, dim,
         degree, nel_1d, n_levels, q_order,
-        a=-0.5, b=0.5, seed=0, test_case='exact'):
+        a=-0.5, b=0.5, seed=0, test_case="exact"):
     """
     meshmode mesh control: nel_1d, degree
     volumential mesh control: n_levels, q_order
@@ -156,10 +156,10 @@ def drive_test_to_meshmode_interpolation(
             cl_ctx, trav=boxgeo.trav, discr=discr)
     lookup, evt = lookup_fac(queue)
 
-    if test_case == 'exact':
+    if test_case == "exact":
         # algebraically exact interpolation
         func = random_polynomial_func(dim, degree, seed)
-    elif test_case == 'non-exact':
+    elif test_case == "non-exact":
         if dim == 2:
             def func(pts):
                 x, y = pts
@@ -178,7 +178,7 @@ def drive_test_to_meshmode_interpolation(
     res = interpolate_to_meshmode(queue, potential, lookup).get(queue)
     ref = eval_func_on_discr_nodes(queue, discr, func).get(queue)
 
-    if test_case == 'exact':
+    if test_case == "exact":
         return np.allclose(ref, res)
 
     resid = np.linalg.norm(ref - res, ord=np.inf)
@@ -195,7 +195,7 @@ def test_from_meshmode_interpolation_2d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case='exact')
+            cl_ctx, queue, 2, *params, test_case="exact")
 
 
 @pytest.mark.parametrize("params", [
@@ -205,7 +205,7 @@ def test_from_meshmode_interpolation_2d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case='non-exact') < 1e-3
+            cl_ctx, queue, 2, *params, test_case="non-exact") < 1e-3
 
 
 @pytest.mark.parametrize("params", [
@@ -216,7 +216,7 @@ def test_to_meshmode_interpolation_2d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case='exact')
+            cl_ctx, queue, 2, *params, test_case="exact")
 
 
 @pytest.mark.parametrize("params", [
@@ -226,7 +226,7 @@ def test_to_meshmode_interpolation_2d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case='non-exact') < 1e-3
+            cl_ctx, queue, 2, *params, test_case="non-exact") < 1e-3
 
 # }}} End 2d tests
 
@@ -241,7 +241,7 @@ def test_from_meshmode_interpolation_3d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case='exact')
+            cl_ctx, queue, 3, *params, test_case="exact")
 
 
 @pytest.mark.parametrize("params", [
@@ -251,7 +251,7 @@ def test_from_meshmode_interpolation_3d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case='non-exact') < 1e-3
+            cl_ctx, queue, 3, *params, test_case="non-exact") < 1e-3
 
 
 @pytest.mark.parametrize("params", [
@@ -262,7 +262,7 @@ def test_to_meshmode_interpolation_3d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case='exact')
+            cl_ctx, queue, 3, *params, test_case="exact")
 
 
 @pytest.mark.parametrize("params", [
@@ -272,12 +272,12 @@ def test_to_meshmode_interpolation_3d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case='non-exact') < 1e-3
+            cl_ctx, queue, 3, *params, test_case="non-exact") < 1e-3
 
 # }}} End 3d tests
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     resid = drive_test_to_meshmode_interpolation(

--- a/test/test_laplace.py
+++ b/test/test_laplace.py
@@ -52,7 +52,7 @@ def test_patch_laplace():
 
     import random
 
-    for r in range(rep):
+    for _ in range(rep):
         center_x = random.uniform(-1, 1)
         center_y = random.uniform(-1, 1)
         center = [center_x, center_y]

--- a/test/test_laplace.py
+++ b/test/test_laplace.py
@@ -22,8 +22,10 @@ THE SOFTWARE.
 """
 
 import numpy as np
-import volumential.nearfield_potential_table as npt
+
 from sumpy.point_calculus import CalculusPatch
+
+import volumential.nearfield_potential_table as npt
 
 
 # Directly evaluate volume integrals on a calculus patch to

--- a/test/test_laplace.py
+++ b/test/test_laplace.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
@@ -153,4 +152,4 @@ def test_laplace_same_box_on_patch(longrun):
         print("f_vals", f_values)
         print("lap", lap)
 
-        assert max(abs((lap))) < 0.1
+        assert max(abs(lap)) < 0.1

--- a/test/test_laplace3d.py
+++ b/test/test_laplace3d.py
@@ -41,7 +41,7 @@ def test_patch_laplace():
 
     import random
 
-    for r in range(rep):
+    for _ in range(rep):
         center = [random.uniform(-1, 1) for d in range(dim)]
         patch = make_patch(center, size)
 

--- a/test/test_laplace3d.py
+++ b/test/test_laplace3d.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 

--- a/test/test_laplace3d.py
+++ b/test/test_laplace3d.py
@@ -23,8 +23,8 @@ THE SOFTWARE.
 
 import numpy as np
 
-# import volumential.nearfield_potential_table as npt
 from sumpy.point_calculus import CalculusPatch
+
 
 dim = 3
 patch_order = 3

--- a/test/test_list1_gallery.py
+++ b/test/test_list1_gallery.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_nearfield_interaction_completeness.py
+++ b/test/test_nearfield_interaction_completeness.py
@@ -22,10 +22,12 @@ THE SOFTWARE.
 """
 
 import subprocess
-import numpy as np
-import pyopencl as cl
-import pyopencl.array  # NOQA
 from functools import partial
+
+import numpy as np
+
+import pyopencl as cl
+import pyopencl.array  # noqa: F401
 
 
 def drive_test_completeness(ctx, queue, dim, q_order):
@@ -129,9 +131,9 @@ def drive_test_completeness(ctx, queue, dim, q_order):
 
     # {{{ expansion wrangler
 
-    from sumpy.kernel import LaplaceKernel
-    from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion
     from sumpy.expansion.local import VolumeTaylorLocalExpansion
+    from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion
+    from sumpy.kernel import LaplaceKernel
 
     knl = LaplaceKernel(dim)
     out_kernels = [knl]
@@ -139,8 +141,7 @@ def drive_test_completeness(ctx, queue, dim, q_order):
     mpole_expn_class = partial(VolumeTaylorMultipoleExpansion, use_rscale=None)
 
     from volumential.expansion_wrangler_fpnd import (
-            FPNDExpansionWranglerCodeContainer,
-            FPNDExpansionWrangler)
+        FPNDExpansionWrangler, FPNDExpansionWranglerCodeContainer)
 
     wcc = FPNDExpansionWranglerCodeContainer(
         ctx,

--- a/test/test_nearfield_interaction_completeness.py
+++ b/test/test_nearfield_interaction_completeness.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_nearfield_interaction_completeness.py
+++ b/test/test_nearfield_interaction_completeness.py
@@ -166,7 +166,7 @@ def drive_test_completeness(ctx, queue, dim, q_order):
         trav.neighbor_source_boxes_lists, mode_coefs=source_vals)
     pot = pot[0]
     for p in pot[0]:
-        assert(abs(p - 2**dim) < 1e-8)
+        assert abs(p - 2**dim) < 1.0e-8
 
 
 def test_completeness_1(ctx_factory):

--- a/test/test_nearfield_interaction_completeness.py
+++ b/test/test_nearfield_interaction_completeness.py
@@ -118,7 +118,7 @@ def drive_test_completeness(ctx, queue, dim, q_order):
 
     from volumential.table_manager import NearFieldInteractionTableManager
 
-    subprocess.check_call(['rm', '-f', 'nft-test-completeness.hdf5'])
+    subprocess.check_call(["rm", "-f", "nft-test-completeness.hdf5"])
     with NearFieldInteractionTableManager("nft-test-completeness.hdf5",
                                           progress_bar=False) as tm:
 

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -21,9 +21,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import volumential.nearfield_potential_table as npt
 import numpy as np
 from numpy.polynomial.chebyshev import chebval, chebval2d, chebval3d
+
+import volumential.nearfield_potential_table as npt
 
 
 def test_const_order_1():

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -28,7 +28,7 @@ from numpy.polynomial.chebyshev import chebval, chebval2d, chebval3d
 
 def test_const_order_1():
     table = npt.NearFieldInteractionTable(
-        quad_order=1, build_method='Transform', progress_bar=False)
+        quad_order=1, build_method="Transform", progress_bar=False)
     table.build_table()
     for ary in table.data:
         assert np.allclose(ary, 1)
@@ -36,7 +36,7 @@ def test_const_order_1():
 
 def test_const_order_2(longrun):
     table = npt.NearFieldInteractionTable(
-        quad_order=2, build_method='Transform', progress_bar=False)
+        quad_order=2, build_method="Transform", progress_bar=False)
     table.build_table()
     for ary in table.data:
         assert np.allclose(ary, 0.25)
@@ -44,7 +44,7 @@ def test_const_order_2(longrun):
 
 def interp_modes(q_order):
     table = npt.NearFieldInteractionTable(
-            quad_order=q_order, build_method='Transform', progress_bar=False)
+            quad_order=q_order, build_method="Transform", progress_bar=False)
 
     modes = [table.get_mode(i) for i in range(table.n_q_points)]
 
@@ -81,12 +81,12 @@ def cheb_eval(dim, coefs, coords):
     elif dim == 3:
         return chebval3d(coords[0], coords[1], coords[2], coefs)
     else:
-        raise NotImplementedError('dimension %d not supported' % dim)
+        raise NotImplementedError("dimension %d not supported" % dim)
 
 
 def drive_test_modes_cheb_coeffs(dim, q, cheb_order):
     if not cheb_order >= q:
-        raise RuntimeError('Insufficient cheb_order to fully resolve the modes')
+        raise RuntimeError("Insufficient cheb_order to fully resolve the modes")
 
     sample_mode = np.random.randint(q**dim)
     table = npt.NearFieldInteractionTable(quad_order=q, dim=dim, progress_bar=False)

--- a/test/test_singular_integral_2d.py
+++ b/test/test_singular_integral_2d.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_singular_integral_2d.py
+++ b/test/test_singular_integral_2d.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
+
 import volumential.singular_integral_2d as sint
 
 

--- a/test/test_table_builder_symmetry.py
+++ b/test/test_table_builder_symmetry.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_table_builder_symmetry.py
+++ b/test/test_table_builder_symmetry.py
@@ -23,10 +23,4 @@ THE SOFTWARE.
 
 
 def test_import():
-    try:
-        # Silence flake8 on this import
-        import volumential  # NOQA
-
-        assert True
-    except ImportError:
-        assert False
+    import volumential  # noqa: F401

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -40,7 +40,7 @@ def get_table(queue, q_order=1, dim=2):
         copyfile("nft.hdf5",
                  f"nft-test-table-manager-{pid}.hdf5")
 
-    subprocess.check_call(['rm', '-f', f'nft-test-table-manager-{pid}.hdf5'])
+    subprocess.check_call(["rm", "-f", f"nft-test-table-manager-{pid}.hdf5"])
 
     with NFTable(f"nft-test-table-manager-{pid}.hdf5",
                  progress_bar=True) as table_manager:

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -23,13 +23,15 @@ THE SOFTWARE.
 
 import os
 import subprocess
-import numpy as np
-import pyopencl as cl
-import pytest
-import volumential as vm
 from shutil import copyfile
-from volumential.table_manager import (
-        NearFieldInteractionTableManager as NFTable)
+
+import numpy as np
+import pytest
+
+import pyopencl as cl
+
+import volumential as vm
+from volumential.table_manager import NearFieldInteractionTableManager as NFTable
 
 
 def get_table(queue, q_order=1, dim=2):

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -202,7 +202,7 @@ def laplace_problem(ctx_factory):
 
     from volumential.table_manager import NearFieldInteractionTableManager
 
-    subprocess.check_call(['rm', '-f', 'nft-test-volume-fmm.hdf5'])
+    subprocess.check_call(["rm", "-f", "nft-test-volume-fmm.hdf5"])
     tm = NearFieldInteractionTableManager("nft-test-volume-fmm.hdf5")
     nftable, _ = tm.get_table(dim, "Laplace", q_order)
 

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -1,4 +1,3 @@
-from __future__ import division, absolute_import, print_function
 
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -21,15 +21,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import subprocess
 import logging
-import pytest
+import subprocess
+from functools import partial
 
 import numpy as np
+import pytest
+
 import pyopencl as cl
+
 import volumential.meshgen as mg
 
-from functools import partial
 
 logger = logging.getLogger(__name__)
 
@@ -210,15 +212,12 @@ def laplace_problem(ctx_factory):
 
     # {{{ sumpy expansion for laplace kernel
 
-    from sumpy.kernel import LaplaceKernel
-
+    from sumpy.expansion.local import LinearPDEConformingVolumeTaylorLocalExpansion
     # from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion
     # from sumpy.expansion.local import VolumeTaylorLocalExpansion
-
-    from sumpy.expansion.multipole import \
-        LinearPDEConformingVolumeTaylorMultipoleExpansion
-    from sumpy.expansion.local import \
-        LinearPDEConformingVolumeTaylorLocalExpansion
+    from sumpy.expansion.multipole import (
+        LinearPDEConformingVolumeTaylorMultipoleExpansion)
+    from sumpy.kernel import LaplaceKernel
 
     knl = LaplaceKernel(dim)
     out_kernels = [knl]
@@ -229,8 +228,7 @@ def laplace_problem(ctx_factory):
 
     exclude_self = True
     from volumential.expansion_wrangler_fpnd import (
-            FPNDExpansionWranglerCodeContainer,
-            FPNDExpansionWrangler)
+        FPNDExpansionWrangler, FPNDExpansionWranglerCodeContainer)
 
     wcc = FPNDExpansionWranglerCodeContainer(
         ctx,

--- a/volumential/__init__.py
+++ b/volumential/__init__.py
@@ -20,14 +20,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 import os
+
 from pytools.persistent_dict import WriteOncePersistentDict
 
-from volumential.singular_integral_2d import box_quad
-from volumential.version import VERSION_TEXT
-from volumential.table_manager import NearFieldInteractionTableManager  # noqa: F401
 from volumential.nearfield_potential_table import (  # noqa: F401
-    NearFieldInteractionTable,
-)
+    NearFieldInteractionTable)
+from volumential.singular_integral_2d import box_quad
+from volumential.table_manager import NearFieldInteractionTableManager  # noqa: F401
+from volumential.version import VERSION_TEXT
+
 
 volumential_version = VERSION_TEXT
 

--- a/volumential/__init__.py
+++ b/volumential/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -73,7 +71,7 @@ def set_caching_enabled(flag):
     CACHING_ENABLED = flag
 
 
-class CacheMode(object):
+class CacheMode:
     """A context manager for setting whether :mod:`volumential` is allowed to use
     disk caches.
     """

--- a/volumential/droste.py
+++ b/volumential/droste.py
@@ -1167,8 +1167,8 @@ class DrosteReduced(DrosteBase):
             ext_tgt_ordering.reverse()
             ext_fun_ordering.reverse()
 
-            ext_instruction_ids = ':'.join([
-                'result_ext_' + str(eid)
+            ext_instruction_ids = ":".join([
+                "result_ext_" + str(eid)
                 for eid in range(len(ext_ids))
                 if eid != ext_index
                 ])
@@ -1501,7 +1501,7 @@ class DrosteReduced(DrosteBase):
     def get_cache_key(self):
         if self.reduce_by_symmetry.symmetry_tags is None:
             # Bn: the full n-dimensional hyperoctahedral group
-            symmetry_info = 'B%d' % self.dim
+            symmetry_info = "B%d" % self.dim
         else:
             symmetry_info = "Span{%s}" % ",".join([
                 repr(tag) for tag in
@@ -1739,7 +1739,7 @@ class InverseDrosteReduced(DrosteReduced):
             code.append("<> fc = if(1 - rndist > 0, exp(-1 / (1 - rndist)), 0)")
             code.append("<> windowing = 1 - fv / (fv + fc)")
 
-        return '\n'.join(code)
+        return "\n".join(code)
 
     def make_dim_independent(self, knlstring):
         r"""Produce the correct
@@ -1766,7 +1766,7 @@ class InverseDrosteReduced(DrosteReduced):
         if self.get_kernel_id == 0:
             resknl = resknl.replace(
                     "POSTPROCESS_KNL_VAL",
-                    '\n'.join([
+                    "\n".join([
                         self.codegen_windowing_function(),
                         "<> knl_val_post = windowing * knl_val {id=pp_kval}"
                         ])
@@ -1774,7 +1774,7 @@ class InverseDrosteReduced(DrosteReduced):
         elif self.get_kernel_id == 1:
             resknl = resknl.replace(
                     "POSTPROCESS_KNL_VAL",
-                    '\n'.join([
+                    "\n".join([
                         self.codegen_windowing_function(),
                         "<> knl_val_post = (1 - windowing) * knl_val {id=pp_kval}"
                         ])
@@ -1802,10 +1802,10 @@ class InverseDrosteReduced(DrosteReduced):
                         "PREPARE_BASIS_VALS",
                         "\n".join(basis_eval_insns + [
                             "... nop {id=basis_evals,dep=%s}"
-                            % ':'.join(
-                                ['basis%d' % i for i in range(self.dim)]
-                                + ['tgtbasis%d' % i for i in range(self.dim)]
-                                + ['tgtd2basis%d' % i for i in range(self.dim)]
+                            % ":".join(
+                                ["basis%d" % i for i in range(self.dim)]
+                                + ["tgtbasis%d" % i for i in range(self.dim)]
+                                + ["tgtd2basis%d" % i for i in range(self.dim)]
                                 ),
                             ])
                         )
@@ -1814,8 +1814,8 @@ class InverseDrosteReduced(DrosteReduced):
                         "PREPARE_BASIS_VALS",
                         "\n".join(basis_eval_insns + [
                             "... nop {id=basis_evals,dep=%s}"
-                            % ':'.join(
-                                ['basis%d' % i for i in range(self.dim)]
+                            % ":".join(
+                                ["basis%d" % i for i in range(self.dim)]
                                 ),
                             ])
                         )
@@ -1824,7 +1824,7 @@ class InverseDrosteReduced(DrosteReduced):
                 if target_box_is_source:
                     resknl = resknl.replace(
                             "DENSITY_VAL_ASSIGNMENT",
-                            ' '.join([
+                            " ".join([
                                 "0.5 * der2_basis_tgt_eval0 * (dist[0]**2)",
                                 ])
                             )
@@ -1838,7 +1838,7 @@ class InverseDrosteReduced(DrosteReduced):
                 if target_box_is_source:
                     resknl = resknl.replace(
                             "DENSITY_VAL_ASSIGNMENT",
-                            ' '.join([
+                            " ".join([
                                 "  0.5 * der2_basis_tgt_eval0 * basis_tgt_eval1 * (dist[0]**2)",  # noqa: E501
                                 "+ 0.5 * basis_tgt_eval0 * der2_basis_tgt_eval1 * (dist[1]**2)",  # noqa: E501
                                 ])
@@ -1853,7 +1853,7 @@ class InverseDrosteReduced(DrosteReduced):
                 if target_box_is_source:
                     resknl = resknl.replace(
                             "DENSITY_VAL_ASSIGNMENT",
-                            ' '.join([
+                            " ".join([
                                 "  0.5 * der2_basis_tgt_eval0 * basis_tgt_eval1 * basis_tgt_eval2 * (dist[0]**2)",  # noqa: E501
                                 "+ 0.5 * basis_tgt_eval0 * der2_basis_tgt_eval1 * basis_tgt_eval2 * (dist[1]**2)",  # noqa: E501
                                 "+ 0.5 * basis_tgt_eval0 * basis_tgt_eval1 * der2_basis_tgt_eval2 * (dist[2]**2)",  # noqa: E501
@@ -1876,18 +1876,18 @@ class InverseDrosteReduced(DrosteReduced):
                         "PREPARE_BASIS_VALS",
                         "\n".join(basis_eval_insns + [
                             "... nop {id=basis_evals,dep=%s}"
-                            % ':'.join(
-                                ['basis%d' % i for i in range(self.dim)]
-                                + ['tgtbasis%d' % i for i in range(self.dim)]
+                            % ":".join(
+                                ["basis%d" % i for i in range(self.dim)]
+                                + ["tgtbasis%d" % i for i in range(self.dim)]
                                 ),
                             ])
                         )
                 resknl = resknl.replace(
                         "DENSITY_VAL_ASSIGNMENT",
-                        ' - '.join([
-                            ' * '.join(
+                        " - ".join([
+                            " * ".join(
                                 ["basis_tgt_eval%d" % i for i in range(self.dim)]),
-                            ' * '.join(
+                            " * ".join(
                                 ["basis_eval%d" % i for i in range(self.dim)]),
                             ])
                         )
@@ -1897,14 +1897,14 @@ class InverseDrosteReduced(DrosteReduced):
                         "PREPARE_BASIS_VALS",
                         "\n".join(basis_eval_insns + [
                             "... nop {id=basis_evals,dep=%s}"
-                            % ':'.join(
-                                ['basis%d' % i for i in range(self.dim)]
+                            % ":".join(
+                                ["basis%d" % i for i in range(self.dim)]
                                 ),
                             ])
                         )
                 resknl = resknl.replace(
                         "DENSITY_VAL_ASSIGNMENT",
-                        ' - ' + ' * '.join(
+                        " - " + " * ".join(
                             ["basis_eval%d" % i for i in range(self.dim)]
                             )
                         )
@@ -2178,7 +2178,7 @@ class InverseDrosteReduced(DrosteReduced):
         except Exception:  # noqa: B902
             pass
         knl2 = self.get_cached_optimized_kernel()
-        result_array = res0['result'] + res1['result']
+        result_array = res0["result"] + res1["result"]
 
         evt2, res2 = knl2(
             queue,

--- a/volumential/droste.py
+++ b/volumential/droste.py
@@ -474,7 +474,7 @@ class DrosteBase(KernelCacheWrapper):
     def get_kernel_code(self):
         return [
             self.make_dim_independent(
-                """  # noqa
+                """  # noqa: E501
         for iaxis
             <> root_center[iaxis] = 0.5 * (
                     root_brick[iaxis, 1] + root_brick[iaxis, 0]) {dup=iaxis}
@@ -763,7 +763,7 @@ class DrosteFull(DrosteBase):
         if "extra_kernel_kwarg_types" in kwargs:
             extra_kernel_kwarg_types = kwargs["extra_kernel_kwarg_types"]
 
-        loopy_knl = lp.make_kernel(  # NOQA
+        loopy_knl = lp.make_kernel(
             [domain],
             self.get_kernel_code()
             + self.get_sumpy_kernel_eval_insns(),
@@ -1210,7 +1210,7 @@ class DrosteReduced(DrosteBase):
             extra_kernel_kwarg_types = kwargs["extra_kernel_kwarg_types"]
 
         if self.get_kernel_id == 0:
-            loopy_knl = lp.make_kernel(  # NOQA
+            loopy_knl = lp.make_kernel(
                 [domain],
                 self.get_kernel_code()
                 # FIXME: cannot have expansion in the same kernel, since it
@@ -1238,7 +1238,7 @@ class DrosteReduced(DrosteBase):
             )
 
         elif self.get_kernel_id == 1:
-            loopy_knl = lp.make_kernel(  # NOQA
+            loopy_knl = lp.make_kernel(
                 [domain],
                 self.get_kernel_expansion_by_symmetry_code(),
                 [
@@ -1625,7 +1625,7 @@ class InverseDrosteReduced(DrosteReduced):
             self.reduce_by_symmetry.reduced_vecs[self.current_base_case][d] == 0
             for d in range(self.dim))
 
-        code = """  # noqa
+        code = """  # noqa: E501
             <> T0_tgt_IAXIS = 1
             <> T1_tgt_IAXIS = template_true_target[IAXIS] {dep=template_true_targets}
             <> Tprev_tgt_IAXIS = T0_tgt_IAXIS {id=t0_tgt_IAXIS}
@@ -1671,7 +1671,7 @@ class InverseDrosteReduced(DrosteReduced):
             self.reduce_by_symmetry.reduced_vecs[self.current_base_case][d] == 0
             for d in range(self.dim))
 
-        code = """  # noqa
+        code = """  # noqa: E501
             <> U0_tgt_IAXIS = 1
             <> U1_tgt_IAXIS = 2 * template_true_target[IAXIS] {dep=template_true_targets}
             <> Uprev_tgt_IAXIS = U0_tgt_IAXIS {id=u0_tgt_IAXIS}
@@ -1975,7 +1975,7 @@ class InverseDrosteReduced(DrosteReduced):
             extra_loopy_kernel_kwargs = kwargs["extra_loopy_kernel_kwargs"]
 
         if self.get_kernel_id == 0 or self.get_kernel_id == 1:
-            loopy_knl = lp.make_kernel(  # NOQA
+            loopy_knl = lp.make_kernel(
                 [domain],
                 self.get_kernel_code()
                 + self.get_sumpy_kernel_eval_insns(),
@@ -2002,7 +2002,7 @@ class InverseDrosteReduced(DrosteReduced):
             )
 
         elif self.get_kernel_id == 2:
-            loopy_knl = lp.make_kernel(  # NOQA
+            loopy_knl = lp.make_kernel(
                 [domain],
                 self.get_kernel_expansion_by_symmetry_code(),
                 [

--- a/volumential/droste.py
+++ b/volumential/droste.py
@@ -238,11 +238,10 @@ class DrosteBase(KernelCacheWrapper):
             ),
         )
         sac.run_global_cse()
-        import six
         from sumpy.codegen import to_loopy_insns
 
         loopy_insns = to_loopy_insns(
-            six.iteritems(sac.assignments),
+            sac.assignments.items(),
             vector_names=set(["dist"]),
             pymbolic_expr_maps=[self.integral_knl.get_code_transformer()],
             retain_names=[result_name],

--- a/volumential/droste.py
+++ b/volumential/droste.py
@@ -20,11 +20,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import logging
+
 import numpy as np
+
 import loopy as lp
+
 from volumential.tools import KernelCacheWrapper
 
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -1007,8 +1010,8 @@ class DrosteReduced(DrosteBase):
                     else:
                         prev_swappable[iaxis] = list(group)[axid - 1]
 
-        from functools import reduce
         import operator
+        from functools import reduce
 
         tgt_domain_ubounds = reduce(
             operator.and_,
@@ -1272,6 +1275,7 @@ class DrosteReduced(DrosteBase):
         # self.current_base_case, self.get_kernel_id
         if ncpus is None:
             import multiprocessing
+
             # NOTE: this detects the number of logical cores, which
             # may result in suboptimal performance.
             ncpus = multiprocessing.cpu_count()

--- a/volumential/droste.py
+++ b/volumential/droste.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -720,7 +718,7 @@ class DrosteFull(DrosteBase):
                  n_brick_quad_points=50,
                  special_radial_quadrature=False,
                  nradial_quad_points=None):
-        super(DrosteFull, self).__init__(
+        super().__init__(
             integral_knl, quad_order, case_vecs, n_brick_quad_points,
             special_radial_quadrature, nradial_quad_points)
         self.name = "DrosteFull"
@@ -932,7 +930,7 @@ class DrosteReduced(DrosteBase):
         special_radial_quadrature=False,
         nradial_quad_points=None,
     ):
-        super(DrosteReduced, self).__init__(
+        super().__init__(
             integral_knl, quad_order, case_vecs, n_brick_quad_points,
             special_radial_quadrature, nradial_quad_points)
 
@@ -1601,7 +1599,7 @@ class InverseDrosteReduced(DrosteReduced):
         """
         :param auto_windowing: auto-detect window radius.
         """
-        super(InverseDrosteReduced, self).__init__(
+        super().__init__(
             integral_knl, quad_order, case_vecs,
             n_brick_quad_points, special_radial_quadrature,
             nradial_quad_points, knl_symmetry_tags)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -285,7 +285,7 @@ class FPNDSumpyExpansionWrangler(
         return SumpyExpansionWrangler.reorder_sources(self, source_array)
 
     def reorder_targets(self, target_array):
-        if not hasattr(self.tree, 'user_target_ids'):
+        if not hasattr(self.tree, "user_target_ids"):
             self.tree.user_target_ids = inverse_id_map(
                 self.queue, self.tree.sorted_target_ids)
         return target_array.with_queue(self.queue)[self.tree.user_target_ids]
@@ -846,10 +846,10 @@ class FPNDFMMLibExpansionWrangler(
                         frozenset([("k", helmholtz_k)]), tree, level)
 
         rotation_data = None
-        if 'traversal' in kwargs:
+        if "traversal" in kwargs:
             # add rotation data if traversal is passed as a keyword argument
             from boxtree.pyfmmlib_integration import FMMLibRotationData
-            rotation_data = FMMLibRotationData(self.queue, kwargs['traversal'])
+            rotation_data = FMMLibRotationData(self.queue, kwargs["traversal"])
         else:
             logger.warning("Rotation data is not utilized since traversal is "
                            "not known to FPNDFMMLibExpansionWrangler.")
@@ -902,7 +902,7 @@ class FPNDFMMLibExpansionWrangler(
         return FMMLibExpansionWrangler.reorder_sources(self, source_array)
 
     def reorder_targets(self, target_array):
-        if not hasattr(self.tree, 'user_target_ids'):
+        if not hasattr(self.tree, "user_target_ids"):
             self.tree.user_target_ids = inverse_id_map(
                 self.queue, self.tree.sorted_target_ids)
         return target_array[self.tree.user_target_ids]

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -150,7 +150,7 @@ class FPNDSumpyExpansionWrangler(
 
         # dictionary of lists of tables
         elif isinstance(near_field_table, dict):
-            self.n_tables = dict()
+            self.n_tables = {}
             for out_knl in self.code.target_kernels:
                 if repr(out_knl) not in near_field_table:
                     raise RuntimeError(
@@ -599,8 +599,11 @@ class FPNDFMMLibExpansionWranglerCodeContainer(
         self.exclude_self = True
 
     def get_wrangler(self, queue, tree, dtype, fmm_level_to_order,
-            source_extra_kwargs={}, kernel_extra_kwargs=None,
+            source_extra_kwargs=None, kernel_extra_kwargs=None,
             *args, **kwargs):
+        if source_extra_kwargs is None:
+            source_extra_kwargs = {}
+
         return FPNDFMMLibExpansionWrangler(self, queue, tree,
                 dtype, fmm_level_to_order,
                 source_extra_kwargs, kernel_extra_kwargs,
@@ -725,7 +728,7 @@ class FPNDFMMLibExpansionWrangler(
 
         # dictionary of lists of tables
         elif isinstance(near_field_table, dict):
-            self.n_tables = dict()
+            self.n_tables = {}
             for out_knl in self.code.target_kernels:
                 if repr(out_knl) not in near_field_table:
                     raise RuntimeError(

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -20,23 +20,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
 import logging
+
+import numpy as np
+
 import pyopencl as cl
 import pyopencl.array
-from pytools.obj_array import make_obj_array
-
-# from pytools import memoize_method
-from volumential.nearfield_potential_table import NearFieldInteractionTable
-from volumential.expansion_wrangler_interface import (
-        ExpansionWranglerInterface, ExpansionWranglerCodeContainerInterface)
-from sumpy.fmm import SumpyExpansionWrangler, \
-        SumpyTimingFuture, SumpyExpansionWranglerCodeContainer
 from boxtree.pyfmmlib_integration import FMMLibExpansionWrangler
-
+from pytools.obj_array import make_obj_array
+from sumpy.fmm import (
+    SumpyExpansionWrangler, SumpyExpansionWranglerCodeContainer, SumpyTimingFuture)
 from sumpy.kernel import (
-        LaplaceKernel, HelmholtzKernel, AxisTargetDerivative,
-        DirectionalSourceDerivative)
+    AxisTargetDerivative, DirectionalSourceDerivative, HelmholtzKernel,
+    LaplaceKernel)
+
+from volumential.expansion_wrangler_interface import (
+    ExpansionWranglerCodeContainerInterface, ExpansionWranglerInterface)
+from volumential.nearfield_potential_table import NearFieldInteractionTable
+
 
 logger = logging.getLogger(__name__)
 

--- a/volumential/expansion_wrangler_interface.py
+++ b/volumential/expansion_wrangler_interface.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -37,7 +35,7 @@ __doc__ = """
 # NOTE: abstractmethod's signatures (arguement lists) are not enforced
 
 
-class ExpansionWranglerInterface(object):
+class ExpansionWranglerInterface:
     """
         Abstract expansion handling interface.
         The interface is adapted from, and stays compatible with boxtree/fmm.
@@ -216,7 +214,7 @@ class ExpansionWranglerInterface(object):
 # {{{ code container interface
 
 
-class ExpansionWranglerCodeContainerInterface(object):
+class ExpansionWranglerCodeContainerInterface:
     """
         Abstract expansion code container interface.
         The interface is adapted from, and stays compatible with boxtree/fmm.

--- a/volumential/expansion_wrangler_interface.py
+++ b/volumential/expansion_wrangler_interface.py
@@ -21,10 +21,11 @@ THE SOFTWARE.
 """
 
 import logging
+from abc import ABCMeta, abstractmethod
+
 
 logger = logging.getLogger(__name__)
 
-from abc import ABCMeta, abstractmethod
 
 __doc__ = """
 .. autoclass::ExpansionWranglerInterface

--- a/volumential/function_extension.py
+++ b/volumential/function_extension.py
@@ -39,12 +39,15 @@ THE SOFTWARE.
 import logging
 
 import numpy as np
+
 import pyopencl as cl
-from pytools.obj_array import make_obj_array
 from pymbolic import var
 from pytential import bind, sym
 from pytential.solve import gmres
-from pytential.symbolic.stokes import StressletWrapper, StokesletWrapper
+from pytential.symbolic.stokes import StokesletWrapper, StressletWrapper
+from pytools.obj_array import make_obj_array
+from sumpy.kernel import AxisTargetDerivative, ExpressionKernel
+
 
 # {{{ helper functions
 
@@ -234,8 +237,6 @@ def compute_harmonic_extension(queue, target_discr,
 # {{{ biharmonic extension
 
 # {{{ Goursat kernels
-
-from sumpy.kernel import ExpressionKernel, AxisTargetDerivative
 
 
 class ComplexLogKernel(ExpressionKernel):

--- a/volumential/function_extension.py
+++ b/volumential/function_extension.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 """Function extension with regularity contraints:
 
 1. :math:`L^2`: extend with constant value
@@ -255,7 +253,7 @@ class ComplexLogKernel(ExpressionKernel):
         else:
             raise NotImplementedError("unsupported dimensionality")
 
-        super(ComplexLogKernel, self).__init__(
+        super().__init__(
                 dim,
                 expression=expr,
                 global_scaling_const=scaling,
@@ -303,7 +301,7 @@ class ComplexLinearLogKernel(ExpressionKernel):
         else:
             raise NotImplementedError("unsupported dimensionality")
 
-        super(ComplexLinearLogKernel, self).__init__(
+        super().__init__(
                 dim,
                 expression=expr,
                 global_scaling_const=scaling,
@@ -332,7 +330,7 @@ class ComplexLinearKernel(ExpressionKernel):
         else:
             raise NotImplementedError("unsupported dimensionality")
 
-        super(ComplexLinearKernel, self).__init__(
+        super().__init__(
                 dim,
                 expression=expr,
                 global_scaling_const=scaling,
@@ -373,7 +371,7 @@ class ComplexFractionalKernel(ExpressionKernel):
         else:
             raise NotImplementedError("unsupported dimensionality")
 
-        super(ComplexFractionalKernel, self).__init__(
+        super().__init__(
                 dim,
                 expression=expr,
                 global_scaling_const=scaling,

--- a/volumential/function_extension.py
+++ b/volumential/function_extension.py
@@ -179,7 +179,7 @@ def compute_harmonic_extension(queue, target_discr,
 
     # {{{ postprocess
 
-    repr_kwargs = dict(qbx_forced_limit=None)
+    repr_kwargs = {"qbx_forced_limit": None}
     representation_sym = (
             sym.S(kernel, inv_sqrt_w_sigma, **repr_kwargs)
             + sym.D(kernel, inv_sqrt_w_sigma, **repr_kwargs))

--- a/volumential/function_extension.py
+++ b/volumential/function_extension.py
@@ -175,7 +175,7 @@ def compute_harmonic_extension(queue, target_discr,
     # }}}
 
     debugging_info = {}
-    debugging_info['gmres_result'] = gmres_result
+    debugging_info["gmres_result"] = gmres_result
 
     # {{{ postprocess
 
@@ -187,9 +187,9 @@ def compute_harmonic_extension(queue, target_discr,
     qbx_stick_out = qbx.copy(
             target_association_tolerance=target_association_tolerance)
 
-    debugging_info['qbx'] = qbx_stick_out
-    debugging_info['representation'] = representation_sym
-    debugging_info['density'] = sigma
+    debugging_info["qbx"] = qbx_stick_out
+    debugging_info["representation"] = representation_sym
+    debugging_info["density"] = sigma
 
     ext_f = bind(
             (qbx_stick_out, target_discr),
@@ -224,7 +224,7 @@ def compute_harmonic_extension(queue, target_discr,
             (qbx_stick_out, target_discr),
             representation_sym)(queue, sigma=sigma).real + matching_const
 
-    debugging_info['eval_ext_f'] = eval_ext_f
+    debugging_info["eval_ext_f"] = eval_ext_f
 
     return ext_f, debugging_info
 
@@ -411,9 +411,9 @@ def get_extension_bie_symbolic_operator(loc_sign=1):
     bdry_op_sym = (
             loc_sign * 0.5 * sigma_sym
             - stresslet_obj.apply(sigma_sym, nvec_sym, mu_sym,
-                qbx_forced_limit='avg')
+                qbx_forced_limit="avg")
             - stokeslet_obj.apply(sigma_sym, mu_sym,
-                qbx_forced_limit='avg') + int_sigma)
+                qbx_forced_limit="avg") + int_sigma)
 
     return bdry_op_sym
 
@@ -585,11 +585,11 @@ def compute_biharmonic_extension(queue, target_discr,
             queue, integrand=omega_S_bdry+omega_D_bdry+omega_W_bdry)
 
     debugging_info = {}
-    debugging_info['omega_S'] = omega_S
-    debugging_info['omega_D'] = omega_D
-    debugging_info['omega_W'] = omega_W
-    debugging_info['omega_v1'] = v1
-    debugging_info['omega_D1'] = omega_D1
+    debugging_info["omega_S"] = omega_S
+    debugging_info["omega_D"] = omega_D
+    debugging_info["omega_W"] = omega_W
+    debugging_info["omega_v1"] = v1
+    debugging_info["omega_D1"] = omega_D1
 
     int_interior_func_bdry = bind(qbx, sym.integral(2, 1, var("integrand")))(
             queue, integrand=f)

--- a/volumential/geometry.py
+++ b/volumential/geometry.py
@@ -21,9 +21,11 @@ THE SOFTWARE.
 """
 
 import numpy as np
+
 import pyopencl as cl
-from pytools.obj_array import make_obj_array
 from boxtree.pyfmmlib_integration import FMMLibRotationData
+from pytools.obj_array import make_obj_array
+
 
 # {{{ bounding box factory
 
@@ -95,8 +97,8 @@ class BoundingBoxFactory:
         self.lbounds = box_center - box_radius
         self.ubounds = box_center + box_radius
 
-        from boxtree.tools import AXIS_NAMES
         from boxtree.bounding_box import make_bounding_box_dtype
+        from boxtree.tools import AXIS_NAMES
 
         axis_names = AXIS_NAMES[:self.dim]
         bbox_type, _ = make_bounding_box_dtype(
@@ -164,6 +166,7 @@ class BoxFMMGeometryFactory:
         self.dim = dim
         if quadrature_formula is None:
             from modepy import LegendreGaussQuadrature
+
             # order = degree + 1
             self.quadrature_formula = LegendreGaussQuadrature(order - 1)
         else:

--- a/volumential/geometry.py
+++ b/volumential/geometry.py
@@ -31,9 +31,9 @@ from boxtree.pyfmmlib_integration import FMMLibRotationData
 class BoundingBoxFactory:
     def __init__(self, dim,
             center=None, radius=None,
-            dtype=np.dtype("float64")):
+            dtype=float):
         self.dim = dim
-        self.dtype = dtype
+        self.dtype = np.dtype(dtype)
 
         self.center = center
         self.radius = radius

--- a/volumential/geometry.py
+++ b/volumential/geometry.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
 
 __license__ = """
@@ -30,7 +28,7 @@ from boxtree.pyfmmlib_integration import FMMLibRotationData
 # {{{ bounding box factory
 
 
-class BoundingBoxFactory():
+class BoundingBoxFactory:
     def __init__(self, dim,
             center=None, radius=None,
             dtype=np.dtype("float64")):
@@ -116,7 +114,7 @@ class BoundingBoxFactory():
 # {{{ box mesh data factory
 
 
-class BoxFMMGeometryFactory():
+class BoxFMMGeometryFactory:
     """Builds the geometry information needed for performing volume FMM.
     The objects of this class is designed to be "interactive", i.e., be
     manipulated repeatedly and on demand, produce a series of desired

--- a/volumential/interpolation.py
+++ b/volumential/interpolation.py
@@ -1,6 +1,4 @@
-__copyright__ = """
-Copyright (C) 2020 Xiaoyu Wei
-"""
+__copyright__ = "Copyright (C) 2020 Xiaoyu Wei"
 
 __license__ = """
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/volumential/interpolation.py
+++ b/volumential/interpolation.py
@@ -21,17 +21,21 @@ THE SOFTWARE.
 """
 
 import itertools
+import logging
+
 import numpy as np
-import pyopencl as cl
+
 import loopy as lp
-from pytools import memoize_method, ProcessLogger
-from pytools.obj_array import make_obj_array
+import pyopencl as cl
 from boxtree.tools import DeviceDataRecord
 from meshmode.array_context import PyOpenCLArrayContext
-from meshmode.dof_array import unflatten, flatten, thaw
+from meshmode.dof_array import flatten, thaw, unflatten
+from pytools import ProcessLogger, memoize_method
+from pytools.obj_array import make_obj_array
+
 from volumential.volume_fmm import interpolate_volume_potential
 
-import logging
+
 logger = logging.getLogger(__name__)
 
 

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -149,7 +149,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
             code = code + "+" + self.codegen_vec_component(d)
         return code
 
-    def codegen_compute_scaling(self, box_name='sbox'):
+    def codegen_compute_scaling(self, box_name="sbox"):
         """box_name: the name of the box whose extent is used.
         """
         if ("infer_kernel_scaling" in self.extra_kwargs) and (
@@ -204,17 +204,17 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
         elif "kernel_scaling_code" in self.extra_kwargs:
             # user-defined scaling rule
-            assert isinstance(self.extra_kwargs['kernel_scaling_code'], str)
+            assert isinstance(self.extra_kwargs["kernel_scaling_code"], str)
             logger.info("Using scaling rule %s for %s.",
-                        self.extra_kwargs['kernel_scaling_code'], self.kname
+                        self.extra_kwargs["kernel_scaling_code"], self.kname
                         )
-            return self.extra_kwargs['kernel_scaling_code']
+            return self.extra_kwargs["kernel_scaling_code"]
         else:
             logger.info("not scaling for " + self.kname)
             logger.info("(using multiple tables)")
             return "1.0"
 
-    def codegen_compute_displacement(self, box_name='sbox'):
+    def codegen_compute_displacement(self, box_name="sbox"):
         if ("infer_kernel_scaling" in self.extra_kwargs) and (
             self.extra_kwargs["infer_kernel_scaling"]
         ):
@@ -250,12 +250,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
         elif "kernel_displacement_code" in self.extra_kwargs:
             # user-defined displacement rule
             assert isinstance(
-                    self.extra_kwargs['kernel_displacement_code'], str)
+                    self.extra_kwargs["kernel_displacement_code"], str)
             logger.info("Using displacement %s for %s.",
-                        self.extra_kwargs['kernel_displacement_code'],
+                        self.extra_kwargs["kernel_displacement_code"],
                         self.kname
                         )
-            code = self.extra_kwargs['kernel_displacement_code']
+            code = self.extra_kwargs["kernel_displacement_code"]
         else:
             logger.info("no displacement for " + self.kname)
             logger.info("(using multiple tables)")
@@ -263,7 +263,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
         return code.replace("BOX", box_name)
 
-    def codegen_get_table_level(self, box_name='sbox'):
+    def codegen_get_table_level(self, box_name="sbox"):
         if ("infer_kernel_scaling" in self.extra_kwargs) and (
             self.extra_kwargs["infer_kernel_scaling"]
         ):
@@ -402,11 +402,11 @@ class NearFieldFromCSR(NearFieldEvalBase):
             .replace("COMPUTE_VEC_ID", self.codegen_vec_id())
             .replace("COMPUTE_SCALING", self.codegen_compute_scaling())
             .replace("COMPUTE_DISPLACEMENT", self.codegen_compute_displacement())
-            .replace("COMPUTE_TGT_SCALING", self.codegen_compute_scaling('tbox'))
+            .replace("COMPUTE_TGT_SCALING", self.codegen_compute_scaling("tbox"))
             .replace("COMPUTE_TGT_DISPLACEMENT",
-                    self.codegen_compute_displacement('tbox'))
+                    self.codegen_compute_displacement("tbox"))
             .replace("GET_TABLE_LEVEL", self.codegen_get_table_level())
-            .replace("GET_TGT_TABLE_LEVEL", self.codegen_get_table_level('tbox'))
+            .replace("GET_TGT_TABLE_LEVEL", self.codegen_get_table_level("tbox"))
             .replace("EXTERIOR_PART", self.codegen_exterior_part()),
             [
                 loopy.TemporaryVariable("vec_id", np.int32),
@@ -538,12 +538,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
             **extra_knl_args_from_init
             )
 
-        res['result'].add_event(evt)
+        res["result"].add_event(evt)
         if isinstance(result, cl.array.Array):
             assert result is res["result"]
         else:
             assert isinstance(result, np.ndarray)
-            result = res['result'].get(queue)
+            result = res["result"].get(queue)
 
         queue.finish()
         logger.info("list1 evaluation finished")

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -311,7 +311,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
         else:
             potential_dtype = np.float64
 
-        lpknl = loopy.make_kernel(  # NOQA
+        lpknl = loopy.make_kernel(
             [
                 "{ [ tbox ] : 0 <= tbox < n_tgt_boxes }",
                 "{ [ tid, sbox ] : 0 <= tid < n_box_targets and \

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -27,17 +27,18 @@ __doc__ = """
    :members:
 """
 
+import logging
+
 import numpy as np
+
 import loopy
 import pyopencl as cl
 
 from volumential.tools import KernelCacheWrapper
 
-import logging
 
 logger = logging.getLogger(__name__)
 
-logging.basicConfig(level=logging.INFO)
 
 # {{{ near field eval base class
 
@@ -456,6 +457,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
     def get_optimized_kernel(self, ncpus=None):
         if ncpus is None:
             import multiprocessing
+
             # NOTE: this detects the number of logical cores, disable hyperthreading
             # for the optimal performance.
             ncpus = multiprocessing.cpu_count()

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -53,7 +53,7 @@ class NearFieldEvalBase(KernelCacheWrapper):
         integral_kernel,
         table_data_shapes,
         potential_kind=1,
-        options=[],
+        options=None,
         name=None,
         device=None,
         **kwargs
@@ -68,6 +68,8 @@ class NearFieldEvalBase(KernelCacheWrapper):
         The two kinds share the same far-field code, but the second kind requires
         exterior_mode_nmlz when computing the list1 interactions.
         """
+        if options is None:
+            options = []
 
         self.integral_kernel = integral_kernel
 
@@ -484,12 +486,10 @@ class NearFieldFromCSR(NearFieldEvalBase):
         table_data_combined = kwargs.pop("table_data_combined")
         target_boxes = kwargs.pop("target_boxes")
 
-        integral_kernel_init_kargs = {
-                name: val
-                for name, val in zip(
-                    self.integral_kernel.init_arg_names,
-                    self.integral_kernel.__getinitargs__())
-                }
+        integral_kernel_init_kargs = dict(
+            zip(self.integral_kernel.init_arg_names,
+                self.integral_kernel.__getinitargs__())
+        )
 
         # help loopy's type inference
         for key, val in integral_kernel_init_kargs.items():

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 
 __license__ = """

--- a/volumential/list1_gallery.py
+++ b/volumential/list1_gallery.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __doc__ = """
 .. autofunction:: generate_list1_gallery
 """
@@ -95,8 +93,7 @@ def generate_boxes_on_level(box, ilevel):
     """
     if ilevel:
         for child in box.children:
-            for result in generate_boxes_on_level(child, ilevel - 1):
-                yield result
+            yield from generate_boxes_on_level(child, ilevel - 1)
     else:
         yield box
 
@@ -108,8 +105,7 @@ def generate_boxes(box):
     yield box
 
     for child in box.children:
-        for result in generate_boxes(child):
-            yield result
+        yield from generate_boxes(child)
 
 
 def linf_dist(box1, box2):

--- a/volumential/list1_gallery.py
+++ b/volumential/list1_gallery.py
@@ -159,7 +159,7 @@ def postprocess_interactions(near_neighbor_interactions):
     tb0, wb0 = near_neighbor_interactions[0]
     unique_interaction_vectors.add(tuple(tb0.center - tb0.center))
 
-    list1_interactions = sorted(list(unique_interaction_vectors))
+    list1_interactions = sorted(unique_interaction_vectors)
 
     return list1_interactions
 

--- a/volumential/list1_symmetry.py
+++ b/volumential/list1_symmetry.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -28,7 +26,7 @@ import math
 # {{{ symmetry operations
 
 
-class SymmetryOperationBase(object):
+class SymmetryOperationBase:
     def __init__(self, index):
         self._index = index
 
@@ -46,7 +44,7 @@ class Flip(SymmetryOperationBase):
     """
 
     def __init__(self, iaxis):
-        super(Flip, self).__init__(iaxis)
+        super().__init__(iaxis)
         self.axis = iaxis
 
     def __repr__(self):
@@ -60,7 +58,7 @@ class Swap(SymmetryOperationBase):
 
     def __init__(self, iaxis, jaxis):
         self.axes = (iaxis, jaxis)
-        super(Swap, self).__init__(sorted(self.axes))
+        super().__init__(sorted(self.axes))
 
     def __repr__(self):
         return "Swap(%d,%d)" % tuple(sorted(self.axes))
@@ -69,7 +67,7 @@ class Swap(SymmetryOperationBase):
 # }}} End symmetry operations
 
 
-class CaseVecReduction(object):
+class CaseVecReduction:
     """
     Reduce a set of case vectors based on symmetry.
     """

--- a/volumential/list1_symmetry.py
+++ b/volumential/list1_symmetry.py
@@ -20,8 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
 import math
+
+import numpy as np
+
 
 # {{{ symmetry operations
 

--- a/volumential/list1_symmetry.py
+++ b/volumential/list1_symmetry.py
@@ -31,7 +31,7 @@ class SymmetryOperationBase:
         self._index = index
 
     def __lt__(self, other):
-        if type(self) == type(other):
+        if type(self) is type(other):
             return self._index < other._index
 
         # differnt operations in lexicographical order
@@ -106,7 +106,7 @@ class CaseVecReduction:
 
         if tags is None:
             flippable += 1
-            swappable_groups.append({i for i in range(self.dim)})
+            swappable_groups.append(set(range(self.dim)))
             return flippable, swappable_groups
 
         for tag in tags:

--- a/volumential/meshgen.py
+++ b/volumential/meshgen.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -45,7 +43,7 @@ provider = None
 # {{{ meshgen Python provider
 
 
-class MeshGenBase(object):
+class MeshGenBase:
     """Base class for Meshgen via BoxTree.
     The interface is similar to the Meshgen via Deal.II, except that
     the arguments a and b can also be of higher dimensions to allow

--- a/volumential/meshgen.py
+++ b/volumential/meshgen.py
@@ -32,9 +32,12 @@ Mesh generation
 """
 
 import logging
+
 import numpy as np
+
 import pyopencl as cl
 from pytools.obj_array import make_obj_array
+
 
 logger = logging.getLogger(__name__)
 
@@ -262,11 +265,7 @@ except ImportError as e:
 else:
     # noexcept on importing meshgen_dealii
     logger.info("Using Meshgen via Deal.II interface.")
-    from volumential.meshgen_dealii import (  # noqa: F401
-        greet,
-        MeshGen2D,
-        MeshGen3D,
-    )
+    from volumential.meshgen_dealii import MeshGen2D, MeshGen3D, greet  # noqa: F401
 
     def make_uniform_cubic_grid(degree, level, dim, queue=None):
         from volumential.meshgen_dealii import make_uniform_cubic_grid as _mucg

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -31,7 +31,7 @@ from functools import partial
 import volumential.list1_gallery as gallery
 import volumential.singular_integral_2d as squad
 
-logger = logging.getLogger('NearFieldInteractionTable')
+logger = logging.getLogger("NearFieldInteractionTable")
 
 
 def _self_tp(vec, tpd=2):
@@ -296,8 +296,8 @@ class NearFieldInteractionTable:
             # quad points in [-1,1]
             import volumential.meshgen as mg
 
-            if 'queue' in kwargs:
-                queue = kwargs['queue']
+            if "queue" in kwargs:
+                queue = kwargs["queue"]
             else:
                 queue = None
 
@@ -471,7 +471,7 @@ class NearFieldInteractionTable:
         mode = self.get_template_mode(mode_index)
         grid = np.meshgrid(
                 *[cheby_nodes for d in range(self.dim)],
-                indexing='ij')
+                indexing="ij")
         mvals = mode(*grid)
 
         from numpy.polynomial.chebyshev import Chebyshev
@@ -1166,7 +1166,7 @@ class NearFieldInteractionTable:
         from tempfile import mkdtemp
         from os.path import join
         temp_dir = mkdtemp(prefix="tmp_volumential_nft")
-        msh_filename = join(temp_dir, 'chinese_lucky_coin.msh')
+        msh_filename = join(temp_dir, "chinese_lucky_coin.msh")
         gmsh.write(msh_filename)
         gmsh.finalize()
 
@@ -1291,7 +1291,7 @@ class NearFieldInteractionTable:
 
         for target in self.q_points:
             evt, res = lpknl(queue, quad_points=nodes, target_point=target)
-            knl_vals = res['result']
+            knl_vals = res["result"]
 
             integ = bind(discr,
                     sym.integral(self.dim, self.dim, sym.var("integrand")))(

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -357,7 +357,7 @@ class NearFieldInteractionTable:
         """This is the inverse function of get_entry_index()
         """
 
-        index_info = dict()
+        index_info = {}
 
         case_id = entry_id // self.n_pairs
         pair_id = entry_id % self.n_pairs
@@ -712,7 +712,7 @@ class NearFieldInteractionTable:
                 pool = Pool(processes=None)
 
             for mode_id, nmlz in pool.imap_unordered(
-                self.compute_nmlz, [i for i in range(self.n_q_points)]
+                self.compute_nmlz, range(self.n_q_points)
             ):
                 self.mode_normalizers[mode_id] = nmlz
                 if pb is not None:
@@ -769,7 +769,7 @@ class NearFieldInteractionTable:
         if 0:
             # Then complete the table via symmetry lookup
             for entry_id, centry_id in pool.imap_unordered(
-                    self.lookup_by_symmetry, [i for i in range(len(self.data))]):
+                    self.lookup_by_symmetry, range(len(self.data))):
                 assert not np.isnan(self.data[centry_id])
                 if centry_id == entry_id:
                     continue

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1247,7 +1247,7 @@ class NearFieldInteractionTable:
         if "extra_kernel_kwarg_types" in kwargs:
             extra_kernel_kwarg_types = kwargs["extra_kernel_kwarg_types"]
 
-        lpknl = lp.make_kernel(  # NOQA
+        lpknl = lp.make_kernel(
             "{ [iqpt, iaxis]: 0<=iqpt<n_q_points and 0<=iaxis<dim }",
             [
                 """

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -185,7 +183,7 @@ def sumpy_kernel_to_lambda(sknl):
 # {{{ table data structure
 
 
-class NearFieldInteractionTable(object):
+class NearFieldInteractionTable:
     """Class for a near-field interaction table.
 
         A near-field interaction table stores precomputed singular integrals
@@ -1137,7 +1135,7 @@ class NearFieldInteractionTable(object):
         hs = self.source_box_extent / 2
         # radius of bouding sphere
         r = hs * np.sqrt(self.dim)
-        logger.debug("r_inner = %f, r_outer = %f" % (hs, r))
+        logger.debug(f"r_inner = {hs:f}, r_outer = {r:f}")
 
         if self.dim == 2:
             tag_box = gmsh.model.occ.addRectangle(x=0, y=0, z=0,

--- a/volumential/qbfem/__init__.py
+++ b/volumential/qbfem/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
 
 __license__ = """

--- a/volumential/qbfem/mesh.py
+++ b/volumential/qbfem/mesh.py
@@ -1,7 +1,4 @@
-"""Mesh handling
-"""
-
-from __future__ import absolute_import, division, print_function
+"""Mesh handling."""
 
 __copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
 
@@ -23,7 +20,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-"""
-
-"""Given a boundary mesh, generat
 """

--- a/volumential/singular_integral_2d.py
+++ b/volumential/singular_integral_2d.py
@@ -127,7 +127,7 @@ def qquad(
 
         # Using lambda for readability
         def outer_integrand(y):
-            return sint.quadrature(  # NOQA
+            return sint.quadrature(
                 lambda x: func(x, y, *args),
                 a,
                 b,
@@ -137,9 +137,7 @@ def qquad(
                 maxiteri,
                 vec_func,
                 miniteri,
-            )[
-                0
-            ]  # NOQA
+            )[0]
 
         # Is there a simple way to retrieve err info from the inner quad calls?
 
@@ -153,11 +151,9 @@ def qquad(
 
         # Using lambda for readability
         def outer_integrand(y):
-            return sp.integrate.fixed_quad(  # NOQA
+            return sp.integrate.fixed_quad(
                 np.vectorize(lambda x: func(x, y, *args)), a, b, (), maxiteri
-            )[
-                0
-            ]  # NOQA
+            )[0]
 
         # Is there a simple way to retrieve err info from the inner quad calls?
 
@@ -245,12 +241,12 @@ def solve_affine_map_2d(source_tria, target_tria):
     b = np.array([x[4], x[5]])
 
     # Using default value is the idiomatic way to "capture by value"
-    mapping = lambda x, a=a, b=b: a.dot(np.array(x)) + b  # NOQA
+    mapping = lambda x, a=a, b=b: a.dot(np.array(x)) + b  # noqa: E731
     jacob = np.linalg.det(a)
 
     inva = np.linalg.inv(a)
     invb = -inva.dot(b)
-    invmap = lambda x, a=inva, b=invb: inva.dot(np.array(x)) + invb  # NOQA
+    invmap = lambda x, a=inva, b=invb: inva.dot(np.array(x)) + invb  # noqa: E731
     inv_jacob = np.linalg.det(inva)
 
     assert np.abs(jacob * inv_jacob - 1) < 1e-12

--- a/volumential/singular_integral_2d.py
+++ b/volumential/singular_integral_2d.py
@@ -27,6 +27,7 @@ import scipy as sp
 import scipy.integrate as sint
 from scipy.integrate import quadrature as quad  # noqa:F401
 
+
 __doc__ = """The 2D singular integrals are computed using the transform
 described in http://link.springer.com/10.1007/BF00370482.
 

--- a/volumential/singular_integral_2d.py
+++ b/volumential/singular_integral_2d.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """

--- a/volumential/symbolic.py
+++ b/volumential/symbolic.py
@@ -30,23 +30,23 @@ from volumential.tools import ScalarFieldExpressionEvaluation
 CL_MATH_URL = r"https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/mathFunctions.html"  # noqa
 
 CL_MATH_FUNCS = [
-        'acos',     'acosh',     'acospi',  'asin',
-        'asinh',    'asinpi',    'atan',    'atan2',
-        'atanh',    'atanpi',    'atan2pi', 'cbrt',
-        'ceil',     'copysign',  'cos',     'cosh',
-        'cospi',    'erfc',      'erf',     'exp',
-        'exp2',     'exp10',     'expm1',   'fabs',
-        'fdim',     'floor',     'fma',     'fmax',
-        'fmin',     'fmod',      'fract',   'frexp',
-        'hypot',    'ilogb',     'ldexp',   'lgamma',
-        'lgamma_r', 'log',       'log2',    'log10',
-        'log1p',    'logb',      'mad',     'modf',
-        'nan',      'nextafter', 'pow',     'pown',
-        'powr',     'remainder', 'remquo',  'rint',
-        'rootn',    'round',     'rsqrt',   'sin',
-        'sincos',   'sinh',      'sinpi',   'sqrt',
-        'tan',      'tanh',      'tanpi',   'tgamma',
-        'trunc',
+        "acos",     "acosh",     "acospi",  "asin",
+        "asinh",    "asinpi",    "atan",    "atan2",
+        "atanh",    "atanpi",    "atan2pi", "cbrt",
+        "ceil",     "copysign",  "cos",     "cosh",
+        "cospi",    "erfc",      "erf",     "exp",
+        "exp2",     "exp10",     "expm1",   "fabs",
+        "fdim",     "floor",     "fma",     "fmax",
+        "fmin",     "fmod",      "fract",   "frexp",
+        "hypot",    "ilogb",     "ldexp",   "lgamma",
+        "lgamma_r", "log",       "log2",    "log10",
+        "log1p",    "logb",      "mad",     "modf",
+        "nan",      "nextafter", "pow",     "pown",
+        "powr",     "remainder", "remquo",  "rint",
+        "rootn",    "round",     "rsqrt",   "sin",
+        "sincos",   "sinh",      "sinpi",   "sqrt",
+        "tan",      "tanh",      "tanpi",   "tgamma",
+        "trunc",
         ]
 
 clmath_decl_code = r"""
@@ -59,8 +59,8 @@ def FUNC_NAME(x):
 
 for fname in CL_MATH_FUNCS:
     code = clmath_decl_code.replace(
-            'FUNC_NAME', fname).replace(
-                    'CL_MATH_URL', CL_MATH_URL)
+            "FUNC_NAME", fname).replace(
+                    "CL_MATH_URL", CL_MATH_URL)
     exec(code)
 
 # }}} End math functions
@@ -88,7 +88,7 @@ def math_func_mangler(target, name, arg_dtypes):
 
         fname = name.name
         if not (isinstance(name.aggregate, pmbl.primitives.Variable)
-                and name.aggregate.name == 'math'):
+                and name.aggregate.name == "math"):
             raise RuntimeError("unexpected aggregate '%s'" %
                     str(name.aggregate))
 

--- a/volumential/symbolic.py
+++ b/volumential/symbolic.py
@@ -30,7 +30,7 @@ from volumential.tools import ScalarFieldExpressionEvaluation
 
 # {{{ math functions
 
-CL_MATH_URL = r"https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/mathFunctions.html"  # noqa
+CL_MATH_URL = r"https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/mathFunctions.html"  # noqa: E501
 
 CL_MATH_FUNCS = [
         "acos",     "acosh",     "acospi",  "asin",

--- a/volumential/symbolic.py
+++ b/volumential/symbolic.py
@@ -70,7 +70,10 @@ y = pmbl.var("y")
 z = pmbl.var("z")
 
 
-def der_laplacian(func, coord_vars=["x", "y", "z"]):
+def der_laplacian(func, coord_vars=None):
+    if coord_vars is None:
+        coord_vars = ["x", "y", "z"]
+
     return sum(pmbl.diff(pmbl.diff(func, var), var)
             for var in coord_vars)
 

--- a/volumential/symbolic.py
+++ b/volumential/symbolic.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
 
 __license__ = """
@@ -101,7 +99,7 @@ def math_func_mangler(target, name, arg_dtypes):
                         arg_dtype)
 
             return lp.CallMangleInfo(
-                   target_name="%s_%s" % (tpname, fname),
+                   target_name=f"{tpname}_{fname}",
                    result_dtypes=(arg_dtype,),
                    arg_dtypes=(arg_dtype,))
 

--- a/volumential/symbolic.py
+++ b/volumential/symbolic.py
@@ -21,9 +21,12 @@ THE SOFTWARE.
 """
 
 import numpy as np
+
 import loopy as lp
 import pymbolic as pmbl
+
 from volumential.tools import ScalarFieldExpressionEvaluation
+
 
 # {{{ math functions
 

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __doc__ = """
@@ -51,7 +49,7 @@ class ConstantKernel(ExpressionKernel):
         expr = 1
         scaling = 1
 
-        super(ConstantKernel, self).__init__(
+        super().__init__(
             dim, expression=expr,
             global_scaling_const=scaling, is_complex_valued=False
         )
@@ -75,7 +73,7 @@ class ConstantKernel(ExpressionKernel):
 # {{{ table dataset manager class
 
 
-class NearFieldInteractionTableManager(object):
+class NearFieldInteractionTableManager:
     """
     A class that manages near field interaction table computation and
     storage.
@@ -102,7 +100,7 @@ class NearFieldInteractionTableManager(object):
         if read_only == 'auto':
             try:
                 self.datafile = hdf.File(self.filename, "a")
-            except (IOError, OSError) as e:
+            except OSError as e:
                 from warnings import warn
                 warn("Trying to open in read/write mode failed: %s" % str(e))
                 warn("Opening table dataset %s in read-only mode." % self.filename)

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -89,7 +89,7 @@ class NearFieldInteractionTableManager:
 
     def __init__(self, dataset_filename="nft.hdf5",
             root_extent=1, dtype=np.float64,
-            read_only='auto', **kwargs):
+            read_only="auto", **kwargs):
         """Constructor.
         """
         self.dtype = dtype
@@ -97,7 +97,7 @@ class NearFieldInteractionTableManager:
         self.filename = dataset_filename
         self.root_extent = root_extent
 
-        if read_only == 'auto':
+        if read_only == "auto":
             try:
                 self.datafile = hdf.File(self.filename, "a")
             except OSError as e:
@@ -345,17 +345,17 @@ class NearFieldInteractionTableManager:
         assert q_order == grp.attrs["quad_order"]
 
         if compute_method == "Transform":
-            if 'knl_func' not in kwargs:
+            if "knl_func" not in kwargs:
                 knl_func = self.get_kernel_function(dim, kernel_type, **kwargs)
             else:
-                knl_func = kwargs['knl_func']
+                knl_func = kwargs["knl_func"]
             sumpy_knl = None
         elif compute_method == "DrosteSum":
             knl_func = None
-            if 'sumpy_knl' not in kwargs:
+            if "sumpy_knl" not in kwargs:
                 sumpy_knl = self.get_sumpy_kernel(dim, kernel_type)
             else:
-                sumpy_knl = kwargs['sumpy_knl']
+                sumpy_knl = kwargs["sumpy_knl"]
         else:
             from warnings import warn
 
@@ -381,9 +381,9 @@ class NearFieldInteractionTableManager:
         # Load data
         table.q_points[...] = grp["q_points"]
         table.data[...] = grp["data"]
-        if 'mode_normalizers' in grp:
+        if "mode_normalizers" in grp:
             table.mode_normalizers[...] = grp["mode_normalizers"]
-        if 'kernel_exterior_normalizers' in grp:
+        if "kernel_exterior_normalizers" in grp:
             table.kernel_exterior_normalizers[...] = \
                     grp["kernel_exterior_normalizers"]
 
@@ -599,17 +599,17 @@ class NearFieldInteractionTableManager:
         assert "Order_" + str(q_order) in self.datafile[str(dim) + "D"][kernel_type]
 
         if compute_method == "Transform":
-            if 'knl_func' not in kwargs:
+            if "knl_func" not in kwargs:
                 knl_func = self.get_kernel_function(dim, kernel_type, **kwargs)
             else:
-                knl_func = kwargs['knl_func']
+                knl_func = kwargs["knl_func"]
             sumpy_knl = None
         elif compute_method == "DrosteSum":
             knl_func = None
-            if 'sumpy_knl' not in kwargs:
+            if "sumpy_knl" not in kwargs:
                 sumpy_knl = self.get_sumpy_kernel(dim, kernel_type)
             else:
-                sumpy_knl = kwargs['sumpy_knl']
+                sumpy_knl = kwargs["sumpy_knl"]
         else:
             raise NotImplementedError("Unsupported compute_method.")
 
@@ -631,9 +631,9 @@ class NearFieldInteractionTableManager:
 
         if 0:
             # self-similarly shrink delta
-            if 'delta' in kwargs:
-                delta = kwargs.pop('delta') * (2 ** (-source_box_level))
-                kwargs['delta'] = delta
+            if "delta" in kwargs:
+                delta = kwargs.pop("delta") * (2 ** (-source_box_level))
+                kwargs["delta"] = delta
 
         table.build_table(cl_ctx, queue, **kwargs)
         assert table.is_built

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -30,15 +30,15 @@ import logging
 import h5py as hdf
 import numpy as np
 
-import volumential as vm
+from sumpy.kernel import ExpressionKernel
 
+import volumential as vm
 from volumential.nearfield_potential_table import NearFieldInteractionTable
+
 
 logger = logging.getLogger(__name__)
 
 # {{{ constant sumpy kernel
-
-from sumpy.kernel import ExpressionKernel
 
 
 class ConstantKernel(ExpressionKernel):
@@ -447,17 +447,17 @@ class NearFieldInteractionTableManager:
             return LaplaceKernel(dim)
 
         if kernel_type == "Laplace-Dx":
-            from sumpy.kernel import LaplaceKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
 
             return AxisTargetDerivative(0, LaplaceKernel(dim))
 
         if kernel_type == "Laplace-Dy":
-            from sumpy.kernel import LaplaceKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
 
             return AxisTargetDerivative(1, LaplaceKernel(dim))
 
         if kernel_type == "Laplace-Dz":
-            from sumpy.kernel import LaplaceKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
 
             assert dim >= 3
             return AxisTargetDerivative(2, LaplaceKernel(dim))
@@ -471,12 +471,12 @@ class NearFieldInteractionTableManager:
             return YukawaKernel(dim)
 
         elif kernel_type == "Yukawa-Dx":
-            from sumpy.kernel import YukawaKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, YukawaKernel
 
             return AxisTargetDerivative(0, YukawaKernel(dim))
 
         elif kernel_type == "Yukawa-Dy":
-            from sumpy.kernel import YukawaKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, YukawaKernel
 
             return AxisTargetDerivative(1, YukawaKernel(dim))
 
@@ -487,23 +487,19 @@ class NearFieldInteractionTableManager:
 
         elif kernel_type == "Cahn-Hilliard-Laplacian":
             from sumpy.kernel import (
-                FactorizedBiharmonicKernel,
-                LaplacianTargetDerivative,
-            )
+                FactorizedBiharmonicKernel, LaplacianTargetDerivative)
 
             return LaplacianTargetDerivative(FactorizedBiharmonicKernel(dim))
 
         elif kernel_type == "Cahn-Hilliard-Dx":
-            from sumpy.kernel import FactorizedBiharmonicKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, FactorizedBiharmonicKernel
 
             return AxisTargetDerivative(0, FactorizedBiharmonicKernel(dim))
 
         elif kernel_type == "Cahn-Hilliard-Laplacian-Dx":
             from sumpy.kernel import (
-                FactorizedBiharmonicKernel,
-                LaplacianTargetDerivative,
-            )
-            from sumpy.kernel import AxisTargetDerivative
+                AxisTargetDerivative, FactorizedBiharmonicKernel,
+                LaplacianTargetDerivative)
 
             return AxisTargetDerivative(
                 0, LaplacianTargetDerivative(FactorizedBiharmonicKernel(dim))
@@ -511,17 +507,15 @@ class NearFieldInteractionTableManager:
 
         elif kernel_type == "Cahn-Hilliard-Laplacian-Dy":
             from sumpy.kernel import (
-                FactorizedBiharmonicKernel,
-                LaplacianTargetDerivative,
-            )
-            from sumpy.kernel import AxisTargetDerivative
+                AxisTargetDerivative, FactorizedBiharmonicKernel,
+                LaplacianTargetDerivative)
 
             return AxisTargetDerivative(
                 1, LaplacianTargetDerivative(FactorizedBiharmonicKernel(dim))
             )
 
         elif kernel_type == "Cahn-Hilliard-Dy":
-            from sumpy.kernel import FactorizedBiharmonicKernel, AxisTargetDerivative
+            from sumpy.kernel import AxisTargetDerivative, FactorizedBiharmonicKernel
 
             return AxisTargetDerivative(1, FactorizedBiharmonicKernel(dim))
 

--- a/volumential/tools.py
+++ b/volumential/tools.py
@@ -203,7 +203,7 @@ class ScalarFieldExpressionEvaluation(KernelCacheWrapper):
             for insn in [scalar_assignment]
         ]
 
-        loopy_knl = lp.make_kernel(  # NOQA
+        loopy_knl = lp.make_kernel(
             "{ [itgt]: 0<=itgt<n_targets }",
             [
                 """
@@ -427,7 +427,7 @@ class DiscreteLegendreTransform(BoxSpecificMap):
 
     def get_kernel(self, **kwargs):
 
-        loopy_knl = lp.make_kernel(  # NOQA
+        loopy_knl = lp.make_kernel(
                 [
                     "{ [ bid ] : 0 <= bid < n_boxes }",
                     "{ [ mid ] : 0 <= mid < n_box_nodes }",
@@ -592,7 +592,7 @@ class BoxSum(BoxSpecificReduction):
 
     def get_kernel(self, **kwargs):
 
-        loopy_knl = lp.make_kernel(  # NOQA
+        loopy_knl = lp.make_kernel(
                 [
                     "{ [ bid ] : 0 <= bid < n_boxes }",
                     "{ [ nid ] : 0 <= nid < n_box_nodes }"

--- a/volumential/tools.py
+++ b/volumential/tools.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import six
 
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
@@ -62,7 +61,7 @@ def clean_file(filename, new_name=None):
 # {{{ loopy kernel cache wrapper
 
 
-class KernelCacheWrapper(object):
+class KernelCacheWrapper:
     # FIXME: largely code duplication with sumpy.
 
     def __init__(self):
@@ -97,16 +96,14 @@ class KernelCacheWrapper(object):
 
             try:
                 result = code_cache[cache_key]
-                logger.debug("%s: kernel cache hit [key=%s]" % (
-                    self.name, cache_key))
+                logger.debug(f"{self.name}: kernel cache hit [key={cache_key}]")
                 return result
             except KeyError:
                 pass
 
         logger.info("%s: kernel cache miss" % self.name)
         if CACHING_ENABLED:
-            logger.info("%s: kernel cache miss [key=%s]" % (
-                self.name, cache_key))
+            logger.info(f"{self.name}: kernel cache miss [key={cache_key}]")
 
         from pytools import MinRecursionLimit
         with MinRecursionLimit(3000):

--- a/volumential/tools.py
+++ b/volumential/tools.py
@@ -1,5 +1,3 @@
-import six
-
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -88,7 +86,7 @@ class KernelCacheWrapper:
             from volumential.version import KERNEL_VERSION
             cache_key = (
                     self.get_cache_key()
-                    + tuple(sorted(six.iteritems(kwargs)))
+                    + tuple(sorted(kwargs.items()))
                     + (loopy.version.DATA_MODEL_VERSION,)
                     + (SUMPY_KERNEL_VERSION,)
                     + (KERNEL_VERSION,)

--- a/volumential/tools.py
+++ b/volumential/tools.py
@@ -20,15 +20,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
-import loopy as lp
-import pyopencl as cl
-import pymbolic as pmbl
-from pytools import memoize_method
-from pymbolic.primitives import Variable as VariableType
-from pymbolic.primitives import Expression as ExpressionType
-
 import logging
+
+import numpy as np
+
+import loopy as lp
+import pymbolic as pmbl
+import pyopencl as cl
+from pymbolic.primitives import (
+    Expression as ExpressionType, Variable as VariableType)
+from pytools import memoize_method
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,11 +80,12 @@ class KernelCacheWrapper:
 
     @memoize_method
     def get_cached_optimized_kernel(self, **kwargs):
-        from sumpy import code_cache, CACHING_ENABLED, OPT_ENABLED
+        from sumpy import CACHING_ENABLED, OPT_ENABLED, code_cache
 
         if CACHING_ENABLED:
             import loopy.version
             from sumpy.version import KERNEL_VERSION as SUMPY_KERNEL_VERSION
+
             from volumential.version import KERNEL_VERSION
             cache_key = (
                     self.get_cache_key()
@@ -250,6 +253,7 @@ class ScalarFieldExpressionEvaluation(KernelCacheWrapper):
         knl = self.get_kernel(**kwargs)
         if ncpus is None:
             import multiprocessing
+
             # NOTE: this detects the number of logical cores, which
             # may result in suboptimal performance.
             ncpus = multiprocessing.cpu_count()

--- a/volumential/version.py
+++ b/volumential/version.py
@@ -23,6 +23,8 @@ THE SOFTWARE.
 # {{{ find install- or run-time git revision
 
 import os
+
+
 if os.environ.get("AKPYTHON_EXEC_FROM_WITHIN_WITHIN_SETUP_PY") is not None:
     # We're just being exec'd by setup.py. We can't import anything.
     _git_rev = None

--- a/volumential/version.py
+++ b/volumential/version.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -25,16 +25,19 @@ __doc__ = """
 .. autofunction:: interpolate_volume_potential
 """
 
-import numpy as np
-import pyopencl as cl
-from pytools.obj_array import make_obj_array
-from boxtree.fmm import TimingRecorder
-from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
-from volumential.expansion_wrangler_fpnd import (
-        FPNDSumpyExpansionWrangler, FPNDFMMLibExpansionWrangler)
-
-
 import logging
+
+import numpy as np
+
+import pyopencl as cl
+from boxtree.fmm import TimingRecorder
+from pytools.obj_array import make_obj_array
+
+from volumential.expansion_wrangler_fpnd import (
+    FPNDFMMLibExpansionWrangler, FPNDSumpyExpansionWrangler)
+from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -150,7 +150,7 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
 
     # Return list 1 only, for debugging
     # 'list1_only' takes precedence over 'exclude_list1'
-    if 'list1_only' in kwargs and kwargs['list1_only']:
+    if "list1_only" in kwargs and kwargs["list1_only"]:
 
         if reorder_potentials:
             logger.debug("reorder potentials")
@@ -166,7 +166,7 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         return result
 
     # Do not include list 1
-    if 'exclude_list1' in kwargs and kwargs['exclude_list1']:
+    if "exclude_list1" in kwargs and kwargs["exclude_list1"]:
         logger.info("Using zeros for list 1")
         logger.warn("list 1 interactions are not included")
         potentials = wrangler.output_zeros()
@@ -389,17 +389,17 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
                                  potential_in_tree_order=False,
                                  target_radii=None, lbl_lookup=None, **kwargs):
     """
-    Interpolate the volume potential, only works for tensor-product quadrature formulae.
-    target_points and potential should be an cl array.
+    Interpolate the volume potential, only works for tensor-product quadrature
+    formulae. target_points and potential should be an cl array.
 
-    :arg wrangler: Used only for general info (nothing sumpy kernel specific). May also
-        be None if the needed information is passed by kwargs.
-    :arg potential_in_tree_order: Whether the potential is in tree order (as opposed to
-        in user order).
-    :lbl_lookup: a :class:`boxtree.LeavesToBallsLookup` that has the lookup information
-        for target points. Can be None if the lookup lists are provided separately in
-        kwargs. If it is None and no other information is provided, the lookup will be
-        built from scratch.
+    :arg wrangler: Used only for general info (nothing sumpy kernel specific).
+        May also be None if the needed information is passed by kwargs.
+    :arg potential_in_tree_order: Whether the potential is in tree order (as
+        opposed to in user order).
+    :lbl_lookup: a :class:`boxtree.LeavesToBallsLookup` that has the lookup
+        information for target points. Can be None if the lookup lists are
+        provided separately in kwargs. If it is None and no other information is
+        provided, the lookup will be built from scratch.
     """
     if wrangler is not None:
         dim = next(iter(wrangler.near_field_table.values()))[0].dim
@@ -496,9 +496,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
 
     import loopy
 
-    # FIXME: noqa for specific lines does not work here
-    # flake8: noqa
-    lpknl = loopy.make_kernel(  # noqa
+    lpknl = loopy.make_kernel(
         [
             "{ [ tbox, iaxis ] : 0 <= tbox < n_tgt_boxes " "and 0 <= iaxis < dim }",
             "{ [ tpt, mid, mjd, mkd ] : tpt_begin <= tpt < tpt_end "
@@ -593,7 +591,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
 
             end
 
-            """.replace(
+            """.replace(    # noqa: E501
             "TARGET_COORDS_ASSIGNMENT", code_target_coords_assignment
         )
         .replace("MODE_INDEX_ASSIGNMENT", code_mode_index_assignment)

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -405,11 +405,11 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
         q_order = wrangler.quad_order
         dtype = wrangler.dtype
     else:
-        dim = kwargs['dim']
-        tree = kwargs['tree']
-        queue = kwargs['queue']
-        q_order = kwargs['q_order']
-        dtype = kwargs['dtype']
+        dim = kwargs["dim"]
+        tree = kwargs["tree"]
+        queue = kwargs["queue"]
+        q_order = kwargs["q_order"]
+        dtype = kwargs["dtype"]
 
     ctx = queue.context
     coord_dtype = tree.coord_dtype


### PR DESCRIPTION
This includes #5, so needs to go after that. The commits are fairly self-contained, but essentially
* Apply `pyupgrade` fixes, mainly to remove the `from __future__ import print_function` stuff
* Fix base flake8 issues
* Fix `flake8-quotes` issues
* Fix `flake8-isort` issues

This should get the code into a reasonable state linting-wise. It would be nice to also enable `pylint`, but for another PR :grin: 