### PR TITLE
modernize upstream compatibility and adaptive FMM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# Volumential Agent Guide
+
+This repository is an older volume-potential/FMM codebase built on the
+PyOpenCL + boxtree + sumpy + pytential stack. Treat it as research software with
+useful core ideas, uneven modernization, and a few stale interfaces.
+
+## Project Intent
+
+- `volumential` computes volume potentials in 2D/3D using fast multipole ideas.
+- The near-field story is table-driven: singular or nearly singular local
+  interactions are precomputed and cached.
+- The far-field story is wrangler-driven: boxtree traversals and expansion
+  wranglers execute the FMM passes.
+- The medium-term modernization goal is to make this package complement
+  `pytential` rather than duplicate it. Prefer integrations that make volume and
+  boundary workflows compose cleanly.
+
+## Important Files
+
+- `volumential/volume_fmm.py`: top-level volume FMM driver and interpolation of
+  computed potentials.
+- `volumential/expansion_wrangler_interface.py`: expected wrangler API.
+- `volumential/expansion_wrangler_fpnd.py`: concrete wrangler implementations.
+- `volumential/nearfield_potential_table.py`: near-field interaction table
+  construction and lookup.
+- `volumential/table_manager.py`: HDF5-backed table caching and retrieval.
+- `volumential/geometry.py`: bounding boxes, tree setup, FMM geometry helpers.
+- `volumential/interpolation.py`: meshmode <-> box-grid interpolation helpers.
+- `volumential/function_extension.py`: pytential-facing extension logic; likely a
+  key integration point for future PDE workflows.
+- `volumential/droste.py`: alternative table-building path, especially relevant
+  in higher dimensions.
+- `test/`: best source of expected behavior for maintenance.
+- `examples/`: end-to-end usage patterns for Laplace volume potentials.
+
+## What To Read First
+
+When starting non-trivial work, read these in roughly this order:
+
+1. `README.md`
+2. `volumential/__init__.py`
+3. `volumential/volume_fmm.py`
+4. `volumential/table_manager.py`
+5. `volumential/nearfield_potential_table.py`
+6. the most relevant test in `test/`
+
+For pytential integration work, also read:
+
+1. `volumential/interpolation.py`
+2. `volumential/function_extension.py`
+3. `test/test_interpolation.py`
+4. `test/test_function_extension.py`
+
+## Current Reality / Known Debt
+
+- Packaging is old: `setup.py` only, no `pyproject.toml`, stale Python metadata.
+- The code assumes old inducer-stack APIs in places, especially around
+  `pytential`, `meshmode`, `arraycontext`, and `pyopencl`.
+- Some tests and modules already document drift. In particular,
+  `test/test_function_extension.py` notes that it needs updating for
+  `GeometryCollection`.
+- There are explicit `FIXME`s and partial implementations, especially around
+  multiple source fields, 3D paths, and optional build methods.
+- Interactive OpenCL context creation appears in a few places; avoid adding more
+  of that during modernization.
+- This repo contains older contrib/native code under `contrib/`; do not assume
+  it should be preserved unless the task explicitly depends on it.
+- `volumential/meshgen.py` depends on legacy boxtree behavior that has drifted
+  out of current upstream. In particular, the old
+  `boxtree.tree_interactive_build` fallback no longer exists in current
+  `inducer/boxtree`.
+- There is a historical fork at `xywei/boxtree`, but it appears stale and should
+  not be treated as an actively maintained compatibility target.
+
+## Preferred Modernization Direction
+
+- Favor a small, reliable public API over preserving every legacy entry point.
+- Keep the separation between near-field tables, geometry/traversal setup, and
+  FMM execution explicit.
+- Prefer `arraycontext`-friendly and pytential-friendly interfaces over raw,
+  ad hoc array handling.
+- When integrating with `pytential`, aim for workflows where boundary solves can
+  feed volume evaluation without bespoke glue in user code.
+- Add or revive tests before large refactors in the integration layers.
+
+## Working Conventions
+
+- Preserve numerical behavior unless the task is explicitly to change it.
+- Be careful with cached-table semantics in `table_manager.py`; changes to table
+  format, kernel definitions, or scaling rules may invalidate old HDF5 caches.
+- When editing public behavior, update or add focused tests in `test/`.
+- Prefer extending current examples or adding small new ones over writing prose
+  docs first.
+- Avoid broad rewrites unless the user asks for them. Incremental stabilization
+  is safer here.
+
+## Testing Guidance
+
+- Start with the narrowest relevant test file under `test/`.
+- Good anchors:
+  - `test/test_volume_fmm.py`
+  - `test/test_table_manager.py`
+  - `test/test_nearfield_potential_table.py`
+  - `test/test_interpolation.py`
+  - `test/test_droste.py`
+- Expect GPU/OpenCL-dependent tests. If a test requires unavailable hardware or
+  drivers, say so clearly instead of papering over it.
+- If touching pytential integration, check for API drift first before assuming a
+  numerical bug.
+
+## When Unsure
+
+- Use the tests and examples as the behavioral spec.
+- Prefer the pure Python/OpenCL path over reviving old contrib code.
+- If a design choice affects how `volumential` should complement `pytential`,
+  choose the option that reduces duplicate abstractions and improves composable
+  PDE workflows.

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -1,0 +1,176 @@
+# Volumential Modernization Plan
+
+This plan reflects the current state of `volumential` as of March 2026 after a
+first compatibility sweep against current upstream inducer-stack packages.
+
+## Goal
+
+Revive `volumential` so it complements `pytential` for PDE workflows instead of
+acting as an isolated legacy codebase. The package should support maintainable,
+testable volume-potential workflows that compose with modern boundary-integral
+infrastructure.
+
+## Current Situation
+
+- Basic import can work, but only after papering over legacy assumptions in the
+  environment.
+- The main breakages are ecosystem drift, not one isolated bug.
+- The package currently depends on a mix of removed APIs, stale tests, and old
+  build/runtime assumptions.
+
+## Confirmed Breakage Areas
+
+### 1. Bootstrap and Packaging
+
+- `volumential/version.py` expects generated `volumential/_git_rev.py` even in a
+  source-tree test run.
+- `setup.py`-only packaging is brittle for modern editable/dev workflows.
+- Local default environments may be missing required compiled/runtime deps such
+  as `h5py` and OpenCL stack pieces.
+
+### 2. SciPy Quadrature API Drift
+
+- `volumential/singular_integral_2d.py` imports
+  `scipy.integrate.quadrature`, which is no longer available in current SciPy.
+- Several tests in `test/test_singular_integral_2d.py` fail because the old
+  quadrature calling convention no longer matches current SciPy integrators.
+
+### 3. Test Harness Drift
+
+- `test/conftest.py` assumes the `worker_id` fixture is always present.
+- That now fails unless `pytest-xdist` is installed, even for ordinary single-
+  process test runs.
+
+### 4. Meshmode / Arraycontext Drift
+
+- `test/test_interpolation.py` imports `flatten` from
+  `meshmode.dof_array`, which no longer matches current meshmode.
+- This likely indicates a larger interpolation-layer API update is needed in
+  `volumential/interpolation.py`, not just a one-line test fix.
+
+### 5. Mesh Generation / Boxtree Drift
+
+- `volumential/meshgen.py` tries `volumential.meshgen_dealii` first, then falls
+  back to `boxtree.tree_interactive_build`.
+- The dealii path is not available in the current environment.
+- The boxtree fallback is also broken because `tree_interactive_build` no longer
+  exists in current upstream `inducer/boxtree`.
+- There is an old fork at `xywei/boxtree`, but it appears stale and should be
+  treated as historical reference only, not as the modernization target.
+
+### 6. Pytential Integration Drift
+
+- `volumential/function_extension.py` still uses deprecated interfaces such as
+  `pytential.solve.gmres`.
+- `test/test_function_extension.py` is already marked stale and says it needs to
+  be updated for `GeometryCollection`.
+
+## Strategic Direction
+
+- Target current upstream inducer packages, not the old `xywei/boxtree` fork.
+- Remove legacy compatibility assumptions instead of layering more shims than
+  necessary.
+- Recover a minimal reliable core first: imports, quadrature, mesh generation,
+  interpolation, then deeper FMM integration.
+- Keep the modernization oriented toward `pytential` interoperability.
+
+## Phased Plan
+
+## Phase 0: Make the Project Testable Again
+
+- Make `volumential/version.py` tolerant of missing `_git_rev.py`.
+- Modernize packaging enough to support reproducible editable installs.
+- Fix `test/conftest.py` so `worker_id` is optional.
+- Document a supported development environment for local and remote runs.
+
+Success criteria:
+
+- `pytest -q test/test_import.py`
+- `pytest -q test/test_singular_integral_2d.py`
+- `pytest -q test/test_table_manager.py`
+
+collect and run in a modern env without ad hoc monkeypatching.
+
+## Phase 1: Repair Numerical Foundation Code
+
+- Replace the old SciPy quadrature dependency in
+  `volumential/singular_integral_2d.py` with a supported integration path.
+- Revalidate 2D singular quadrature behavior against existing tests.
+- Check whether any table-building logic depends on quadrature subtleties that
+  changed with the replacement.
+
+Success criteria:
+
+- `test/test_singular_integral_2d.py` passes.
+- table-building tests no longer fail for quadrature reasons.
+
+## Phase 2: Replace Dead Meshgen Assumptions
+
+- Audit what `volumential/meshgen.py` actually needs from the old
+  `tree_interactive_build` path.
+- Re-implement that behavior against current upstream `boxtree`, or replace it
+  with a simpler supported geometry-builder path.
+- Treat `xywei/boxtree` as reference material only if needed to understand the
+  old intent.
+- Decide whether the dealii path should be removed, demoted to optional legacy
+  support, or replaced.
+
+Success criteria:
+
+- `test/test_volume_fmm.py` can collect.
+- basic geometry/tree construction works without a private fork.
+
+## Phase 3: Modernize Interpolation Layer
+
+- Update `volumential/interpolation.py` and related tests for current
+  `meshmode`/`arraycontext` APIs.
+- Rework old DOF flattening/thawing assumptions.
+- Keep the public interpolation story aligned with meshmode's current container
+  conventions.
+
+Success criteria:
+
+- `test/test_interpolation.py` passes or has a small, explicit remaining skip set.
+
+## Phase 4: Refresh Pytential-Facing APIs
+
+- Update `volumential/function_extension.py` to modern pytential interfaces.
+- Replace deprecated solver imports and adapt to `GeometryCollection`.
+- Re-evaluate the intended user-facing workflow for boundary-to-volume coupling.
+
+Success criteria:
+
+- `test/test_function_extension.py` is unskipped or replaced by modernized tests.
+
+## Phase 5: Rebuild the Volume-FMM Story
+
+- Revisit `volumential/volume_fmm.py`, wranglers, and geometry integration after
+  the bootstrap layers are fixed.
+- Decide what subset of existing functionality is still core and what should be
+  retired.
+- Add small end-to-end tests that reflect the intended future `pytential`-
+  complementary workflow.
+
+Success criteria:
+
+- A documented, supported path exists from boundary/mesh input to volume
+  evaluation using current upstream dependencies.
+
+## Priority Order for Immediate Work
+
+1. `volumential/version.py`
+2. `test/conftest.py`
+3. `volumential/singular_integral_2d.py`
+4. `volumential/meshgen.py`
+5. `volumential/interpolation.py`
+6. `volumential/function_extension.py`
+7. `volumential/volume_fmm.py`
+
+## Non-Goals for the First Revival Pass
+
+- Do not try to preserve compatibility with every historical environment.
+- Do not resurrect the old `xywei/boxtree` fork as a required dependency.
+- Do not start with broad performance tuning before basic correctness and test
+  coverage are back.
+- Do not revive old contrib/native code unless the modern pure-Python path is
+  clearly insufficient.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["test"]

--- a/setup.py
+++ b/setup.py
@@ -28,24 +28,34 @@ from setuptools import find_packages, setup
 
 # {{{ capture git revision at install time
 
+
 # authoritative version in pytools/__init__.py
 def find_git_revision(tree_root):
     # Keep this routine self-contained so that it can be copy-pasted into
     # setup.py.
 
     from os.path import join, exists, abspath
+
     tree_root = abspath(tree_root)
 
     if not exists(join(tree_root, ".git")):
         return None
 
     from subprocess import Popen, PIPE, STDOUT
-    p = Popen(["git", "rev-parse", "HEAD"], shell=False,
-              stdin=PIPE, stdout=PIPE, stderr=STDOUT, close_fds=True,
-              cwd=tree_root)
+
+    p = Popen(
+        ["git", "rev-parse", "HEAD"],
+        shell=False,
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=STDOUT,
+        close_fds=True,
+        cwd=tree_root,
+    )
     (git_rev, _) = p.communicate()
 
     import sys
+
     git_rev = git_rev.decode()
 
     git_rev = git_rev.rstrip()
@@ -54,6 +64,7 @@ def find_git_revision(tree_root):
     assert retcode is not None
     if retcode != 0:
         from warnings import warn
+
         warn("unable to find git revision")
         return None
 
@@ -62,6 +73,7 @@ def find_git_revision(tree_root):
 
 def write_git_revision(package_name):
     from os.path import dirname, join
+
     dn = dirname(__file__)
     git_rev = find_git_revision(dn)
 
@@ -76,9 +88,7 @@ def main():
     version_dict = {}
     init_filename = "volumential/version.py"
     os.environ["AKPYTHON_EXEC_FROM_WITHIN_WITHIN_SETUP_PY"] = "1"
-    exec(compile(
-        open(init_filename).read(), init_filename, "exec"),
-        version_dict)
+    exec(compile(open(init_filename).read(), init_filename, "exec"), version_dict)
 
     write_git_revision("volumential")
 
@@ -86,7 +96,7 @@ def main():
         name="volumential",
         version=version_dict["VERSION_TEXT"],
         description="Volume potential computation powered by FMM.",
-        long_description=open("README.md", "rb").read().decode('utf-8'),
+        long_description=open("README.md", "rb").read().decode("utf-8"),
         author="Xiaoyu Wei",
         author_email="wxy0516@gmail.com",
         license="MIT",
@@ -106,7 +116,7 @@ def main():
             "Topic :: Utilities",
         ],
         packages=find_packages(),
-        python_requires='~=3.6',
+        python_requires=">=3.11",
         install_requires=[
             "boxtree",
             "h5py",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-
 __copyright__ = "Copyright (C) 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -29,9 +28,21 @@ from filelock import FileLock
 
 # setup the ctx_factory fixture
 from pyopencl.tools import (  # noqa: F401
-    pytest_generate_tests_for_pyopencl as pytest_generate_tests)
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,
+)
 
 from volumential.table_manager import NearFieldInteractionTableManager as NFTManager
+
+
+UNSUPPORTED_OPENCL_PLATFORMS = {
+    "Intel(R) OpenCL",
+}
+
+
+def _is_unsupported_ctx_factory(ctx_factory):
+    ctx = ctx_factory()
+    platform_names = {dev.platform.name for dev in ctx.devices}
+    return any(name in UNSUPPORTED_OPENCL_PLATFORMS for name in platform_names)
 
 
 def pytest_addoption(parser):
@@ -40,8 +51,24 @@ def pytest_addoption(parser):
     --longrun  Skip expensive tests unless told otherwise.
 
     """
-    parser.addoption("--longrun", action="store_true", dest="longrun",
-                     default=False, help="enable longrundecorated tests")
+    parser.addoption(
+        "--longrun",
+        action="store_true",
+        dest="longrun",
+        default=False,
+        help="enable longrundecorated tests",
+    )
+
+
+def pytest_runtest_setup(item):
+    callspec = getattr(item, "callspec", None)
+    if callspec is None or "ctx_factory" not in callspec.params:
+        return
+
+    ctx_factory = callspec.params["ctx_factory"]
+    if _is_unsupported_ctx_factory(ctx_factory):
+        unsupported = ", ".join(sorted(UNSUPPORTED_OPENCL_PLATFORMS))
+        pytest.skip(f"unsupported OpenCL backend for this stack: {unsupported}")
 
 
 @pytest.fixture(scope="session")
@@ -59,7 +86,9 @@ def requires_pypvfmm(request):
 
 
 @pytest.fixture(scope="session")
-def table_2d_order1(tmp_path_factory, worker_id):
+def table_2d_order1(tmp_path_factory, request):
+    worker_id = getattr(request.config, "workerinput", {}).get("workerid")
+
     if not worker_id:
         # not executing in with multiple workers, just produce the data and let
         # pytest's fixture caching do its job

--- a/test/test_function_extension.py
+++ b/test/test_function_extension.py
@@ -1,108 +1,101 @@
-
-__copyright__ = "Copyright (C) 2019 Xiaoyu Wei"
-
-__license__ = """
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-"""
-
 import numpy as np
-import numpy.linalg as la
-import pytest
 
 import pyopencl as cl
-import pyopencl.clmath
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import (
-    InterpolatoryQuadratureSimplexGroupFactory)
+    InterpolatoryQuadratureSimplexGroupFactory,
+)
+from pytential.array_context import PyOpenCLArrayContext
 from pytential.target import PointsTarget
 
-from volumential.function_extension import compute_harmonic_extension
+from volumential.function_extension import (
+    compute_constant_extension,
+    compute_harmonic_extension,
+)
 
 
-@pytest.mark.skip(reason="this test needs to be updated to use GeometryCollection")
-def test_harmonic_extension_exterior_3d(ctx_factory):
+def _skip_unstable_backend(ctx):
+    platform_names = {dev.platform.name for dev in ctx.devices}
+    if any(name == "Intel(R) OpenCL" for name in platform_names):
+        import pytest
 
-    dim = 3  # noqa: F841
-    mesh_order = 8
-    fmm_order = 3
-    bdry_quad_order = mesh_order
-    bdry_ovsmp_quad_order = 4 * bdry_quad_order
-    qbx_order = mesh_order
+        pytest.skip("QBX function-extension tests are unstable on Intel(R) OpenCL")
 
-    cl_ctx = ctx_factory()
-    queue = cl.CommandQueue(cl_ctx)
 
-    from meshmode.mesh.generation import generate_icosphere
-    from meshmode.mesh.refinement import refine_uniformly
+def _make_test_qbx(actx, nelements=40, order=4, qbx_order=3):
+    from functools import partial
 
-    radius = 2.5
-    base_mesh = generate_icosphere(radius, order=mesh_order)
-    mesh = refine_uniformly(base_mesh, 1)
-
-    pre_density_discr = Discretization(
-            cl_ctx, mesh,
-            InterpolatoryQuadratureSimplexGroupFactory(bdry_quad_order))
-
+    from meshmode.mesh.generation import make_curve_mesh
+    from meshmode.mesh.generation import ellipse
     from pytential.qbx import QBXLayerPotentialSource
-    qbx, _ = QBXLayerPotentialSource(
-            pre_density_discr, fine_order=bdry_ovsmp_quad_order, qbx_order=qbx_order,
-            fmm_order=fmm_order,
-            ).with_refinement()
-    density_discr = qbx.density_discr
 
-    ntgts = 200
-    rng = np.random.default_rng(seed=42)
-    rho = rng.random(ntgts) * 3 + radius + 0.05
-    theta = rng.random(ntgts) * 2 * np.pi
-    phi = (rng.random(ntgts) - 0.5) * np.pi
-
-    nodes = density_discr.nodes().with_queue(queue)
-    source = np.array([0, 1, 2])
-
-    def test_func(x):
-        return 1.0/la.norm(x.get()-source[:, None], axis=0)
-
-    f = cl.array.to_device(queue, test_func(nodes))
-
-    targets = cl.array.to_device(queue,
-            np.array([
-                rho * np.cos(phi) * np.cos(theta),
-                rho * np.cos(phi) * np.sin(theta),
-                rho * np.sin(phi)])
-            )
-
-    exact_f = test_func(targets)
-
-    ext_f, _ = compute_harmonic_extension(
-            queue, PointsTarget(targets), qbx, density_discr,
-            f, loc_sign=1)
-
-    assert np.linalg.norm(exact_f - ext_f.get()) < 1e-3 * np.linalg.norm(exact_f)
+    mesh = make_curve_mesh(
+        partial(ellipse, 1.0), np.linspace(0, 1, nelements + 1), order
+    )
+    discr = Discretization(
+        actx, mesh, InterpolatoryQuadratureSimplexGroupFactory(order)
+    )
+    qbx = QBXLayerPotentialSource(
+        discr,
+        fine_order=4 * order,
+        qbx_order=qbx_order,
+        fmm_order=False,
+    )
+    return qbx, discr
 
 
-if __name__ == "__main__":
-    import sys
+def test_constant_extension_geometry_collection(ctx_factory):
+    ctx = ctx_factory()
+    _skip_unstable_backend(ctx)
+    queue = cl.CommandQueue(ctx)
+    actx = PyOpenCLArrayContext(queue)
 
-    if len(sys.argv) > 1:
-        exec(sys.argv[1])
-    else:
-        pytest.main([__file__])
+    qbx, density_discr = _make_test_qbx(actx)
+    targets = np.array([[1.5, -1.25, 0.0], [0.0, 0.5, -1.75]], dtype=np.float64)
+    target_discr = PointsTarget(actx.freeze(actx.from_numpy(targets)))
+
+    ext_f, _ = compute_constant_extension(
+        queue,
+        target_discr,
+        qbx,
+        density_discr,
+        constant_val=2.5,
+        actx=actx,
+    )
+
+    np.testing.assert_allclose(actx.to_numpy(ext_f), 2.5)
 
 
-# vim: filetype=pyopencl:foldmethod=marker
+def test_harmonic_extension_geometry_collection_smoke(ctx_factory):
+    ctx = ctx_factory()
+    _skip_unstable_backend(ctx)
+    queue = cl.CommandQueue(ctx)
+    actx = PyOpenCLArrayContext(queue)
+
+    qbx, density_discr = _make_test_qbx(actx)
+    nodes = actx.thaw(density_discr.nodes())
+    f = nodes[0]
+
+    target_points = np.array(
+        [[0.5, -0.4, 0.0, 0.2], [0.0, 0.4, -0.6, 0.1]],
+        dtype=np.float64,
+    )
+    target_discr = PointsTarget(actx.freeze(actx.from_numpy(target_points)))
+
+    ext_f, debug = compute_harmonic_extension(
+        queue,
+        target_discr,
+        qbx,
+        density_discr,
+        f,
+        loc_sign=-1,
+        target_association_tolerance=0.05,
+        gmres_tolerance=1e-10,
+        actx=actx,
+    )
+
+    result = actx.to_numpy(ext_f)
+
+    assert debug["gmres_result"].state == "success"
+    assert result.shape == (target_points.shape[1],)
+    assert np.isfinite(result).all()

--- a/test/test_function_extension_helpers.py
+++ b/test/test_function_extension_helpers.py
@@ -1,0 +1,64 @@
+import types
+
+import pytest
+
+import volumential.function_extension as fe
+
+
+def test_setup_cl_ctx_prefers_queue_context():
+    queue = types.SimpleNamespace(context="ctx-from-queue")
+    assert fe.setup_cl_ctx(queue=queue) == "ctx-from-queue"
+
+
+def test_setup_cl_ctx_prefers_explicit_context():
+    queue = types.SimpleNamespace(context="ctx-from-queue")
+    assert fe.setup_cl_ctx(ctx="explicit-ctx", queue=queue) == "explicit-ctx"
+
+
+def test_setup_command_queue_returns_existing_queue():
+    queue = object()
+    assert fe.setup_command_queue(queue=queue) is queue
+
+
+def test_get_tangent_vectors_rotates_normals(monkeypatch):
+    normal = [2, -3]
+
+    monkeypatch.setattr(fe, "get_normal_vectors", lambda queue, discr, loc_sign: normal)
+
+    tangent = fe.get_tangent_vectors(queue=None, density_discr=None, loc_sign=1)
+
+    assert tangent[0] == 3
+    assert tangent[1] == 2
+
+
+@pytest.mark.parametrize("loc_sign, bound_value, expected", [(1, 1, -1), (-1, 1, 1)])
+def test_get_normal_vectors_uses_expected_orientation(
+    monkeypatch, loc_sign, bound_value, expected
+):
+    calls = []
+
+    class FakeNormal:
+        def __init__(self, dim):
+            self.dim = dim
+
+        def as_vector(self):
+            return ("normal", self.dim)
+
+    monkeypatch.setattr(fe.sym, "normal", lambda dim: FakeNormal(dim))
+
+    def fake_bind(discr, expr):
+        calls.append((discr, expr))
+
+        def evaluator(queue):
+            return bound_value
+
+        return evaluator
+
+    monkeypatch.setattr(fe, "bind", fake_bind)
+
+    result = fe.get_normal_vectors(
+        queue="queue", density_discr="discr", loc_sign=loc_sign
+    )
+
+    assert result == expected
+    assert calls == [("discr", ("normal", 2))]

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -23,23 +23,28 @@ import numpy as np
 import pytest
 
 import pyopencl as cl
+from arraycontext import flatten
+from boxtree.array_context import PyOpenCLArrayContext as BoxtreePyOpenCLArrayContext
 from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import PolynomialWarpAndBlendGroupFactory
-from meshmode.dof_array import flatten, thaw
+from meshmode.dof_array import DOFArray
 from meshmode.mesh.generation import generate_regular_rect_mesh
 
 from volumential.geometry import BoundingBoxFactory, BoxFMMGeometryFactory
 from volumential.interpolation import (
-    ElementsToSourcesLookupBuilder, LeavesToNodesLookupBuilder,
-    interpolate_from_meshmode, interpolate_to_meshmode)
+    ElementsToSourcesLookupBuilder,
+    LeavesToNodesLookupBuilder,
+    interpolate_from_meshmode,
+    interpolate_to_meshmode,
+)
 
 
 # {{{ test data
 
+
 def random_polynomial_func(dim, degree, seed=None):
-    """Makes a random polynomial function.
-    """
+    """Makes a random polynomial function."""
     rng = np.random.default_rng(seed=seed)
     coefs = rng.random((degree + 1,) * dim)
 
@@ -54,7 +59,7 @@ def random_polynomial_func(dim, degree, seed=None):
                 continue
             mono = np.ones(npts)
             for iaxis in range(dim):
-                mono *= pts[iaxis, :]**deg[iaxis]
+                mono *= pts[iaxis, :] ** deg[iaxis]
             res += coefs[deg] * mono
         return res
 
@@ -63,26 +68,39 @@ def random_polynomial_func(dim, degree, seed=None):
 
 def eval_func_on_discr_nodes(queue, discr, func):
     arr_ctx = PyOpenCLArrayContext(queue)
-    nodes = np.vstack([
-        c.get() for c in flatten(thaw(arr_ctx, discr.nodes()))])
+    nodes = np.vstack(
+        [
+            c.get()
+            for c in flatten(arr_ctx.thaw(discr.nodes()), arr_ctx, leaf_class=DOFArray)
+        ]
+    )
     fvals = func(nodes)
     return cl.array.to_device(queue, fvals)
+
 
 # }}} End test data
 
 
 def drive_test_from_meshmode_interpolation(
-        cl_ctx, queue, dim,
-        degree, nel_1d, n_levels, q_order,
-        a=-0.5, b=0.5, seed=0, test_case="exact"):
+    cl_ctx,
+    queue,
+    dim,
+    degree,
+    nel_1d,
+    n_levels,
+    q_order,
+    a=-0.5,
+    b=0.5,
+    seed=0,
+    test_case="exact",
+):
     """
     meshmode mesh control: nel_1d, degree
     volumential mesh control: n_levels, q_order
     """
     mesh = generate_regular_rect_mesh(
-            a=(a, ) * dim,
-            b=(b, ) * dim,
-            n=(nel_1d, ) * dim)
+        a=(a,) * dim, b=(b,) * dim, nelements_per_axis=(nel_1d,) * dim
+    )
 
     arr_ctx = PyOpenCLArrayContext(queue)
     group_factory = PolynomialWarpAndBlendGroupFactory(order=degree)
@@ -90,12 +108,16 @@ def drive_test_from_meshmode_interpolation(
 
     bbox_fac = BoundingBoxFactory(dim=dim)
     boxfmm_fac = BoxFMMGeometryFactory(
-            cl_ctx, dim=dim, order=q_order,
-            nlevels=n_levels, bbox_getter=bbox_fac,
-            expand_to_hold_mesh=mesh, mesh_padding_factor=0.)
+        cl_ctx,
+        dim=dim,
+        order=q_order,
+        nlevels=n_levels,
+        bbox_getter=bbox_fac,
+        expand_to_hold_mesh=mesh,
+        mesh_padding_factor=0.0,
+    )
     boxgeo = boxfmm_fac(queue)
-    lookup_fac = ElementsToSourcesLookupBuilder(
-            cl_ctx, tree=boxgeo.tree, discr=discr)
+    lookup_fac = ElementsToSourcesLookupBuilder(cl_ctx, tree=boxgeo.tree, discr=discr)
     lookup, evt = lookup_fac(queue)
 
     if test_case == "exact":
@@ -103,10 +125,12 @@ def drive_test_from_meshmode_interpolation(
         func = random_polynomial_func(dim, degree, seed)
     elif test_case == "non-exact":
         if dim == 2:
+
             def func(pts):
                 x, y = pts
                 return np.sin(x + y) * x
         elif dim == 3:
+
             def func(pts):
                 x, y, z = pts
                 return np.sin(x + y * z) * x
@@ -118,7 +142,7 @@ def drive_test_from_meshmode_interpolation(
     dof_vec = eval_func_on_discr_nodes(queue, discr, func)
     res = interpolate_from_meshmode(queue, dof_vec, lookup).get(queue)
 
-    tree = boxgeo.tree.get(queue)
+    tree = BoxtreePyOpenCLArrayContext(queue).to_numpy(boxgeo.tree)
     ref = func(np.vstack(tree.sources))
 
     if test_case == "exact":
@@ -129,17 +153,25 @@ def drive_test_from_meshmode_interpolation(
 
 
 def drive_test_to_meshmode_interpolation(
-        cl_ctx, queue, dim,
-        degree, nel_1d, n_levels, q_order,
-        a=-0.5, b=0.5, seed=0, test_case="exact"):
+    cl_ctx,
+    queue,
+    dim,
+    degree,
+    nel_1d,
+    n_levels,
+    q_order,
+    a=-0.5,
+    b=0.5,
+    seed=0,
+    test_case="exact",
+):
     """
     meshmode mesh control: nel_1d, degree
     volumential mesh control: n_levels, q_order
     """
     mesh = generate_regular_rect_mesh(
-            a=(a, ) * dim,
-            b=(b, ) * dim,
-            n=(nel_1d, ) * dim)
+        a=(a,) * dim, b=(b,) * dim, nelements_per_axis=(nel_1d,) * dim
+    )
 
     arr_ctx = PyOpenCLArrayContext(queue)
     group_factory = PolynomialWarpAndBlendGroupFactory(order=degree)
@@ -147,12 +179,16 @@ def drive_test_to_meshmode_interpolation(
 
     bbox_fac = BoundingBoxFactory(dim=dim)
     boxfmm_fac = BoxFMMGeometryFactory(
-            cl_ctx, dim=dim, order=q_order,
-            nlevels=n_levels, bbox_getter=bbox_fac,
-            expand_to_hold_mesh=mesh, mesh_padding_factor=0.)
+        cl_ctx,
+        dim=dim,
+        order=q_order,
+        nlevels=n_levels,
+        bbox_getter=bbox_fac,
+        expand_to_hold_mesh=mesh,
+        mesh_padding_factor=0.0,
+    )
     boxgeo = boxfmm_fac(queue)
-    lookup_fac = LeavesToNodesLookupBuilder(
-            cl_ctx, trav=boxgeo.trav, discr=discr)
+    lookup_fac = LeavesToNodesLookupBuilder(cl_ctx, trav=boxgeo.trav, discr=discr)
     lookup, evt = lookup_fac(queue)
 
     if test_case == "exact":
@@ -160,10 +196,12 @@ def drive_test_to_meshmode_interpolation(
         func = random_polynomial_func(dim, degree, seed)
     elif test_case == "non-exact":
         if dim == 2:
+
             def func(pts):
                 x, y = pts
                 return np.sin(x + y) * x
         elif dim == 3:
+
             def func(pts):
                 x, y, z = pts
                 return np.sin(x + y * z) * x
@@ -172,7 +210,7 @@ def drive_test_to_meshmode_interpolation(
     else:
         raise ValueError()
 
-    tree = boxgeo.tree.get(queue)
+    tree = BoxtreePyOpenCLArrayContext(queue).to_numpy(boxgeo.tree)
     potential = func(np.vstack(tree.sources))
     res = interpolate_to_meshmode(queue, potential, lookup).get(queue)
     ref = eval_func_on_discr_nodes(queue, discr, func).get(queue)
@@ -186,92 +224,143 @@ def drive_test_to_meshmode_interpolation(
 
 # {{{ 2d tests
 
-@pytest.mark.parametrize("params", [
-    [1, 8, 3, 1], [1, 8, 5, 2], [1, 8, 7, 3],
-    [2, 16, 3, 1], [2, 32, 5, 2], [2, 64, 7, 3],
-    ])
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        [1, 8, 3, 1],
+        [1, 8, 5, 2],
+        [1, 8, 7, 3],
+        [2, 16, 3, 1],
+        [2, 32, 5, 2],
+        [2, 64, 7, 3],
+    ],
+)
 def test_from_meshmode_interpolation_2d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case="exact")
+        cl_ctx, queue, 2, *params, test_case="exact"
+    )
 
 
-@pytest.mark.parametrize("params", [
-    [1, 128, 5, 1], [2, 64, 5, 3], [3, 64, 5, 4]
-    ])
+@pytest.mark.parametrize("params", [[1, 128, 5, 1], [2, 64, 5, 3], [3, 64, 5, 4]])
 def test_from_meshmode_interpolation_2d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
-    assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case="non-exact") < 1e-3
+    assert (
+        drive_test_from_meshmode_interpolation(
+            cl_ctx, queue, 2, *params, test_case="non-exact"
+        )
+        < 1e-3
+    )
 
 
-@pytest.mark.parametrize("params", [
-    [1, 8, 3, 2], [1, 8, 5, 2], [1, 8, 7, 3],
-    [2, 16, 3, 3], [3, 32, 5, 4], [4, 64, 7, 5],
-    ])
+@pytest.mark.parametrize(
+    "params",
+    [
+        [1, 8, 3, 2],
+        [1, 8, 5, 2],
+        [1, 8, 7, 3],
+        [2, 16, 3, 3],
+        [3, 32, 5, 4],
+        [4, 64, 7, 5],
+    ],
+)
 def test_to_meshmode_interpolation_2d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case="exact")
+        cl_ctx, queue, 2, *params, test_case="exact"
+    )
 
 
-@pytest.mark.parametrize("params", [
-    [1, 32, 7, 2], [2, 64, 5, 3], [3, 64, 6, 4]
-    ])
+@pytest.mark.parametrize("params", [[1, 32, 7, 2], [2, 64, 5, 3], [3, 64, 6, 4]])
 def test_to_meshmode_interpolation_2d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
-    assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 2, *params, test_case="non-exact") < 1e-3
+    assert (
+        drive_test_to_meshmode_interpolation(
+            cl_ctx, queue, 2, *params, test_case="non-exact"
+        )
+        < 1e-3
+    )
+
 
 # }}} End 2d tests
 
 
 # {{{ 3d tests
 
-@pytest.mark.parametrize("params", [
-    [1, 3, 3, 1], [2, 2, 4, 2], [3, 3, 4, 3],
-    [4, 4, 3, 1], [5, 2, 2, 2], [8, 4, 3, 3],
-    ])
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        [1, 3, 3, 1],
+        [2, 2, 4, 2],
+        [3, 3, 4, 3],
+        [4, 4, 3, 1],
+        [5, 2, 2, 2],
+        [8, 4, 3, 3],
+    ],
+)
 def test_from_meshmode_interpolation_3d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case="exact")
+        cl_ctx, queue, 3, *params, test_case="exact"
+    )
 
 
-@pytest.mark.parametrize("params", [
-    [6, 4, 5, 1], [7, 3, 4, 3], [8, 2, 3, 4]
-    ])
+@pytest.mark.parametrize("params", [[6, 4, 5, 1], [7, 3, 4, 3], [8, 2, 3, 4]])
 def test_from_meshmode_interpolation_3d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
-    assert drive_test_from_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case="non-exact") < 1e-3
+    assert (
+        drive_test_from_meshmode_interpolation(
+            cl_ctx, queue, 3, *params, test_case="non-exact"
+        )
+        < 1e-3
+    )
 
 
-@pytest.mark.parametrize("params", [
-    [1, 5, 3, 2], [2, 7, 3, 3], [3, 7, 3, 4],
-    [4, 8, 3, 5], [8, 10, 3, 9], [9, 7, 2, 10],
-    ])
+@pytest.mark.parametrize(
+    "params",
+    [
+        [1, 5, 3, 2],
+        [2, 7, 3, 3],
+        [3, 7, 3, 4],
+        [4, 8, 3, 5],
+        [8, 10, 3, 9],
+        [9, 7, 2, 10],
+    ],
+)
 def test_to_meshmode_interpolation_3d_exact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
     assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case="exact")
+        cl_ctx, queue, 3, *params, test_case="exact"
+    )
 
 
-@pytest.mark.parametrize("params", [
-    [2, 5, 4, 4], [3, 7, 5, 3], [4, 7, 3, 5],
-    ])
+@pytest.mark.parametrize(
+    "params",
+    [
+        [2, 5, 4, 4],
+        [3, 7, 5, 3],
+        [4, 7, 3, 5],
+    ],
+)
 def test_to_meshmode_interpolation_3d_nonexact(ctx_factory, params):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx)
-    assert drive_test_to_meshmode_interpolation(
-            cl_ctx, queue, 3, *params, test_case="non-exact") < 1e-3
+    assert (
+        drive_test_to_meshmode_interpolation(
+            cl_ctx, queue, 3, *params, test_case="non-exact"
+        )
+        < 1e-3
+    )
+
 
 # }}} End 3d tests
 
@@ -280,6 +369,12 @@ if __name__ == "__main__":
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     resid = drive_test_to_meshmode_interpolation(
-        cl_ctx, queue,
-        dim=3, degree=9, nel_1d=7, n_levels=2, q_order=10,
-        test_case="exact")
+        cl_ctx,
+        queue,
+        dim=3,
+        degree=9,
+        nel_1d=7,
+        n_levels=2,
+        q_order=10,
+        test_case="exact",
+    )

--- a/test/test_nearfield_interaction_completeness.py
+++ b/test/test_nearfield_interaction_completeness.py
@@ -1,4 +1,3 @@
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -80,54 +79,48 @@ def drive_test_completeness(ctx, queue, dim, q_order):
 
     # {{{ build tree and traversals
 
-    from boxtree.tools import AXIS_NAMES
-
-    axis_names = AXIS_NAMES[:dim]
-
-    from pytools import single_valued
-
-    coord_dtype = single_valued(coord.dtype for coord in q_points)
-    from boxtree.bounding_box import make_bounding_box_dtype
-
-    bbox_type, _ = make_bounding_box_dtype(ctx.devices[0], dim, coord_dtype)
-
-    bbox = np.empty(1, bbox_type)
-    for ax in axis_names:
-        bbox["min_" + ax] = a
-        bbox["max_" + ax] = b
-
     # tune max_particles_in_box to reconstruct the mesh
     # TODO: use points from FieldPlotter are used as target points for better
     # visuals
     from boxtree import TreeBuilder
+    from boxtree.array_context import PyOpenCLArrayContext
 
-    tb = TreeBuilder(ctx)
+    actx = PyOpenCLArrayContext(queue)
+
+    tb = TreeBuilder(actx)
     tree, _ = tb(
-        queue,
+        actx,
         particles=q_points,
         targets=q_points,
-        bbox=bbox,
-        max_particles_in_box=q_order ** dim * (2 ** dim) - 1,
+        max_particles_in_box=q_order**dim * (2**dim) - 1,
         kind="adaptive-level-restricted",
     )
 
     from boxtree.traversal import FMMTraversalBuilder
 
-    tg = FMMTraversalBuilder(ctx)
-    trav, _ = tg(queue, tree)
+    tg = FMMTraversalBuilder(actx)
+    trav, _ = tg(actx, tree)
 
     # }}} End build tree and traversals
 
     from volumential.table_manager import NearFieldInteractionTableManager
 
     subprocess.check_call(["rm", "-f", "nft-test-completeness.hdf5"])
-    with NearFieldInteractionTableManager("nft-test-completeness.hdf5",
-                                          progress_bar=False) as tm:
-
+    with NearFieldInteractionTableManager(
+        "nft-test-completeness.hdf5", progress_bar=False
+    ) as tm:
         nft, _ = tm.get_table(
-            dim, "Constant", q_order, queue=queue, n_levels=1, alpha=0,
-            compute_method="DrosteSum", n_brick_quad_points=50,
-            adaptive_level=False, use_symmetry=True)
+            dim,
+            "Constant",
+            q_order,
+            queue=queue,
+            n_levels=1,
+            alpha=0,
+            compute_method="DrosteSum",
+            n_brick_quad_points=50,
+            adaptive_level=False,
+            use_symmetry=True,
+        )
 
     # {{{ expansion wrangler
 
@@ -141,7 +134,9 @@ def drive_test_completeness(ctx, queue, dim, q_order):
     mpole_expn_class = partial(VolumeTaylorMultipoleExpansion, use_rscale=None)
 
     from volumential.expansion_wrangler_fpnd import (
-        FPNDExpansionWrangler, FPNDExpansionWranglerCodeContainer)
+        FPNDExpansionWrangler,
+        FPNDExpansionWranglerCodeContainer,
+    )
 
     wcc = FPNDExpansionWranglerCodeContainer(
         ctx,
@@ -154,7 +149,7 @@ def drive_test_completeness(ctx, queue, dim, q_order):
     wrangler = FPNDExpansionWrangler(
         code_container=wcc,
         queue=queue,
-        tree=tree,
+        traversal=trav,
         near_field_table=nft,
         dtype=dtype,
         fmm_level_to_order=lambda kernel, kernel_args, tree, lev: 1,
@@ -163,8 +158,11 @@ def drive_test_completeness(ctx, queue, dim, q_order):
 
     # }}} End sumpy expansion for laplace kernel
     pot = wrangler.eval_direct(
-        trav.target_boxes, trav.neighbor_source_boxes_starts,
-        trav.neighbor_source_boxes_lists, mode_coefs=source_vals)
+        trav.target_boxes,
+        trav.neighbor_source_boxes_starts,
+        trav.neighbor_source_boxes_lists,
+        mode_coefs=source_vals,
+    )
     pot = pot[0]
     for p in pot[0]:
         assert abs(p - 2**dim) < 1.0e-8

--- a/test/test_tree_interactive_build.py
+++ b/test/test_tree_interactive_build.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+import pyopencl as cl
+
+from volumential.tree_interactive_build import BoxTree, QuadratureOnBoxTree
+
+
+def test_box_tree_refine_and_quadrature(ctx_factory):
+    ctx = ctx_factory()
+    queue = cl.CommandQueue(ctx)
+
+    tree = BoxTree()
+    tree.generate_uniform_boxtree(
+        queue, root_vertex=np.array([-1.0, -1.0]), root_extent=2.0, nlevels=2
+    )
+
+    assert tree.n_active_boxes == 4
+
+    refine_flags = np.zeros(tree.nboxes, dtype=bool)
+    refine_flags[int(tree.active_boxes.get()[0])] = True
+    coarsen_flags = np.zeros(tree.nboxes, dtype=bool)
+    tree.refine_and_coarsen(refine_flags, coarsen_flags, error_on_ignored_flags=False)
+
+    assert tree.n_active_boxes > 4
+
+    quad = QuadratureOnBoxTree(tree)
+    q_points = quad.get_q_points(queue)
+    q_weights = quad.get_q_weights(queue)
+    cell_centers = quad.get_cell_centers(queue)
+    cell_measures = quad.get_cell_measures(queue)
+
+    assert len(q_points) == 2
+    assert q_weights.size > 0
+    assert len(cell_centers) == 2
+    assert cell_measures.size == tree.n_active_boxes

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -1,4 +1,3 @@
-
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __license__ = """
@@ -24,6 +23,7 @@ THE SOFTWARE.
 import logging
 import subprocess
 from functools import partial
+import os
 
 import numpy as np
 import pytest
@@ -97,8 +97,8 @@ def laplace_problem(ctx_factory):
     rratio_bot = 0.5
 
     # bounding box
-    a = -1.
-    b = 1.
+    a = -1.0
+    b = 1.0
 
     m_order = 15  # multipole order
 
@@ -108,11 +108,11 @@ def laplace_problem(ctx_factory):
         assert len(x) == dim
         assert dim == 2
         norm2 = x[0] ** 2 + x[1] ** 2
-        lap_u = (4 * alpha ** 2 * norm2 - 4 * alpha) * np.exp(-alpha * norm2)
+        lap_u = (4 * alpha**2 * norm2 - 4 * alpha) * np.exp(-alpha * norm2)
         return -lap_u
 
     def exact_solu(x, y):
-        norm2 = x ** 2 + y ** 2
+        norm2 = x**2 + y**2
         return np.exp(-alpha * norm2)
 
     # {{{ generate quad points
@@ -165,39 +165,18 @@ def laplace_problem(ctx_factory):
 
     # {{{ build tree and traversals
 
-    from boxtree.tools import AXIS_NAMES
-
-    axis_names = AXIS_NAMES[:dim]
-
-    from pytools import single_valued
-
-    coord_dtype = single_valued(coord.dtype for coord in q_points)
-    from boxtree.bounding_box import make_bounding_box_dtype
-
-    bbox_type, _ = make_bounding_box_dtype(ctx.devices[0], dim, coord_dtype)
-
-    bbox = np.empty(1, bbox_type)
-    for ax in axis_names:
-        bbox["min_" + ax] = a
-        bbox["max_" + ax] = b
-
     # tune max_particles_in_box to reconstruct the mesh
     from boxtree import TreeBuilder
+    from boxtree.array_context import PyOpenCLArrayContext
+    from volumential.tree_interactive_build import build_particle_tree_from_box_tree
 
-    tb = TreeBuilder(ctx)
-    tree, _ = tb(
-        queue,
-        particles=q_points,
-        targets=q_points,
-        bbox=bbox,
-        max_particles_in_box=q_order ** 2 * 4 - 1,
-        kind="adaptive-level-restricted",
-    )
+    actx = PyOpenCLArrayContext(queue)
+    tree = build_particle_tree_from_box_tree(actx, mesh.boxtree, q_points_org)
 
     from boxtree.traversal import FMMTraversalBuilder
 
-    tg = FMMTraversalBuilder(ctx)
-    trav, _ = tg(queue, tree)
+    tg = FMMTraversalBuilder(actx)
+    trav, _ = tg(actx, tree)
 
     # }}} End build tree and traversals
 
@@ -214,10 +193,12 @@ def laplace_problem(ctx_factory):
     # {{{ sumpy expansion for laplace kernel
 
     from sumpy.expansion.local import LinearPDEConformingVolumeTaylorLocalExpansion
+
     # from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion
     # from sumpy.expansion.local import VolumeTaylorLocalExpansion
     from sumpy.expansion.multipole import (
-        LinearPDEConformingVolumeTaylorMultipoleExpansion)
+        LinearPDEConformingVolumeTaylorMultipoleExpansion,
+    )
     from sumpy.kernel import LaplaceKernel
 
     knl = LaplaceKernel(dim)
@@ -229,7 +210,9 @@ def laplace_problem(ctx_factory):
 
     exclude_self = True
     from volumential.expansion_wrangler_fpnd import (
-        FPNDExpansionWrangler, FPNDExpansionWranglerCodeContainer)
+        FPNDExpansionWrangler,
+        FPNDExpansionWranglerCodeContainer,
+    )
 
     wcc = FPNDExpansionWranglerCodeContainer(
         ctx,
@@ -248,7 +231,7 @@ def laplace_problem(ctx_factory):
     wrangler = FPNDExpansionWrangler(
         code_container=wcc,
         queue=queue,
-        tree=tree,
+        traversal=trav,
         near_field_table=nftable,
         dtype=dtype,
         fmm_level_to_order=lambda kernel, kernel_args, tree, lev: m_order,
@@ -258,30 +241,42 @@ def laplace_problem(ctx_factory):
 
     # }}} End sumpy expansion for laplace kernel
 
-    return trav, wrangler, source_vals, q_weights
+    exact_vals = cl.array.to_device(
+        queue,
+        np.array([exact_solu(qp[0], qp[1]) for qp in q_points_org], dtype=dtype),
+    )
+
+    return trav, wrangler, source_vals, q_weights, exact_vals
 
 
 # }}} End laplace volume potential
 
 
 @pytest.mark.skipif(
-    mg.provider != "meshgen_dealii",
-    reason="Adaptive mesh module is not available")
+    mg.provider not in {"meshgen_dealii", "meshgen_boxtree"},
+    reason="Adaptive mesh module is not available",
+)
 def test_volume_fmm_laplace(laplace_problem):
 
-    trav, wrangler, source_vals, q_weights = laplace_problem
+    trav, wrangler, source_vals, q_weights, exact_vals = laplace_problem
 
     from volumential.volume_fmm import drive_volume_fmm
 
-    direct_pot, = drive_volume_fmm(
-        trav, wrangler, source_vals * q_weights,
-        source_vals, direct_evaluation=True)
+    (fmm_pot,) = drive_volume_fmm(
+        trav, wrangler, source_vals * q_weights, source_vals, direct_evaluation=False
+    )
 
-    fmm_pot, = drive_volume_fmm(
-        trav, wrangler, source_vals * q_weights,
-        source_vals, direct_evaluation=False)
-
-    assert max(abs(direct_pot - fmm_pot)) < 1e-6
+    exact_host = exact_vals.get()
+    fmm_host = wrangler.tree_indep._setup_actx.to_numpy(fmm_pot)
+    if os.environ.get("VOLUMENTIAL_DEBUG_NAN"):
+        print("fmm sample", fmm_host[:8])
+        print("exact sample", exact_host[:8])
+        print("abs err sample", np.abs(exact_host - fmm_host)[:8])
+        print("max abs fmm", np.nanmax(np.abs(fmm_host)))
+        print("max abs exact", np.nanmax(np.abs(exact_host)))
+    max_err = np.nanmax(np.abs(exact_host - fmm_host))
+    assert np.isfinite(max_err)
+    assert float(max_err) < 5e-2
 
 
 if __name__ == "__main__":

--- a/volumential/droste.py
+++ b/volumential/droste.py
@@ -72,8 +72,17 @@ class DrosteBase(KernelCacheWrapper):
         ``ibrick_axis == iaxis`` and always uses iname ``q0``.
     """
 
-    def __init__(self, integral_knl, quad_order, case_vecs, n_brick_quad_points,
-                 special_radial_quadrature, nradial_quad_points):
+    def __init__(
+        self,
+        integral_knl,
+        quad_order,
+        case_vecs,
+        n_brick_quad_points,
+        special_radial_quadrature,
+        nradial_quad_points,
+    ):
+        self.name = type(self).__name__
+
         from sumpy.kernel import Kernel
 
         if integral_knl is not None:
@@ -111,16 +120,20 @@ class DrosteBase(KernelCacheWrapper):
 
         if special_radial_quadrature and (self.dim == 1):
             raise ValueError(
-                "please only use normal quadrature nodes for 1D quadrature")
+                "please only use normal quadrature nodes for 1D quadrature"
+            )
 
         self.special_radial_quadrature = special_radial_quadrature
         self.nradial_quad_points = nradial_quad_points
         self.brick_quadrature_kwargs = self.make_brick_quadrature_kwargs()
 
         if self.dim is not None:
-            self.n_q_points = quad_order ** self.dim
+            self.n_q_points = quad_order**self.dim
         else:
             self.n_q_points = None
+
+    def get_kernel_scaling_value(self):
+        return np.float64(self.integral_knl.get_global_scaling_const())
 
         self.name = "DrosteBase"
 
@@ -189,6 +202,7 @@ class DrosteBase(KernelCacheWrapper):
             # we find the largest rule whose size dose not exceed the parameter
             # nradial_quad_points
             import mpmath
+
             mp_ctx = mpmath.mp
             mp_ctx.dps = 20  # decimal precision
             mp_ctx.pretty = True
@@ -204,8 +218,8 @@ class DrosteBase(KernelCacheWrapper):
             # extract quadrature formula over [-1, 1], note the 0.5**level scaling
             ts_nodes = np.array([p[0] for p in nodes], dtype=np.float64)
             ts_weights = np.array(
-                [p[1] * 2 * mp_ctx.power(0.5, deg) for p in nodes],
-                dtype=np.float64)
+                [p[1] * 2 * mp_ctx.power(0.5, deg) for p in nodes], dtype=np.float64
+            )
             if deg == 1:
                 ts_weights *= 0.5  # peculiar scaling when deg=1
 
@@ -218,13 +232,13 @@ class DrosteBase(KernelCacheWrapper):
                 "quadrature_weights": legendre_weights,
                 "radial_quadrature_nodes": ts_nodes,
                 "radial_quadrature_weights": ts_weights,
-                }
+            }
 
         else:
             return {
                 "quadrature_nodes": legendre_nodes,
                 "quadrature_weights": legendre_weights,
-                }
+            }
 
     def get_sumpy_kernel_insns(self):
         # get sumpy kernel insns
@@ -305,9 +319,7 @@ class DrosteBase(KernelCacheWrapper):
                 + simul_reduce(sum, pIAXIS,
                     if(fIAXIS >= 2 and fIAXIS == pIAXIS + 2, Tcur_IAXIS, 0))
                 ) {id=basisIAXIS,dep=tcur_updateIAXIS}
-            """.replace(
-            "IAXIS", str(iaxis)
-        )
+            """.replace("IAXIS", str(iaxis))
         return code
 
     def make_dim_independent(self, knlstring):
@@ -321,12 +333,10 @@ class DrosteBase(KernelCacheWrapper):
         resknl = resknl.replace("QUAD_VARS", ",".join(self.quad_vars))
 
         resknl = resknl.replace(
-                "POSTPROCESS_KNL_VAL",
-                "<> knl_val_post = knl_val {id=pp_kval}"
-                )
+            "POSTPROCESS_KNL_VAL", "<> knl_val_post = knl_val {id=pp_kval}"
+        )
 
         if self.dim == 1:
-
             resknl = resknl.replace("TPLTGT_ASSIGNMENT", """target_nodes[t0]""")
             resknl = resknl.replace("QUAD_PT_ASSIGNMENT", """quadrature_nodes[q0]""")
             resknl = resknl.replace("PROD_QUAD_WEIGHT", """quadrature_weights[q0]""")
@@ -352,7 +362,8 @@ class DrosteBase(KernelCacheWrapper):
                 )
                 resknl = resknl.replace(
                     "PROD_QUAD_WEIGHT",
-                    """radial_quadrature_weights[q0] * quadrature_weights[q1]""")
+                    """radial_quadrature_weights[q0] * quadrature_weights[q1]""",
+                )
             else:
                 resknl = resknl.replace(
                     "QUAD_PT_ASSIGNMENT",
@@ -360,7 +371,8 @@ class DrosteBase(KernelCacheWrapper):
                 )
                 resknl = resknl.replace(
                     "PROD_QUAD_WEIGHT",
-                    """quadrature_weights[q0] * quadrature_weights[q1]""")
+                    """quadrature_weights[q0] * quadrature_weights[q1]""",
+                )
             resknl = resknl.replace(
                 "DENSITY_VAL_ASSIGNMENT", """basis_eval0 * basis_eval1"""
             )
@@ -391,18 +403,21 @@ class DrosteBase(KernelCacheWrapper):
                 resknl = resknl.replace(
                     "PROD_QUAD_WEIGHT",
                     """radial_w[q0] * w[q1] * w[q2]""".replace(
-                        "w", "quadrature_weights"))
+                        "w", "quadrature_weights"
+                    ),
+                )
             else:
                 resknl = resknl.replace(
                     "QUAD_PT_ASSIGNMENT",
                     """if(iaxis == 0, quadrature_nodes[q0], if(
-                      iaxis == 1, quadrature_nodes[q1], quadrature_nodes[q2]))""")
+                      iaxis == 1, quadrature_nodes[q1], quadrature_nodes[q2]))""",
+                )
                 resknl = resknl.replace(
                     "PROD_QUAD_WEIGHT",
-                    """w[q0] * w[q1] * w[q2]""".replace("w", "quadrature_weights"))
+                    """w[q0] * w[q1] * w[q2]""".replace("w", "quadrature_weights"),
+                )
             resknl = resknl.replace(
-                "DENSITY_VAL_ASSIGNMENT",
-                """basis_eval0 * basis_eval1 * basis_eval2"""
+                "DENSITY_VAL_ASSIGNMENT", """basis_eval0 * basis_eval1 * basis_eval2"""
             )
             resknl = resknl.replace(
                 "PREPARE_BASIS_VALS",
@@ -418,8 +433,7 @@ class DrosteBase(KernelCacheWrapper):
         return resknl
 
     def make_result_array(self, **kwargs):
-        """Allocate memory space for results.
-        """
+        """Allocate memory space for results."""
         # by default uses double type returns
         if "result_dtype" in kwargs:
             result_dtype = kwargs["result_dtype"]
@@ -432,41 +446,39 @@ class DrosteBase(KernelCacheWrapper):
         # allocate return arrays
         if self.dim == 1:
             result_array = (
-                    np.zeros(
-                        (self.nfunctions, self.ntgt_points, self.ncases),
-                        result_dtype
-                        )
-                    + np.nan)
+                np.zeros((self.nfunctions, self.ntgt_points, self.ncases), result_dtype)
+                + np.nan
+            )
         elif self.dim == 2:
             result_array = (
-                    np.zeros(
-                        (
-                            self.nfunctions,
-                            self.nfunctions,
-                            self.ntgt_points,
-                            self.ntgt_points,
-                            self.ncases,
-                            ),
-                        result_dtype
-                        )
-                    + np.nan
-                    )
+                np.zeros(
+                    (
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ncases,
+                    ),
+                    result_dtype,
+                )
+                + np.nan
+            )
         elif self.dim == 3:
             result_array = (
-                    np.zeros(
-                        (
-                            self.nfunctions,
-                            self.nfunctions,
-                            self.nfunctions,
-                            self.ntgt_points,
-                            self.ntgt_points,
-                            self.ntgt_points,
-                            self.ncases,
-                            ),
-                        result_dtype
-                        )
-                    + np.nan
-                    )
+                np.zeros(
+                    (
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ncases,
+                    ),
+                    result_dtype,
+                )
+                + np.nan
+            )
         else:
             raise NotImplementedError
         return result_array
@@ -486,13 +498,13 @@ class DrosteBase(KernelCacheWrapper):
 
             # Targets outside projected onto the boundary
             for iaxis
-                <> template_target[iaxis] = TPLTGT_ASSIGNMENT \
+                template_target[iaxis] = TPLTGT_ASSIGNMENT \
                         {id=tplt_tgt_pre,dup=iaxis}
             end
 
             # True targets are used for kernel evaluation
             for iaxis
-                <> true_target[iaxis] = ( root_center[iaxis]
+                true_target[iaxis] = ( root_center[iaxis]
                          + interaction_case_vecs[iaxis, icase]
                             * 0.25 * root_extent[iaxis]
                          + interaction_case_scls[icase]
@@ -501,14 +513,14 @@ class DrosteBase(KernelCacheWrapper):
                          ) {id=true_targets,dup=iaxis,dep=tplt_tgt_pre}
 
                 # Re-map the mapped points to [-1,1]^dim for Chebyshev evals
-                <> template_true_target[iaxis] = 0.0 + (
+                template_true_target[iaxis] = 0.0 + (
                         true_target[iaxis] - root_center[iaxis]
                         ) / root_extent[iaxis] * 2 {id=template_true_targets,dup=iaxis,dep=true_targets}
             end
 
             # Projected targets are used for brick construction
             for iaxis
-                <> target[iaxis] = if(
+                target[iaxis] = if(
                     true_target[iaxis] > root_brick[iaxis, 1],
                     root_brick[iaxis, 1],
                     if(
@@ -550,29 +562,29 @@ class DrosteBase(KernelCacheWrapper):
             #end
 
             for iaxis, iside
-                <> outer_brick[iaxis, iside] = (
+                outer_brick[iaxis, iside] = (
                         (alpha**ilevel)*root_brick[iaxis,iside]
                         + (1-alpha**ilevel) * target[iaxis])  {dup=iaxis:iside}
-                <> inner_brick[iaxis, iside] = (
+                inner_brick[iaxis, iside] = (
                         alpha*outer_brick[iaxis,iside]
                         + (1-alpha) * target[iaxis])  {dup=iaxis:iside}
             end
 
             for iaxis
-                <> ob_ext[iaxis] = (outer_brick[iaxis, 1]
+                ob_ext[iaxis] = (outer_brick[iaxis, 1]
                     - outer_brick[iaxis, 0])  {dup=iaxis}
             end
 
             for ibrick_axis, ibrick_side, QUAD_VARS
                 for iaxis
-                    <> point[iaxis] = QUAD_PT_ASSIGNMENT {dup=iaxis}
+                    point[iaxis] = QUAD_PT_ASSIGNMENT {dup=iaxis}
                 end
 
                 <> deform = point[ibrick_axis]*(1-alpha)
 
                 for iaxis
                     if iaxis == ibrick_axis
-                        <> mapped_point_tmp[iaxis] = (
+                        mapped_point_tmp[iaxis] = (
                             point[ibrick_axis]*(
                                 inner_brick[ibrick_axis, ibrick_side]
                                 - outer_brick[ibrick_axis, ibrick_side])
@@ -592,7 +604,7 @@ class DrosteBase(KernelCacheWrapper):
                     ... nop {id=mpoint,dep=mpoint1:mpoint2}
 
                     # Re-map the mapped points to [-1,1]^dim for Chebyshev evals
-                    <> template_mapped_point_tmp[iaxis] = 0.0 + (
+                    template_mapped_point_tmp[iaxis] = 0.0 + (
                             mapped_point_tmp[iaxis] - root_center[iaxis]
                             ) / root_extent[iaxis] * 2 {dep=mpoint}
 
@@ -617,7 +629,7 @@ class DrosteBase(KernelCacheWrapper):
                 <> jacobian = abs(product(iaxis,
                                           jac_part)) {id=jac,dep=jpart1:jpart2}
 
-                <> dist[iaxis] = (true_target[iaxis]
+                dist[iaxis] = (true_target[iaxis]
                                 - mapped_point_tmp[iaxis]) {dep=mpoint:true_targets}
 
                 # optional postprocessing of kernel values
@@ -656,23 +668,19 @@ class DrosteBase(KernelCacheWrapper):
                     *  knl_scaling
                 ) {id=result,dep=jac:mpoint:density:finish_kval}
         end
-        """)
+        """
+            )
         ]
 
     def get_target_points(self, queue=None):
         import volumential.meshgen as mg
 
         q_points, _, _ = mg.make_uniform_cubic_grid(
-            degree=self.ntgt_points, level=1, dim=self.dim,
-            queue=queue)
+            degree=self.ntgt_points, level=1, dim=self.dim, queue=queue
+        )
 
         # map to [0,1]^d
-        mapped_q_points = np.array(
-                [
-                    0.5 * (qp + np.ones(self.dim))
-                    for qp in q_points
-                    ]
-                )
+        mapped_q_points = np.array([0.5 * (qp + np.ones(self.dim)) for qp in q_points])
         # sort in dictionary order, preserve only the leading
         # digits to prevent floating point errors from polluting
         # the ordering.
@@ -684,8 +692,12 @@ class DrosteBase(KernelCacheWrapper):
 
     def postprocess_cheb_table(self, cheb_table, cheb_coefs):
         nfp_table = np.zeros(
-            [self.n_q_points, ] + list(cheb_table.shape[self.dim:]),
-            dtype=cheb_table.dtype)
+            [
+                self.n_q_points,
+            ]
+            + list(cheb_table.shape[self.dim :]),
+            dtype=cheb_table.dtype,
+        )
 
         # transform to interpolatory basis functions
         # NOTE: the reversed order of indices, e.g.,
@@ -719,13 +731,23 @@ class DrosteFull(DrosteBase):
     Build the full table directly.
     """
 
-    def __init__(self, integral_knl, quad_order, case_vecs,
-                 n_brick_quad_points=50,
-                 special_radial_quadrature=False,
-                 nradial_quad_points=None):
+    def __init__(
+        self,
+        integral_knl,
+        quad_order,
+        case_vecs,
+        n_brick_quad_points=50,
+        special_radial_quadrature=False,
+        nradial_quad_points=None,
+    ):
         super().__init__(
-            integral_knl, quad_order, case_vecs, n_brick_quad_points,
-            special_radial_quadrature, nradial_quad_points)
+            integral_knl,
+            quad_order,
+            case_vecs,
+            n_brick_quad_points,
+            special_radial_quadrature,
+            nradial_quad_points,
+        )
         self.name = "DrosteFull"
 
     def make_loop_domain(self):
@@ -736,11 +758,10 @@ class DrosteFull(DrosteBase):
         pwaffs = self.make_pwaffs()  # noqa: F841
         if self.special_radial_quadrature:
             quad_vars_subdomain = self.make_brick_domain(
-                quad_vars[1:], self.nquad_points) & self.make_brick_domain(
-                    quad_vars[:1], self.nradial_quad_points)
+                quad_vars[1:], self.nquad_points
+            ) & self.make_brick_domain(quad_vars[:1], self.nradial_quad_points)
         else:
-            quad_vars_subdomain = self.make_brick_domain(
-                quad_vars, self.nquad_points)
+            quad_vars_subdomain = self.make_brick_domain(quad_vars, self.nquad_points)
         self.loop_domain = (
             self.make_brick_domain(tgt_vars, self.ntgt_points)
             & quad_vars_subdomain
@@ -765,25 +786,92 @@ class DrosteFull(DrosteBase):
 
         loopy_knl = lp.make_kernel(
             [domain],
-            self.get_kernel_code()
-            + self.get_sumpy_kernel_eval_insns(),
+            self.get_kernel_code() + self.get_sumpy_kernel_eval_insns(),
             [
                 lp.ValueArg("alpha", np.float64),
                 lp.ValueArg("n_cases, nfunctions, quad_order, dim", np.int32),
                 lp.GlobalArg("interaction_case_vecs", np.float64, "dim, n_cases"),
                 lp.GlobalArg("interaction_case_scls", np.float64, "n_cases"),
                 lp.GlobalArg(
-                    "result", None,
+                    "result",
+                    None,
                     ", ".join(
                         ["nfunctions" for d in range(self.dim)]
                         + ["quad_order" for d in range(self.dim)]
                     )
                     + ", n_cases",
-                ), ]
+                ),
+            ]
             + list(extra_kernel_kwarg_types)
-            + ["...", ],
+            + [
+                "...",
+            ],
             name="brick_map",
             lang_version=(2018, 2),
+            temporary_variables={
+                "template_target": lp.TemporaryVariable(
+                    "template_target", np.float64, shape=("dim",)
+                ),
+                "true_target": lp.TemporaryVariable(
+                    "true_target", np.float64, shape=("dim",)
+                ),
+                "template_true_target": lp.TemporaryVariable(
+                    "template_true_target", np.float64, shape=("dim",)
+                ),
+                "target": lp.TemporaryVariable("target", np.float64, shape=("dim",)),
+                "root_center": lp.TemporaryVariable(
+                    "root_center", np.float64, shape=("dim",)
+                ),
+                "root_extent": lp.TemporaryVariable(
+                    "root_extent", np.float64, shape=("dim",)
+                ),
+                "outer_brick": lp.TemporaryVariable(
+                    "outer_brick", np.float64, shape=("dim", 2)
+                ),
+                "inner_brick": lp.TemporaryVariable(
+                    "inner_brick", np.float64, shape=("dim", 2)
+                ),
+                "ob_ext": lp.TemporaryVariable("ob_ext", np.float64, shape=("dim",)),
+                "point": lp.TemporaryVariable("point", np.float64, shape=("dim",)),
+                "mapped_point_tmp": lp.TemporaryVariable(
+                    "mapped_point_tmp", np.float64, shape=("dim",)
+                ),
+                "template_mapped_point_tmp": lp.TemporaryVariable(
+                    "template_mapped_point_tmp", np.float64, shape=("dim",)
+                ),
+                "pre_scale": lp.TemporaryVariable("pre_scale", np.float64),
+                "deform": lp.TemporaryVariable("deform", np.float64),
+                "jac_part": lp.TemporaryVariable("jac_part", np.float64),
+                "jacobian": lp.TemporaryVariable("jacobian", np.float64),
+                "dist": lp.TemporaryVariable("dist", np.float64, shape=("dim",)),
+                "density_val": lp.TemporaryVariable("density_val", np.float64),
+                "knl_scaling": lp.TemporaryVariable("knl_scaling", np.float64),
+            },
+        )
+
+        loopy_knl = lp.add_dtypes(
+            loopy_knl,
+            {
+                "template_target": np.float64,
+                "true_target": np.float64,
+                "template_true_target": np.float64,
+                "target": np.float64,
+                "root_center": np.float64,
+                "root_extent": np.float64,
+                "outer_brick": np.float64,
+                "inner_brick": np.float64,
+                "ob_ext": np.float64,
+                "point": np.float64,
+                "mapped_point_tmp": np.float64,
+                "template_mapped_point_tmp": np.float64,
+                "pre_scale": np.float64,
+                "deform": np.float64,
+                "jac_part": np.float64,
+                "jacobian": np.float64,
+                "dist": np.float64,
+                "density_val": np.float64,
+                "knl_scaling": np.float64,
+            },
         )
 
         loopy_knl = lp.fix_parameters(loopy_knl, d=self.dim)
@@ -837,13 +925,15 @@ class DrosteFull(DrosteBase):
             nlevels = kwargs["nlevels"]
             assert nlevels > 0
             if nlevels > 1 and self.special_radial_quadrature:
-                logger.warn("When using tanh-sinh quadrature in the radial "
-                            "direction, it is often best to use a single level.")
+                logger.warn(
+                    "When using tanh-sinh quadrature in the radial "
+                    "direction, it is often best to use a single level."
+                )
         else:
             # Single level is equivalent to Duffy transform
             nlevels = 1
 
-        missing_measure = (alpha ** nlevels * source_box_extent) ** self.dim
+        missing_measure = (alpha**nlevels * source_box_extent) ** self.dim
         if abs(missing_measure) > 1e-6:
             from warnings import warn
 
@@ -864,22 +954,30 @@ class DrosteFull(DrosteBase):
 
         # target points in 1D
         q_points = self.get_target_points(queue)
-        assert len(q_points) == self.ntgt_points ** self.dim
+        assert len(q_points) == self.ntgt_points**self.dim
         t = np.array([pt[-1] for pt in q_points[: self.ntgt_points]])
 
         knl = self.get_cached_optimized_kernel()
         evt, res = knl(
-            queue, alpha=alpha, result=result_array,
+            queue,
+            alpha=alpha,
+            knl_scaling=self.get_kernel_scaling_value(),
+            result=result_array,
             root_brick=root_brick,
             target_nodes=t.astype(np.float64, copy=True),
             interaction_case_vecs=self.interaction_case_vecs.astype(
-                np.float64, copy=True),
+                np.float64, copy=True
+            ),
             interaction_case_scls=self.interaction_case_scls.reshape(-1).astype(
-                np.float64, copy=True),
-            n_cases=self.ncases, nfunctions=self.nfunctions,
-            quad_order=self.ntgt_points, nlevels=nlevels,
+                np.float64, copy=True
+            ),
+            n_cases=self.ncases,
+            nfunctions=self.nfunctions,
+            quad_order=self.ntgt_points,
+            nlevels=nlevels,
             **self.brick_quadrature_kwargs,
-            **extra_kernel_kwargs)
+            **extra_kernel_kwargs,
+        )
 
         cheb_table = res["result"]
 
@@ -905,7 +1003,7 @@ class DrosteFull(DrosteBase):
         if "cheb_coefs" in kwargs:
             assert len(kwargs["cheb_coefs"]) == self.n_q_points
             for ccoef in kwargs["cheb_coefs"]:
-                assert len(ccoef) == self.nfunctions ** self.dim
+                assert len(ccoef) == self.nfunctions**self.dim
             cheb_coefs = kwargs["cheb_coefs"]
             return self.postprocess_cheb_table(
                 self.call_loopy_kernel(queue, **kwargs), cheb_coefs
@@ -937,14 +1035,21 @@ class DrosteReduced(DrosteBase):
         nradial_quad_points=None,
     ):
         super().__init__(
-            integral_knl, quad_order, case_vecs, n_brick_quad_points,
-            special_radial_quadrature, nradial_quad_points)
+            integral_knl,
+            quad_order,
+            case_vecs,
+            n_brick_quad_points,
+            special_radial_quadrature,
+            nradial_quad_points,
+        )
 
         from volumential.list1_symmetry import CaseVecReduction
 
         # by default only self-interaction is counted
         if case_vecs is None:
-            case_vecs = [np.array([0, 0, 0]), ]
+            case_vecs = [
+                np.array([0, 0, 0]),
+            ]
 
         self.reduce_by_symmetry = CaseVecReduction(case_vecs, knl_symmetry_tags)
         logger.info(
@@ -977,11 +1082,10 @@ class DrosteReduced(DrosteBase):
 
         if self.special_radial_quadrature:
             quad_vars_subdomain = self.make_brick_domain(
-                quad_vars[1:], self.nquad_points) & self.make_brick_domain(
-                    quad_vars[:1], self.nradial_quad_points)
+                quad_vars[1:], self.nquad_points
+            ) & self.make_brick_domain(quad_vars[:1], self.nradial_quad_points)
         else:
-            quad_vars_subdomain = self.make_brick_domain(
-                quad_vars, self.nquad_points)
+            quad_vars_subdomain = self.make_brick_domain(quad_vars, self.nquad_points)
 
         loop_domain_common_parts = (
             quad_vars_subdomain
@@ -1044,8 +1148,7 @@ class DrosteReduced(DrosteBase):
         return self.loop_domains[base_case_id]
 
     def make_result_array(self, **kwargs):
-        """Allocate memory space for results.
-        """
+        """Allocate memory space for results."""
         # by default uses double type returns
         if "result_dtype" in kwargs:
             result_dtype = kwargs["result_dtype"]
@@ -1058,41 +1161,38 @@ class DrosteReduced(DrosteBase):
         # allocate return arrays
         if self.dim == 1:
             result_array = (
-                    np.zeros(
-                        (self.nfunctions, self.ntgt_points, 1),
-                        result_dtype
-                        )
-                    + np.nan)
+                np.zeros((self.nfunctions, self.ntgt_points, 1), result_dtype) + np.nan
+            )
         elif self.dim == 2:
             result_array = (
-                    np.zeros(
-                        (
-                            self.nfunctions,
-                            self.nfunctions,
-                            self.ntgt_points,
-                            self.ntgt_points,
-                            1,
-                            ),
-                        result_dtype
-                        )
-                    + np.nan
-                    )
+                np.zeros(
+                    (
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        1,
+                    ),
+                    result_dtype,
+                )
+                + np.nan
+            )
         elif self.dim == 3:
             result_array = (
-                    np.zeros(
-                        (
-                            self.nfunctions,
-                            self.nfunctions,
-                            self.nfunctions,
-                            self.ntgt_points,
-                            self.ntgt_points,
-                            self.ntgt_points,
-                            1,
-                            ),
-                        result_dtype
-                        )
-                    + np.nan
-                    )
+                np.zeros(
+                    (
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        1,
+                    ),
+                    result_dtype,
+                )
+                + np.nan
+            )
         else:
             raise NotImplementedError
         return result_array
@@ -1133,7 +1233,7 @@ class DrosteReduced(DrosteBase):
 
         ext_ids = product(
             product([0, 1], repeat=nflippables),
-            *[permutations(sgroup) for sgroup in swappable_groups]
+            *[permutations(sgroup) for sgroup in swappable_groups],
         )
 
         # The idea is that, any member of the hyperoctahedral group
@@ -1170,11 +1270,13 @@ class DrosteReduced(DrosteBase):
             ext_tgt_ordering.reverse()
             ext_fun_ordering.reverse()
 
-            ext_instruction_ids = ":".join([
-                "result_ext_" + str(eid)
-                for eid in range(len(ext_ids))
-                if eid != ext_index
-                ])
+            ext_instruction_ids = ":".join(
+                [
+                    "result_ext_" + str(eid)
+                    for eid in range(len(ext_ids))
+                    if eid != ext_index
+                ]
+            )
 
             expansion_code += [
                 self.make_dim_independent(
@@ -1185,9 +1287,7 @@ class DrosteReduced(DrosteBase):
                         result[REV_BASIS_VARS, REV_TGT_VARS, icase]
                         ) {id=result_ext_EXT_ID,nosync=EXT_INSN_IDS}
                 end
-                """.replace(
-                        "EXT_TGT_VARS", ",".join(ext_tgt_ordering)
-                    )
+                """.replace("EXT_TGT_VARS", ",".join(ext_tgt_ordering))
                     .replace("EXT_BASIS_VARS", ",".join(ext_fun_ordering))
                     .replace("EXT_SIGN", ext_sign)
                     .replace("EXT_ID", str(ext_index))
@@ -1220,21 +1320,93 @@ class DrosteReduced(DrosteBase):
                 [
                     lp.ValueArg("alpha", np.float64),
                     lp.ValueArg("n_cases, nfunctions, quad_order, dim", np.int32),
-                    lp.GlobalArg("interaction_case_vecs",
-                        np.float64, "dim, n_cases"),
+                    lp.GlobalArg("interaction_case_vecs", np.float64, "dim, n_cases"),
                     lp.GlobalArg("interaction_case_scls", np.float64, "n_cases"),
                     lp.GlobalArg("target_nodes", np.float64, "quad_order"),
                     lp.GlobalArg(
-                        "result", None,
+                        "result",
+                        None,
                         ", ".join(
                             ["nfunctions" for d in range(self.dim)]
                             + ["quad_order" for d in range(self.dim)]
                         )
                         + ", n_cases",
-                    ), ] + list(extra_kernel_kwarg_types)
-                + ["...", ],
+                    ),
+                ]
+                + list(extra_kernel_kwarg_types)
+                + [
+                    "...",
+                ],
                 name="brick_map",
                 lang_version=(2018, 2),
+                temporary_variables={
+                    "template_target": lp.TemporaryVariable(
+                        "template_target", np.float64, shape=("dim",)
+                    ),
+                    "true_target": lp.TemporaryVariable(
+                        "true_target", np.float64, shape=("dim",)
+                    ),
+                    "template_true_target": lp.TemporaryVariable(
+                        "template_true_target", np.float64, shape=("dim",)
+                    ),
+                    "target": lp.TemporaryVariable(
+                        "target", np.float64, shape=("dim",)
+                    ),
+                    "root_center": lp.TemporaryVariable(
+                        "root_center", np.float64, shape=("dim",)
+                    ),
+                    "root_extent": lp.TemporaryVariable(
+                        "root_extent", np.float64, shape=("dim",)
+                    ),
+                    "outer_brick": lp.TemporaryVariable(
+                        "outer_brick", np.float64, shape=("dim", 2)
+                    ),
+                    "inner_brick": lp.TemporaryVariable(
+                        "inner_brick", np.float64, shape=("dim", 2)
+                    ),
+                    "ob_ext": lp.TemporaryVariable(
+                        "ob_ext", np.float64, shape=("dim",)
+                    ),
+                    "point": lp.TemporaryVariable("point", np.float64, shape=("dim",)),
+                    "mapped_point_tmp": lp.TemporaryVariable(
+                        "mapped_point_tmp", np.float64, shape=("dim",)
+                    ),
+                    "template_mapped_point_tmp": lp.TemporaryVariable(
+                        "template_mapped_point_tmp", np.float64, shape=("dim",)
+                    ),
+                    "pre_scale": lp.TemporaryVariable("pre_scale", np.float64),
+                    "deform": lp.TemporaryVariable("deform", np.float64),
+                    "jac_part": lp.TemporaryVariable("jac_part", np.float64),
+                    "jacobian": lp.TemporaryVariable("jacobian", np.float64),
+                    "dist": lp.TemporaryVariable("dist", np.float64, shape=("dim",)),
+                    "density_val": lp.TemporaryVariable("density_val", np.float64),
+                    "knl_scaling": lp.TemporaryVariable("knl_scaling", np.float64),
+                },
+            )
+
+            loopy_knl = lp.add_dtypes(
+                loopy_knl,
+                {
+                    "template_target": np.float64,
+                    "true_target": np.float64,
+                    "template_true_target": np.float64,
+                    "target": np.float64,
+                    "root_center": np.float64,
+                    "root_extent": np.float64,
+                    "outer_brick": np.float64,
+                    "inner_brick": np.float64,
+                    "ob_ext": np.float64,
+                    "point": np.float64,
+                    "mapped_point_tmp": np.float64,
+                    "template_mapped_point_tmp": np.float64,
+                    "pre_scale": np.float64,
+                    "deform": np.float64,
+                    "jac_part": np.float64,
+                    "jacobian": np.float64,
+                    "dist": np.float64,
+                    "density_val": np.float64,
+                    "knl_scaling": np.float64,
+                },
             )
 
         elif self.get_kernel_id == 1:
@@ -1244,14 +1416,19 @@ class DrosteReduced(DrosteBase):
                 [
                     lp.ValueArg("n_cases, nfunctions, quad_order, dim", np.int32),
                     lp.GlobalArg(
-                        "result", None,
+                        "result",
+                        None,
                         ", ".join(
                             ["nfunctions" for d in range(self.dim)]
                             + ["quad_order" for d in range(self.dim)]
                         )
                         + ", n_cases",
-                    ), ] + list(extra_kernel_kwarg_types)
-                + ["...", ],
+                    ),
+                ]
+                + list(extra_kernel_kwarg_types)
+                + [
+                    "...",
+                ],
                 name="brick_map_expansion",
                 lang_version=(2018, 2),
             )
@@ -1321,9 +1498,8 @@ class DrosteReduced(DrosteBase):
             # Single level is equivalent to Duffy transform
             nlevels = 1
 
-        missing_measure = (alpha ** nlevels * source_box_extent) ** self.dim
+        missing_measure = (alpha**nlevels * source_box_extent) ** self.dim
         if abs(missing_measure) > 1e-6:
-
             logger.warn(
                 "Droste probably has too few levels, missing measure = %e"
                 % missing_measure
@@ -1340,7 +1516,7 @@ class DrosteReduced(DrosteBase):
 
         # target points in 1D
         q_points = self.get_target_points(queue)
-        assert len(q_points) == self.ntgt_points ** self.dim
+        assert len(q_points) == self.ntgt_points**self.dim
         t = np.array([pt[-1] for pt in q_points[: self.ntgt_points]])
 
         base_case_vec = np.array(
@@ -1364,14 +1540,21 @@ class DrosteReduced(DrosteBase):
             pass
         knl = self.get_cached_optimized_kernel()
         evt, res = knl(
-            queue, alpha=alpha, result=result_array,
+            queue,
+            alpha=alpha,
+            knl_scaling=self.get_kernel_scaling_value(),
+            result=result_array,
             root_brick=root_brick,
             target_nodes=t.astype(np.float64, copy=True),
             interaction_case_vecs=base_case_vec.astype(np.float64, copy=True),
             interaction_case_scls=base_case_scl.astype(np.float64, copy=True),
-            n_cases=1, nfunctions=self.nfunctions,
-            quad_order=self.ntgt_points, nlevels=nlevels,
-            **extra_kernel_kwargs, **self.brick_quadrature_kwargs)
+            n_cases=1,
+            nfunctions=self.nfunctions,
+            quad_order=self.ntgt_points,
+            nlevels=nlevels,
+            **extra_kernel_kwargs,
+            **self.brick_quadrature_kwargs,
+        )
 
         raw_cheb_table_case = res["result"]
 
@@ -1403,18 +1586,39 @@ class DrosteReduced(DrosteBase):
 
         if self.dim == 1:
             cheb_table = (
-                np.zeros((self.nfunctions, self.ntgt_points, self.ncases),
-                         dtype) + np.nan)
+                np.zeros((self.nfunctions, self.ntgt_points, self.ncases), dtype)
+                + np.nan
+            )
         elif self.dim == 2:
             cheb_table = (
-                np.zeros((self.nfunctions, self.nfunctions,
-                          self.ntgt_points, self.ntgt_points,
-                          self.ncases,), dtype) + np.nan)
+                np.zeros(
+                    (
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ncases,
+                    ),
+                    dtype,
+                )
+                + np.nan
+            )
         elif self.dim == 3:
             cheb_table = (
-                np.zeros((self.nfunctions, self.nfunctions, self.nfunctions,
-                          self.ntgt_points, self.ntgt_points, self.ntgt_points,
-                          self.ncases,), dtype) + np.nan)
+                np.zeros(
+                    (
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.nfunctions,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ntgt_points,
+                        self.ncases,
+                    ),
+                    dtype,
+                )
+                + np.nan
+            )
         else:
             raise NotImplementedError
 
@@ -1426,10 +1630,9 @@ class DrosteReduced(DrosteBase):
             )[..., 0]
 
             # {{{ expansion by symmetry
-            flippable, swappable_groups = \
-                    self.reduce_by_symmetry.parse_symmetry_tags(
-                            self.reduce_by_symmetry.symmetry_tags
-                            )
+            flippable, swappable_groups = self.reduce_by_symmetry.parse_symmetry_tags(
+                self.reduce_by_symmetry.symmetry_tags
+            )
             nflippables = int(sum(flippable))
             assert len(flippable) == self.dim
             flippable_ids = [i for i in range(self.dim) if flippable[i]]
@@ -1438,12 +1641,11 @@ class DrosteReduced(DrosteBase):
 
             ext_ids = product(
                 product([0, 1], repeat=nflippables),
-                *[permutations(sgroup) for sgroup in swappable_groups]
+                *[permutations(sgroup) for sgroup in swappable_groups],
             )
 
             base_case_vec = self.reduce_by_symmetry.full_vecs[case_id]
-            assert (base_case_vec
-                    == self.reduce_by_symmetry.reduced_vecs[base_case_id])
+            assert base_case_vec == self.reduce_by_symmetry.reduced_vecs[base_case_id]
             for _, ext_id in zip(range(len(ext_ids)), ext_ids):
                 # start from the base vec
                 ext_vec = list(base_case_vec)
@@ -1507,10 +1709,9 @@ class DrosteReduced(DrosteBase):
             # Bn: the full n-dimensional hyperoctahedral group
             symmetry_info = "B%d" % self.dim
         else:
-            symmetry_info = "Span{%s}" % ",".join([
-                repr(tag) for tag in
-                sorted(self.reduce_by_symmetry.symmetry_tags)
-                ])
+            symmetry_info = "Span{%s}" % ",".join(
+                [repr(tag) for tag in sorted(self.reduce_by_symmetry.symmetry_tags)]
+            )
 
         return (
             type(self).__name__,
@@ -1534,7 +1735,7 @@ class DrosteReduced(DrosteBase):
         if "cheb_coefs" in kwargs:
             assert len(kwargs["cheb_coefs"]) == self.n_q_points
             for ccoef in kwargs["cheb_coefs"]:
-                assert len(ccoef) == self.nfunctions ** self.dim
+                assert len(ccoef) == self.nfunctions**self.dim
             cheb_coefs = kwargs["cheb_coefs"]
             return self.postprocess_cheb_table(
                 self.build_cheb_table(queue, **kwargs), cheb_coefs
@@ -1587,17 +1788,29 @@ class InverseDrosteReduced(DrosteReduced):
 
     """
 
-    def __init__(self, integral_knl, quad_order, case_vecs,
-                 n_brick_quad_points=50, knl_symmetry_tags=None,
-                 special_radial_quadrature=False, nradial_quad_points=None,
-                 auto_windowing=True):
+    def __init__(
+        self,
+        integral_knl,
+        quad_order,
+        case_vecs,
+        n_brick_quad_points=50,
+        knl_symmetry_tags=None,
+        special_radial_quadrature=False,
+        nradial_quad_points=None,
+        auto_windowing=True,
+    ):
         """
         :param auto_windowing: auto-detect window radius.
         """
         super().__init__(
-            integral_knl, quad_order, case_vecs,
-            n_brick_quad_points, special_radial_quadrature,
-            nradial_quad_points, knl_symmetry_tags)
+            integral_knl,
+            quad_order,
+            case_vecs,
+            n_brick_quad_points,
+            special_radial_quadrature,
+            nradial_quad_points,
+            knl_symmetry_tags,
+        )
         self.auto_windowing = auto_windowing
 
     def get_cache_key(self):
@@ -1609,7 +1822,8 @@ class InverseDrosteReduced(DrosteReduced):
             "brick_order-" + str(self.nquad_points),
             "brick_radial_order-" + str(self.nradial_quad_points),
             "case-" + str(self.current_base_case),
-            "kernel_id-" + str(self.get_kernel_id),)
+            "kernel_id-" + str(self.get_kernel_id),
+        )
 
     def codegen_basis_tgt_eval(self, iaxis):
         """Generate instructions to evaluate Chebyshev polynomial basis
@@ -1623,7 +1837,8 @@ class InverseDrosteReduced(DrosteReduced):
         # only valid for self-interactions
         assert all(
             self.reduce_by_symmetry.reduced_vecs[self.current_base_case][d] == 0
-            for d in range(self.dim))
+            for d in range(self.dim)
+        )
 
         code = """  # noqa: E501
             <> T0_tgt_IAXIS = 1
@@ -1645,9 +1860,7 @@ class InverseDrosteReduced(DrosteReduced):
                     if(fIAXIS >= 2 and fIAXIS == pIAXIS + 2, Tcur_tgt_IAXIS, 0))
 
                 ) {id=tgtbasisIAXIS,dep=tcur_tgt_updateIAXIS}
-            """.replace(
-            "IAXIS", str(iaxis)
-        )
+            """.replace("IAXIS", str(iaxis))
         return code
 
     def codegen_der2_basis_tgt_eval(self, iaxis):
@@ -1669,7 +1882,8 @@ class InverseDrosteReduced(DrosteReduced):
         # only valid for self-interactions
         assert all(
             self.reduce_by_symmetry.reduced_vecs[self.current_base_case][d] == 0
-            for d in range(self.dim))
+            for d in range(self.dim)
+        )
 
         code = """  # noqa: E501
             <> U0_tgt_IAXIS = 1
@@ -1698,14 +1912,11 @@ class InverseDrosteReduced(DrosteReduced):
                     ((f_order_IAXIS + 1) * basis_tgt_evalIAXIS - basis2_tgt_evalIAXIS)
                     / (template_true_target[IAXIS]**2 - 1)
                 ) * (2**2) / (root_extent[IAXIS]**2) {id=tgtd2basisIAXIS,dep=tgtbasisIAXIS:tgtbasis2IAXIS}
-            """.replace(
-                    "IAXIS", str(iaxis)
-                    )
+            """.replace("IAXIS", str(iaxis))
         return code
 
     def codegen_windowing_function(self):
-        r"""Given :math:`dist = x - y`, compute the windowing function.
-        """
+        r"""Given :math:`dist = x - y`, compute the windowing function."""
 
         code = []
         if self.dim == 1:
@@ -1713,8 +1924,10 @@ class InverseDrosteReduced(DrosteReduced):
         elif self.dim == 2:
             code.append("<> distsq = dist[0]*dist[0] + dist[1]*dist[1]")
         elif self.dim == 3:
-            code.append("<> distsq = dist[0]*dist[0] + \
-                                     dist[1]*dist[1] + dist[2]*dist[2]")
+            code.append(
+                "<> distsq = dist[0]*dist[0] + \
+                                     dist[1]*dist[1] + dist[2]*dist[2]"
+            )
         # renormalized distance
         code.append("<> rndist = sqrt(distsq) / delta")
 
@@ -1735,7 +1948,8 @@ class InverseDrosteReduced(DrosteReduced):
             # classical bump function
             logger.info("Using bump windowing function.")
             code.append(
-                "<> windowing = exp(1) * exp(-(1/(1 - (distsq / (delta*delta)))))")
+                "<> windowing = exp(1) * exp(-(1/(1 - (distsq / (delta*delta)))))"
+            )
         else:
             # smooth transitions of 0-->1-->0
             logger.info("Using smooth transition windowing function.")
@@ -1753,8 +1967,9 @@ class InverseDrosteReduced(DrosteReduced):
 
         # detect for self-interactions
         if all(
-                self.reduce_by_symmetry.reduced_vecs[self.current_base_case][d] == 0
-                for d in range(self.dim)):
+            self.reduce_by_symmetry.reduced_vecs[self.current_base_case][d] == 0
+            for d in range(self.dim)
+        ):
             target_box_is_source = True
         else:
             target_box_is_source = False
@@ -1769,20 +1984,24 @@ class InverseDrosteReduced(DrosteReduced):
 
         if self.get_kernel_id == 0:
             resknl = resknl.replace(
-                    "POSTPROCESS_KNL_VAL",
-                    "\n".join([
+                "POSTPROCESS_KNL_VAL",
+                "\n".join(
+                    [
                         self.codegen_windowing_function(),
-                        "<> knl_val_post = windowing * knl_val {id=pp_kval}"
-                        ])
-                    )
+                        "<> knl_val_post = windowing * knl_val {id=pp_kval}",
+                    ]
+                ),
+            )
         elif self.get_kernel_id == 1:
             resknl = resknl.replace(
-                    "POSTPROCESS_KNL_VAL",
-                    "\n".join([
+                "POSTPROCESS_KNL_VAL",
+                "\n".join(
+                    [
                         self.codegen_windowing_function(),
-                        "<> knl_val_post = (1 - windowing) * knl_val {id=pp_kval}"
-                        ])
-                    )
+                        "<> knl_val_post = (1 - windowing) * knl_val {id=pp_kval}",
+                    ]
+                ),
+            )
         else:
             pass
 
@@ -1792,7 +2011,8 @@ class InverseDrosteReduced(DrosteReduced):
 
         if target_box_is_source:
             basis_eval_insns += [
-                    self.codegen_basis_tgt_eval(i) for i in range(self.dim)]
+                self.codegen_basis_tgt_eval(i) for i in range(self.dim)
+            ]
 
         if self.get_kernel_id == 0:
             # Given target x,
@@ -1800,118 +2020,128 @@ class InverseDrosteReduced(DrosteReduced):
             # truncated to second order 0.5 * [(x - y)' * diag(Hess(u)(x)) * (x - y)]
             if target_box_is_source:
                 basis_eval_insns += [
-                        self.codegen_der2_basis_tgt_eval(i) for i in range(self.dim)]
+                    self.codegen_der2_basis_tgt_eval(i) for i in range(self.dim)
+                ]
 
                 resknl = resknl.replace(
-                        "PREPARE_BASIS_VALS",
-                        "\n".join(basis_eval_insns + [
+                    "PREPARE_BASIS_VALS",
+                    "\n".join(
+                        basis_eval_insns
+                        + [
                             "... nop {id=basis_evals,dep=%s}"
                             % ":".join(
                                 ["basis%d" % i for i in range(self.dim)]
                                 + ["tgtbasis%d" % i for i in range(self.dim)]
                                 + ["tgtd2basis%d" % i for i in range(self.dim)]
-                                ),
-                            ])
-                        )
+                            ),
+                        ]
+                    ),
+                )
             else:
                 resknl = resknl.replace(
-                        "PREPARE_BASIS_VALS",
-                        "\n".join(basis_eval_insns + [
+                    "PREPARE_BASIS_VALS",
+                    "\n".join(
+                        basis_eval_insns
+                        + [
                             "... nop {id=basis_evals,dep=%s}"
-                            % ":".join(
-                                ["basis%d" % i for i in range(self.dim)]
-                                ),
-                            ])
-                        )
+                            % ":".join(["basis%d" % i for i in range(self.dim)]),
+                        ]
+                    ),
+                )
 
             if self.dim == 1:
                 if target_box_is_source:
                     resknl = resknl.replace(
-                            "DENSITY_VAL_ASSIGNMENT",
-                            " ".join([
+                        "DENSITY_VAL_ASSIGNMENT",
+                        " ".join(
+                            [
                                 "0.5 * der2_basis_tgt_eval0 * (dist[0]**2)",
-                                ])
-                            )
+                            ]
+                        ),
+                    )
                 else:
-                    resknl = resknl.replace(
-                            "DENSITY_VAL_ASSIGNMENT",
-                            "- basis_eval0"
-                            )
+                    resknl = resknl.replace("DENSITY_VAL_ASSIGNMENT", "- basis_eval0")
 
             elif self.dim == 2:
                 if target_box_is_source:
                     resknl = resknl.replace(
-                            "DENSITY_VAL_ASSIGNMENT",
-                            " ".join([
+                        "DENSITY_VAL_ASSIGNMENT",
+                        " ".join(
+                            [
                                 "  0.5 * der2_basis_tgt_eval0 * basis_tgt_eval1 * (dist[0]**2)",  # noqa: E501
                                 "+ 0.5 * basis_tgt_eval0 * der2_basis_tgt_eval1 * (dist[1]**2)",  # noqa: E501
-                                ])
-                            )
+                            ]
+                        ),
+                    )
                 else:
                     resknl = resknl.replace(
-                            "DENSITY_VAL_ASSIGNMENT",
-                            "- basis_eval0 * basis_eval1"
-                            )
+                        "DENSITY_VAL_ASSIGNMENT", "- basis_eval0 * basis_eval1"
+                    )
 
             elif self.dim == 3:
                 if target_box_is_source:
                     resknl = resknl.replace(
-                            "DENSITY_VAL_ASSIGNMENT",
-                            " ".join([
+                        "DENSITY_VAL_ASSIGNMENT",
+                        " ".join(
+                            [
                                 "  0.5 * der2_basis_tgt_eval0 * basis_tgt_eval1 * basis_tgt_eval2 * (dist[0]**2)",  # noqa: E501
                                 "+ 0.5 * basis_tgt_eval0 * der2_basis_tgt_eval1 * basis_tgt_eval2 * (dist[1]**2)",  # noqa: E501
                                 "+ 0.5 * basis_tgt_eval0 * basis_tgt_eval1 * der2_basis_tgt_eval2 * (dist[2]**2)",  # noqa: E501
-                                ])
-                            )
+                            ]
+                        ),
+                    )
                 else:
                     resknl = resknl.replace(
-                            "DENSITY_VAL_ASSIGNMENT",
-                            "- basis_eval0 * basis_eval1 * basis_eval2"
-                            )
+                        "DENSITY_VAL_ASSIGNMENT",
+                        "- basis_eval0 * basis_eval1 * basis_eval2",
+                    )
 
             else:  # self.dim not in [1, 2, 3]
                 raise NotImplementedError("No support for dimension %d" % self.dim)
 
         elif self.get_kernel_id == 1:
-
             if target_box_is_source:
                 # u(x) - u(y)
                 resknl = resknl.replace(
-                        "PREPARE_BASIS_VALS",
-                        "\n".join(basis_eval_insns + [
+                    "PREPARE_BASIS_VALS",
+                    "\n".join(
+                        basis_eval_insns
+                        + [
                             "... nop {id=basis_evals,dep=%s}"
                             % ":".join(
                                 ["basis%d" % i for i in range(self.dim)]
                                 + ["tgtbasis%d" % i for i in range(self.dim)]
-                                ),
-                            ])
-                        )
+                            ),
+                        ]
+                    ),
+                )
                 resknl = resknl.replace(
-                        "DENSITY_VAL_ASSIGNMENT",
-                        " - ".join([
+                    "DENSITY_VAL_ASSIGNMENT",
+                    " - ".join(
+                        [
                             " * ".join(
-                                ["basis_tgt_eval%d" % i for i in range(self.dim)]),
-                            " * ".join(
-                                ["basis_eval%d" % i for i in range(self.dim)]),
-                            ])
-                        )
+                                ["basis_tgt_eval%d" % i for i in range(self.dim)]
+                            ),
+                            " * ".join(["basis_eval%d" % i for i in range(self.dim)]),
+                        ]
+                    ),
+                )
             else:
                 # - u(y)
                 resknl = resknl.replace(
-                        "PREPARE_BASIS_VALS",
-                        "\n".join(basis_eval_insns + [
+                    "PREPARE_BASIS_VALS",
+                    "\n".join(
+                        basis_eval_insns
+                        + [
                             "... nop {id=basis_evals,dep=%s}"
-                            % ":".join(
-                                ["basis%d" % i for i in range(self.dim)]
-                                ),
-                            ])
-                        )
+                            % ":".join(["basis%d" % i for i in range(self.dim)]),
+                        ]
+                    ),
+                )
                 resknl = resknl.replace(
-                        "DENSITY_VAL_ASSIGNMENT",
-                        " - " + " * ".join(
-                            ["basis_eval%d" % i for i in range(self.dim)]
-                            )
-                        )
+                    "DENSITY_VAL_ASSIGNMENT",
+                    " - " + " * ".join(["basis_eval%d" % i for i in range(self.dim)]),
+                )
 
         # }}} End density evals
 
@@ -1977,28 +2207,31 @@ class InverseDrosteReduced(DrosteReduced):
         if self.get_kernel_id == 0 or self.get_kernel_id == 1:
             loopy_knl = lp.make_kernel(
                 [domain],
-                self.get_kernel_code()
-                + self.get_sumpy_kernel_eval_insns(),
+                self.get_kernel_code() + self.get_sumpy_kernel_eval_insns(),
                 [
                     lp.ValueArg("alpha", np.float64),
                     lp.ValueArg("delta", np.float64),
                     lp.ValueArg("n_cases, nfunctions, quad_order, dim", np.int32),
-                    lp.GlobalArg("interaction_case_vecs",
-                        np.float64, "dim, n_cases"),
+                    lp.GlobalArg("interaction_case_vecs", np.float64, "dim, n_cases"),
                     lp.GlobalArg("interaction_case_scls", np.float64, "n_cases"),
                     lp.GlobalArg("target_nodes", np.float64, "quad_order"),
                     lp.GlobalArg(
-                        "result", None,
+                        "result",
+                        None,
                         ", ".join(
                             ["nfunctions" for d in range(self.dim)]
                             + ["quad_order" for d in range(self.dim)]
                         )
                         + ", n_cases",
-                    ), ] + list(extra_kernel_kwarg_types)
-                + ["...", ],
+                    ),
+                ]
+                + list(extra_kernel_kwarg_types)
+                + [
+                    "...",
+                ],
                 name="brick_map_%d" % self.get_kernel_id,
                 lang_version=(2018, 2),
-                **extra_loopy_kernel_kwargs
+                **extra_loopy_kernel_kwargs,
             )
 
         elif self.get_kernel_id == 2:
@@ -2008,17 +2241,22 @@ class InverseDrosteReduced(DrosteReduced):
                 [
                     lp.ValueArg("n_cases, nfunctions, quad_order, dim", np.int32),
                     lp.GlobalArg(
-                        "result", None,
+                        "result",
+                        None,
                         ", ".join(
                             ["nfunctions" for d in range(self.dim)]
                             + ["quad_order" for d in range(self.dim)]
                         )
                         + ", n_cases",
-                    ), ] + list(extra_kernel_kwarg_types)
-                + ["...", ],
+                    ),
+                ]
+                + list(extra_kernel_kwarg_types)
+                + [
+                    "...",
+                ],
                 name="brick_map_expansion",
                 lang_version=(2018, 2),
-                **extra_loopy_kernel_kwargs
+                **extra_loopy_kernel_kwargs,
             )
 
         else:
@@ -2068,7 +2306,7 @@ class InverseDrosteReduced(DrosteReduced):
 
         # (template) target points in 1D over [0, 1]
         q_points = self.get_target_points(queue)
-        assert len(q_points) == self.ntgt_points ** self.dim
+        assert len(q_points) == self.ntgt_points**self.dim
         t = np.array([pt[-1] for pt in q_points[: self.ntgt_points]])
 
         tt = t * source_box_extent
@@ -2097,7 +2335,7 @@ class InverseDrosteReduced(DrosteReduced):
             # Single level is equivalent to Duffy transform
             nlevels = 1
 
-        missing_measure = (alpha ** nlevels * source_box_extent) ** self.dim
+        missing_measure = (alpha**nlevels * source_box_extent) ** self.dim
         if abs(missing_measure) > 1e-6:
             from warnings import warn
 
@@ -2139,7 +2377,8 @@ class InverseDrosteReduced(DrosteReduced):
         result_array_0 = self.make_result_array(**kwargs)
         evt0, res0 = knl(
             queue,
-            alpha=alpha, delta=delta,
+            alpha=alpha,
+            delta=delta,
             result=result_array_0,
             root_brick=root_brick,
             target_nodes=t.astype(np.float64, copy=True),
@@ -2149,7 +2388,8 @@ class InverseDrosteReduced(DrosteReduced):
             nfunctions=self.nfunctions,
             quad_order=self.ntgt_points,
             nlevels=nlevels,
-            **extra_kernel_kwargs, **self.brick_quadrature_kwargs
+            **extra_kernel_kwargs,
+            **self.brick_quadrature_kwargs,
         )
 
         # --------- call kernel 1 ----------
@@ -2162,7 +2402,8 @@ class InverseDrosteReduced(DrosteReduced):
         knl = self.get_cached_optimized_kernel()
         evt1, res1 = knl(
             queue,
-            alpha=alpha, delta=delta,
+            alpha=alpha,
+            delta=delta,
             result=result_array_1,
             root_brick=root_brick,
             target_nodes=t.astype(np.float64, copy=True),
@@ -2172,7 +2413,8 @@ class InverseDrosteReduced(DrosteReduced):
             nfunctions=self.nfunctions,
             quad_order=self.ntgt_points,
             nlevels=nlevels,
-            **extra_kernel_kwargs, **self.brick_quadrature_kwargs
+            **extra_kernel_kwargs,
+            **self.brick_quadrature_kwargs,
         )
 
         # --------- call kernel 2 ----------
@@ -2191,10 +2433,11 @@ class InverseDrosteReduced(DrosteReduced):
             nfunctions=self.nfunctions,
             quad_order=self.ntgt_points,
             nlevels=nlevels,
-            **extra_kernel_kwargs
+            **extra_kernel_kwargs,
         )
 
         cheb_table_case = res2["result"]
         return cheb_table_case
+
 
 # }}} End inverse Droste method

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -28,22 +28,54 @@ import pyopencl as cl
 import pyopencl.array
 from boxtree.pyfmmlib_integration import FMMLibExpansionWrangler
 from pytools.obj_array import make_obj_array
+from sumpy.array_context import PyOpenCLArrayContext
 from sumpy.fmm import (
-    SumpyExpansionWrangler, SumpyExpansionWranglerCodeContainer, SumpyTimingFuture)
+    SumpyExpansionWrangler,
+    SumpyTreeIndependentDataForWrangler,
+)
 from sumpy.kernel import (
-    AxisTargetDerivative, DirectionalSourceDerivative, HelmholtzKernel,
-    LaplaceKernel)
+    AxisTargetDerivative,
+    DirectionalSourceDerivative,
+    HelmholtzKernel,
+    LaplaceKernel,
+)
 
 from volumential.expansion_wrangler_interface import (
-    ExpansionWranglerCodeContainerInterface, ExpansionWranglerInterface)
+    ExpansionWranglerCodeContainerInterface,
+    ExpansionWranglerInterface,
+)
 from volumential.nearfield_potential_table import NearFieldInteractionTable
 
 
 logger = logging.getLogger(__name__)
 
 
+def _compute_box_local_ids(queue, tree, n_q_points):
+    n_particles = tree.ntargets
+    if n_particles % n_q_points != 0:
+        raise ValueError("particle count is not divisible by box-local quadrature size")
+
+    user_local_ids = np.tile(
+        np.arange(n_q_points, dtype=np.int32),
+        n_particles // n_q_points,
+    )
+    sorted_target_ids = tree.sorted_target_ids.get(queue)
+    return cl.array.to_device(queue, user_local_ids[sorted_target_ids])
+
+
+class SumpyTimingFuture:
+    def __init__(self, queue, events):
+        self.queue = queue
+        self.events = [evt for evt in events if evt is not None]
+
+    def __call__(self):
+        for evt in self.events:
+            evt.wait()
+        return 0.0
+
+
 def level_to_rscale(tree, level):
-    return tree.root_extent * (2 ** -level)
+    return tree.root_extent * (2**-level)
 
 
 def inverse_id_map(queue, mapped_ids):
@@ -68,8 +100,8 @@ def inverse_id_map(queue, mapped_ids):
 
 
 class FPNDSumpyExpansionWranglerCodeContainer(
-        ExpansionWranglerCodeContainerInterface,
-        SumpyExpansionWranglerCodeContainer):
+    ExpansionWranglerCodeContainerInterface, SumpyTreeIndependentDataForWrangler
+):
     """Objects of this type serve as a place to keep the code needed
     for ExpansionWrangler if it is using sumpy to perform multipole
     expansion and manipulations.
@@ -79,11 +111,63 @@ class FPNDSumpyExpansionWranglerCodeContainer(
     more ephemeral than the code, the code's lifetime
     is decoupled by storing it in this object.
     """
-    get_wrangler = SumpyExpansionWranglerCodeContainer.get_wrangler
+
+    def __init__(
+        self,
+        cl_context,
+        multipole_expansion_factory,
+        local_expansion_factory,
+        target_kernels,
+        exclude_self=True,
+        use_rscale=None,
+        strength_usage=None,
+        source_kernels=None,
+    ):
+        queue = cl.CommandQueue(cl_context)
+        actx = PyOpenCLArrayContext(queue)
+        super().__init__(
+            actx,
+            multipole_expansion_factory,
+            local_expansion_factory,
+            target_kernels=target_kernels,
+            exclude_self=exclude_self,
+            use_rscale=use_rscale,
+            strength_usage=strength_usage,
+            source_kernels=source_kernels,
+        )
+
+    def get_wrangler(
+        self,
+        queue,
+        traversal,
+        dtype,
+        fmm_level_to_order,
+        source_extra_kwargs=None,
+        kernel_extra_kwargs=None,
+        self_extra_kwargs=None,
+        *args,
+        **kwargs,
+    ):
+        return FPNDSumpyExpansionWrangler(
+            self,
+            queue,
+            traversal,
+            *args,
+            dtype=dtype,
+            fmm_level_to_order=fmm_level_to_order,
+            source_extra_kwargs=source_extra_kwargs,
+            kernel_extra_kwargs=kernel_extra_kwargs,
+            self_extra_kwargs=self_extra_kwargs,
+            **kwargs,
+        )
+
+    def opencl_fft_app(self, shape, dtype, inverse):
+        from sumpy.tools import get_opencl_fft_app
+
+        return get_opencl_fft_app(self._setup_actx, shape, dtype, inverse=inverse)
 
 
-class FPNDSumpyExpansionWrangler(
-        ExpansionWranglerInterface, SumpyExpansionWrangler):
+class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrangler):
     """This expansion wrangler uses "fpnd" strategy. That is, Far field is
     computed via Particle approximation and Near field is computed Directly.
     The FMM is performed using sumpy backend.
@@ -110,7 +194,7 @@ class FPNDSumpyExpansionWrangler(
         self,
         code_container,
         queue,
-        tree,
+        traversal,
         near_field_table,
         dtype,
         fmm_level_to_order,
@@ -128,17 +212,57 @@ class FPNDSumpyExpansionWrangler(
             3. otherwise, a dictionary from kernel.__repr__() to a list of its tables
         """
 
+        if source_extra_kwargs is None:
+            source_extra_kwargs = {}
+
+        if kernel_extra_kwargs is None:
+            kernel_extra_kwargs = {}
+
+        if self_extra_kwargs is None:
+            self_extra_kwargs = {}
+
+        super().__init__(
+            code_container,
+            traversal,
+            dtype,
+            fmm_level_to_order,
+            source_extra_kwargs=source_extra_kwargs,
+            kernel_extra_kwargs=kernel_extra_kwargs,
+            self_extra_kwargs=self_extra_kwargs,
+        )
+
         self.code = code_container
         self.queue = queue
-        self.tree = tree
+
+        if "target_to_source" in self.self_extra_kwargs and isinstance(
+            self.self_extra_kwargs["target_to_source"], np.ndarray
+        ):
+            user_target_to_source = self.self_extra_kwargs["target_to_source"]
+            sorted_target_ids = self.tree.sorted_target_ids.get(queue)
+            if hasattr(self.tree, "sorted_source_ids"):
+                sorted_source_ids = self.tree.sorted_source_ids.get(queue)
+            else:
+                sorted_source_ids = sorted_target_ids
+            inverse_sorted_source_ids = np.empty_like(sorted_source_ids)
+            inverse_sorted_source_ids[sorted_source_ids] = np.arange(
+                len(sorted_source_ids), dtype=sorted_source_ids.dtype
+            )
+            target_to_source_sorted = inverse_sorted_source_ids[
+                user_target_to_source[sorted_target_ids]
+            ]
+
+            self.self_extra_kwargs = dict(self.self_extra_kwargs)
+            self.self_extra_kwargs["target_to_source"] = cl.array.to_device(
+                self.queue, target_to_source_sorted
+            )
 
         self.near_field_table = {}
         # list of tables for a single out kernel
         if isinstance(near_field_table, list):
             assert len(self.code.target_kernels) == 1
-            self.near_field_table[
-                self.code.target_kernels[0].__repr__()
-            ] = near_field_table
+            self.near_field_table[self.code.target_kernels[0].__repr__()] = (
+                near_field_table
+            )
             self.n_tables = len(near_field_table)
 
         # single table
@@ -155,11 +279,12 @@ class FPNDSumpyExpansionWrangler(
             for out_knl in self.code.target_kernels:
                 if repr(out_knl) not in near_field_table:
                     raise RuntimeError(
-                            "Missing nearfield table for %s." % repr(out_knl))
-                if isinstance(near_field_table[repr(out_knl)],
-                        NearFieldInteractionTable):
-                    near_field_table[repr(out_knl)] = [
-                            near_field_table[repr(out_knl)]]
+                        "Missing nearfield table for %s." % repr(out_knl)
+                    )
+                if isinstance(
+                    near_field_table[repr(out_knl)], NearFieldInteractionTable
+                ):
+                    near_field_table[repr(out_knl)] = [near_field_table[repr(out_knl)]]
                 else:
                     assert isinstance(near_field_table[repr(out_knl)], list)
 
@@ -174,18 +299,18 @@ class FPNDSumpyExpansionWrangler(
 
         # TODO: make all parameters table-specific (allow using inhomogeneous tables)
         kname = repr(self.code.target_kernels[0])
-        self.root_table_source_box_extent = (
-                self.near_field_table[kname][0].source_box_extent)
+        self.root_table_source_box_extent = self.near_field_table[kname][
+            0
+        ].source_box_extent
         table_starting_level = np.round(
             np.log(self.tree.root_extent / self.root_table_source_box_extent)
             / np.log(2)
-            )
+        )
         for kid in range(len(self.code.target_kernels)):
             kname = self.code.target_kernels[kid].__repr__()
             for lev, table in zip(
-                    range(len(self.near_field_table[kname])),
-                    self.near_field_table[kname]
-                    ):
+                range(len(self.near_field_table[kname])), self.near_field_table[kname]
+            ):
                 assert table.quad_order == self.quad_order
 
                 if not table.is_built:
@@ -194,10 +319,9 @@ class FPNDSumpyExpansionWrangler(
                         "prior to being used"
                     )
 
-                table_root_extent = table.source_box_extent * 2 ** lev
+                table_root_extent = table.source_box_extent * 2**lev
                 assert (
-                    abs(self.root_table_source_box_extent - table_root_extent)
-                    < 1e-15
+                    abs(self.root_table_source_box_extent - table_root_extent) < 1e-15
                 )
 
                 # If the kernel cannot be scaled,
@@ -221,13 +345,13 @@ class FPNDSumpyExpansionWrangler(
             if not isinstance(self.n_tables, dict) and self.n_tables > 1:
                 # this checks that the boxes at the highest level are covered
                 if (
-                    not tree.nlevels
+                    not self.tree.nlevels
                     <= len(self.near_field_table[kname]) + table_starting_level
                 ):
                     raise RuntimeError(
                         "Insufficient list of tables: the "
                         "finest level mesh cells at level "
-                        + str(tree.nlevels)
+                        + str(self.tree.nlevels)
                         + " are not covered."
                     )
 
@@ -235,84 +359,71 @@ class FPNDSumpyExpansionWrangler(
                 # deferred until trav.target_boxes is passed when invoking
                 # eval_direct
 
-        self.dtype = dtype
-
-        if source_extra_kwargs is None:
-            source_extra_kwargs = {}
-
-        if kernel_extra_kwargs is None:
-            kernel_extra_kwargs = {}
-
-        if self_extra_kwargs is None:
-            self_extra_kwargs = {}
-
         if list1_extra_kwargs is None:
             list1_extra_kwargs = {}
-
-        if not callable(fmm_level_to_order):
-            raise TypeError("fmm_level_to_order not passed")
-
-        base_kernel = code_container.get_base_kernel()
-        kernel_arg_set = frozenset(kernel_extra_kwargs.items())
-        self.level_orders = [
-            fmm_level_to_order(base_kernel, kernel_arg_set, tree, lev)
-            for lev in range(tree.nlevels)
-        ]
-
-        # print("Multipole order = ",self.level_orders)
-
-        self.source_extra_kwargs = source_extra_kwargs
-        self.kernel_extra_kwargs = kernel_extra_kwargs
-        self.self_extra_kwargs = self_extra_kwargs
         self.list1_extra_kwargs = list1_extra_kwargs
-
-        self.extra_kwargs = source_extra_kwargs.copy()
-        self.extra_kwargs.update(self.kernel_extra_kwargs)
 
     # }}} End constructor
 
     # {{{ data vector utilities
 
-    def multipole_expansion_zeros(self):
-        return SumpyExpansionWrangler.multipole_expansion_zeros(self)
+    @property
+    def _actx(self):
+        return self.tree_indep._setup_actx
 
-    def local_expansion_zeros(self):
-        return SumpyExpansionWrangler.local_expansion_zeros(self)
+    def multipole_expansion_zeros(self, actx=None):
+        if actx is None:
+            actx = self._actx
+        return SumpyExpansionWrangler.multipole_expansion_zeros(self, actx)
 
-    def output_zeros(self):
-        return SumpyExpansionWrangler.output_zeros(self)
+    def local_expansion_zeros(self, actx=None):
+        if actx is None:
+            actx = self._actx
+        return SumpyExpansionWrangler.local_expansion_zeros(self, actx)
+
+    def output_zeros(self, actx=None):
+        if actx is None:
+            actx = self._actx
+        return SumpyExpansionWrangler.output_zeros(self, actx)
 
     def reorder_sources(self, source_array):
         return SumpyExpansionWrangler.reorder_sources(self, source_array)
 
     def reorder_targets(self, target_array):
-        if not hasattr(self.tree, "user_target_ids"):
-            self.tree.user_target_ids = inverse_id_map(
-                self.queue, self.tree.sorted_target_ids)
-        return target_array.with_queue(self.queue)[self.tree.user_target_ids]
+        if not hasattr(self, "_user_target_ids"):
+            self._user_target_ids = inverse_id_map(
+                self.queue, self.tree.sorted_target_ids
+            )
+        return target_array.with_queue(self.queue)[self._user_target_ids]
 
     def reorder_potentials(self, potentials):
         return SumpyExpansionWrangler.reorder_potentials(self, potentials)
 
     def finalize_potentials(self, potentials):
         # return potentials
-        return SumpyExpansionWrangler.finalize_potentials(self, potentials)
+        return SumpyExpansionWrangler.finalize_potentials(self, self._actx, potentials)
 
     # }}} End data vector utilities
 
     # {{{ formation & coarsening of multipoles
 
     def form_multipoles(self, level_start_source_box_nrs, source_boxes, src_weights):
-        return SumpyExpansionWrangler.form_multipoles(
-            self, level_start_source_box_nrs, source_boxes, src_weights
+        mpoles = SumpyExpansionWrangler.form_multipoles(
+            self, self._actx, level_start_source_box_nrs, source_boxes, src_weights
         )
+        return mpoles, SumpyTimingFuture(self.queue, [])
 
     def coarsen_multipoles(
         self, level_start_source_parent_box_nrs, source_parent_boxes, mpoles
     ):
-        return SumpyExpansionWrangler.coarsen_multipoles(
-            self, level_start_source_parent_box_nrs, source_parent_boxes, mpoles
+        mpoles = SumpyExpansionWrangler.coarsen_multipoles(
+            self,
+            self._actx,
+            level_start_source_parent_box_nrs,
+            source_parent_boxes,
+            mpoles,
         )
+        return mpoles, SumpyTimingFuture(self.queue, [])
 
     # }}} End formation & coarsening of multipoles
 
@@ -352,7 +463,7 @@ class FPNDSumpyExpansionWrangler(
             min_lev = np.min(
                 self.tree.box_levels.get(self.queue)[target_boxes.get(self.queue)]
             )
-            largest_cell_extent = self.tree.root_extent * 0.5 ** min_lev
+            largest_cell_extent = self.tree.root_extent * 0.5**min_lev
             if not self.near_field_table[kname][0].source_box_extent >= (
                 largest_cell_extent - 1e-15
             ):
@@ -380,32 +491,34 @@ class FPNDSumpyExpansionWrangler(
             (
                 len(self.near_field_table[kname]),
                 len(self.near_field_table[kname][0].data),
-            ), dtype=self.near_field_table[kname][0].data.dtype
+            ),
+            dtype=self.near_field_table[kname][0].data.dtype,
         )
         mode_nmlz_combined = np.zeros(
             (
                 len(self.near_field_table[kname]),
                 len(self.near_field_table[kname][0].mode_normalizers),
-            ), dtype=self.near_field_table[kname][0].mode_normalizers.dtype
+            ),
+            dtype=self.near_field_table[kname][0].mode_normalizers.dtype,
         )
         exterior_mode_nmlz_combined = np.zeros(
             (
                 len(self.near_field_table[kname]),
                 len(self.near_field_table[kname][0].kernel_exterior_normalizers),
             ),
-            dtype=self.near_field_table[kname][0].kernel_exterior_normalizers.dtype
+            dtype=self.near_field_table[kname][0].kernel_exterior_normalizers.dtype,
         )
         for lev in range(len(self.near_field_table[kname])):
             table_data_combined[lev, :] = self.near_field_table[kname][lev].data
-            mode_nmlz_combined[lev, :] = \
-                self.near_field_table[kname][lev].mode_normalizers
-            exterior_mode_nmlz_combined[lev, :] = \
-                self.near_field_table[kname][lev].kernel_exterior_normalizers
+            mode_nmlz_combined[lev, :] = self.near_field_table[kname][
+                lev
+            ].mode_normalizers
+            exterior_mode_nmlz_combined[lev, :] = self.near_field_table[kname][
+                lev
+            ].kernel_exterior_normalizers
 
         self.queue.finish()
-        logger.info(
-                "table data for kernel "
-                + out_kernel.__repr__() + " congregated")
+        logger.info("table data for kernel " + out_kernel.__repr__() + " congregated")
 
         # The loop domain needs to know some info about the tables being used
         table_data_shapes = {
@@ -419,16 +532,34 @@ class FPNDSumpyExpansionWrangler(
 
         from volumential.list1 import NearFieldFromCSR
 
-        near_field = NearFieldFromCSR(out_kernel, table_data_shapes,
+        near_field = NearFieldFromCSR(
+            out_kernel,
+            table_data_shapes,
             potential_kind=self.potential_kind,
-            **self.list1_extra_kwargs)
+            **self.list1_extra_kwargs,
+        )
 
-        table_data_combined = cl.array.to_device(self.queue,
-                table_data_combined)
-        mode_nmlz_combined = cl.array.to_device(self.queue,
-                mode_nmlz_combined)
-        exterior_mode_nmlz_combined = cl.array.to_device(self.queue,
-            exterior_mode_nmlz_combined)
+        table_data_combined = cl.array.to_device(self.queue, table_data_combined)
+        mode_nmlz_combined = cl.array.to_device(self.queue, mode_nmlz_combined)
+        exterior_mode_nmlz_combined = cl.array.to_device(
+            self.queue, exterior_mode_nmlz_combined
+        )
+        particle_local_ids = _compute_box_local_ids(
+            self.queue, self.tree, self.near_field_table[kname][0].n_q_points
+        )
+
+        aligned_nboxes = self.tree.box_centers.shape[1]
+        source_counts_nonchild = np.zeros(aligned_nboxes, dtype=np.int32)
+        target_counts_nonchild = np.zeros(aligned_nboxes, dtype=np.int32)
+        source_counts_nonchild[: len(self.tree.box_target_counts_nonchild)] = (
+            self.tree.box_target_counts_nonchild.get(self.queue)
+        )
+        target_counts_nonchild[: len(self.tree.box_target_counts_nonchild)] = (
+            self.tree.box_target_counts_nonchild.get(self.queue)
+        )
+        source_counts_nonchild = cl.array.to_device(self.queue, source_counts_nonchild)
+        target_counts_nonchild = cl.array.to_device(self.queue, target_counts_nonchild)
+
         self.queue.finish()
         logger.info("sent table data to device")
 
@@ -440,9 +571,9 @@ class FPNDSumpyExpansionWrangler(
             result=out_pot,
             box_centers=self.tree.box_centers,
             box_levels=self.tree.box_levels,
-            box_source_counts_cumul=self.tree.box_target_counts_cumul,
+            box_source_counts_nonchild=source_counts_nonchild,
             box_source_starts=self.tree.box_target_starts,
-            box_target_counts_cumul=self.tree.box_target_counts_cumul,
+            box_target_counts_nonchild=target_counts_nonchild,
             box_target_starts=self.tree.box_target_starts,
             case_indices=case_indices_dev,
             encoding_base=base,
@@ -453,8 +584,10 @@ class FPNDSumpyExpansionWrangler(
             root_extent=self.tree.root_extent,
             neighbor_source_boxes_lists=neighbor_source_boxes_lists,
             mode_coefs=mode_coefs,
+            source_mode_ids=particle_local_ids,
             table_data_combined=table_data_combined,
             target_boxes=target_boxes,
+            target_point_ids=particle_local_ids,
             table_root_extent=self.root_table_source_box_extent,
         )
 
@@ -509,21 +642,28 @@ class FPNDSumpyExpansionWrangler(
         src_box_lists,
         mpole_exps,
     ):
-        return SumpyExpansionWrangler.multipole_to_local(
+        local_exps = SumpyExpansionWrangler.multipole_to_local(
             self,
+            self._actx,
             level_start_target_box_nrs,
             target_boxes,
             src_box_starts,
             src_box_lists,
             mpole_exps,
         )
+        return local_exps, SumpyTimingFuture(self.queue, [])
 
     def eval_multipoles(
         self, target_boxes_by_source_level, source_boxes_by_level, mpole_exps
     ):
-        return SumpyExpansionWrangler.eval_multipoles(
-            self, target_boxes_by_source_level, source_boxes_by_level, mpole_exps
+        pot = SumpyExpansionWrangler.eval_multipoles(
+            self,
+            self._actx,
+            target_boxes_by_source_level,
+            source_boxes_by_level,
+            mpole_exps,
         )
+        return pot, SumpyTimingFuture(self.queue, [])
 
     def form_locals(
         self,
@@ -533,14 +673,16 @@ class FPNDSumpyExpansionWrangler(
         lists,
         src_weights,
     ):
-        return SumpyExpansionWrangler.form_locals(
+        local_exps = SumpyExpansionWrangler.form_locals(
             self,
+            self._actx,
             level_start_target_or_target_parent_box_nrs,
             target_or_target_parent_boxes,
             starts,
             lists,
             src_weights,
         )
+        return local_exps, SumpyTimingFuture(self.queue, [])
 
     def refine_locals(
         self,
@@ -548,17 +690,20 @@ class FPNDSumpyExpansionWrangler(
         target_or_target_parent_boxes,
         local_exps,
     ):
-        return SumpyExpansionWrangler.refine_locals(
+        local_exps = SumpyExpansionWrangler.refine_locals(
             self,
+            self._actx,
             level_start_target_or_target_parent_box_nrs,
             target_or_target_parent_boxes,
             local_exps,
         )
+        return local_exps, SumpyTimingFuture(self.queue, [])
 
     def eval_locals(self, level_start_target_box_nrs, target_boxes, local_exps):
-        return SumpyExpansionWrangler.eval_locals(
-            self, level_start_target_box_nrs, target_boxes, local_exps
+        pot = SumpyExpansionWrangler.eval_locals(
+            self, self._actx, level_start_target_box_nrs, target_boxes, local_exps
         )
+        return pot, SumpyTimingFuture(self.queue, [])
 
     # }}} End downward pass of fmm
 
@@ -567,11 +712,39 @@ class FPNDSumpyExpansionWrangler(
     def eval_direct_p2p(
         self, target_boxes, source_box_starts, source_box_lists, src_weights
     ):
-        return SumpyExpansionWrangler.eval_direct(
-            self, target_boxes, source_box_starts, source_box_lists, src_weights
+        pot = self.output_zeros(self._actx)
+
+        kwargs = dict(self.extra_kwargs)
+        kwargs.update(self.self_extra_kwargs)
+        kwargs.update(self.box_source_list_kwargs())
+        kwargs.update(self.box_target_list_kwargs())
+
+        if "target_to_source" in kwargs and isinstance(
+            kwargs["target_to_source"], np.ndarray
+        ):
+            kwargs["target_to_source"] = cl.array.to_device(
+                self.queue, kwargs["target_to_source"]
+            )
+
+        pot_res = self.tree_indep.p2p()(
+            self._actx,
+            target_boxes=target_boxes,
+            source_box_starts=source_box_starts,
+            source_box_lists=source_box_lists,
+            strength=src_weights,
+            result=pot,
+            max_nsources_in_one_box=self.max_nsources_in_one_box,
+            max_ntargets_in_one_box=self.max_ntargets_in_one_box,
+            **kwargs,
         )
 
+        for pot_i, pot_res_i in zip(pot, pot_res, strict=True):
+            assert pot_i is pot_res_i
+
+        return pot, SumpyTimingFuture(self.queue, [])
+
     # }}} End direct evaluation of p2p interactions
+
 
 # }}} End sumpy backend
 
@@ -579,8 +752,8 @@ class FPNDSumpyExpansionWrangler(
 
 
 class FPNDFMMLibExpansionWranglerCodeContainer(
-        ExpansionWranglerCodeContainerInterface,
-        ):
+    ExpansionWranglerCodeContainerInterface,
+):
     """Objects of this type serve as a place to keep the code needed
     for ExpansionWrangler if it is using fmmlib to perform multipole
     expansion and manipulations.
@@ -589,9 +762,17 @@ class FPNDFMMLibExpansionWranglerCodeContainer(
     placeholders, such that it can be a drop-in replacement of sumpy
     backend.
     """
-    def __init__(self, cl_context,
-            multipole_expansion_factory, local_expansion_factory,
-            target_kernels, exclude_self=True, *args, **kwargs):
+
+    def __init__(
+        self,
+        cl_context,
+        multipole_expansion_factory,
+        local_expansion_factory,
+        target_kernels,
+        exclude_self=True,
+        *args,
+        **kwargs,
+    ):
         self.cl_context = cl_context
         self.multipole_expansion_factory = multipole_expansion_factory
         self.local_expansion_factory = local_expansion_factory
@@ -599,20 +780,34 @@ class FPNDFMMLibExpansionWranglerCodeContainer(
         self.target_kernels = target_kernels
         self.exclude_self = True
 
-    def get_wrangler(self, queue, tree, dtype, fmm_level_to_order,
-            source_extra_kwargs=None, kernel_extra_kwargs=None,
-            *args, **kwargs):
+    def get_wrangler(
+        self,
+        queue,
+        tree,
+        dtype,
+        fmm_level_to_order,
+        source_extra_kwargs=None,
+        kernel_extra_kwargs=None,
+        *args,
+        **kwargs,
+    ):
         if source_extra_kwargs is None:
             source_extra_kwargs = {}
 
-        return FPNDFMMLibExpansionWrangler(self, queue, tree,
-                dtype, fmm_level_to_order,
-                source_extra_kwargs, kernel_extra_kwargs,
-                *args, **kwargs)
+        return FPNDFMMLibExpansionWrangler(
+            self,
+            queue,
+            tree,
+            dtype,
+            fmm_level_to_order,
+            source_extra_kwargs,
+            kernel_extra_kwargs,
+            *args,
+            **kwargs,
+        )
 
 
-class FPNDFMMLibExpansionWrangler(
-        ExpansionWranglerInterface, FMMLibExpansionWrangler):
+class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWrangler):
     """This expansion wrangler uses "fpnd" strategy. That is, Far field is
     computed via Particle approximation and Near field is computed Directly.
     The FMM is performed using FMMLib backend.
@@ -629,18 +824,26 @@ class FPNDFMMLibExpansionWrangler(
 
     Much of this class is borrowed from pytential.qbx.fmmlib.
     """
+
     # {{{ constructor
 
-    def __init__(self, code_container, queue, tree,
-            near_field_table, dtype,
-            fmm_level_to_order,
-            quad_order,
-            potential_kind=1,
-            source_extra_kwargs=None,
-            kernel_extra_kwargs=None,
-            self_extra_kwargs=None,
-            list1_extra_kwargs=None,
-            *args, **kwargs):
+    def __init__(
+        self,
+        code_container,
+        queue,
+        tree,
+        near_field_table,
+        dtype,
+        fmm_level_to_order,
+        quad_order,
+        potential_kind=1,
+        source_extra_kwargs=None,
+        kernel_extra_kwargs=None,
+        self_extra_kwargs=None,
+        list1_extra_kwargs=None,
+        *args,
+        **kwargs,
+    ):
         self.code = code_container
         self.queue = queue
 
@@ -659,44 +862,50 @@ class FPNDFMMLibExpansionWrangler(
         k_names = []
 
         for out_knl in self.code.target_kernels:
-
             if self.is_supported_helmknl(out_knl):
                 outputs.append(())
                 no_target_deriv_knl = out_knl
 
-            elif (isinstance(out_knl, AxisTargetDerivative)
-                    and self.is_supported_helmknl(out_knl.inner_kernel)):
+            elif isinstance(
+                out_knl, AxisTargetDerivative
+            ) and self.is_supported_helmknl(out_knl.inner_kernel):
                 outputs.append((out_knl.axis,))
                 ifgrad = True
                 no_target_deriv_knl = out_knl.inner_kernel
 
             else:
                 raise ValueError(
-                        "only the 2/3D Laplace and Helmholtz kernel "
-                        "and their derivatives are supported")
+                    "only the 2/3D Laplace and Helmholtz kernel "
+                    "and their derivatives are supported"
+                )
 
-            source_deriv_names.append(no_target_deriv_knl.dir_vec_name
-                    if isinstance(no_target_deriv_knl, DirectionalSourceDerivative)
-                    else None)
+            source_deriv_names.append(
+                no_target_deriv_knl.dir_vec_name
+                if isinstance(no_target_deriv_knl, DirectionalSourceDerivative)
+                else None
+            )
 
             base_knl = out_knl.get_base_kernel()
-            k_names.append(base_knl.helmholtz_k_name
-                    if isinstance(base_knl, HelmholtzKernel)
-                    else None)
+            k_names.append(
+                base_knl.helmholtz_k_name
+                if isinstance(base_knl, HelmholtzKernel)
+                else None
+            )
 
         self.outputs = outputs
 
         from pytools import is_single_valued
 
         if not is_single_valued(source_deriv_names):
-            raise ValueError("not all kernels passed are the same in "
-                    "whether they represent a source derivative")
+            raise ValueError(
+                "not all kernels passed are the same in "
+                "whether they represent a source derivative"
+            )
 
         source_deriv_name = source_deriv_names[0]
 
         if not is_single_valued(k_names):
-            raise ValueError("not all kernels passed have the same "
-                    "Helmholtz parameter")
+            raise ValueError("not all kernels passed have the same Helmholtz parameter")
 
         k_name = k_names[0]
 
@@ -714,9 +923,9 @@ class FPNDFMMLibExpansionWrangler(
         # list of tables for a single out kernel
         if isinstance(near_field_table, list):
             assert len(self.code.target_kernels) == 1
-            self.near_field_table[
-                self.code.target_kernels[0].__repr__()
-            ] = near_field_table
+            self.near_field_table[self.code.target_kernels[0].__repr__()] = (
+                near_field_table
+            )
             self.n_tables = len(near_field_table)
 
         # single table
@@ -733,11 +942,12 @@ class FPNDFMMLibExpansionWrangler(
             for out_knl in self.code.target_kernels:
                 if repr(out_knl) not in near_field_table:
                     raise RuntimeError(
-                            "Missing nearfield table for %s." % repr(out_knl))
-                if isinstance(near_field_table[repr(out_knl)],
-                        NearFieldInteractionTable):
-                    near_field_table[repr(out_knl)] = [
-                            near_field_table[repr(out_knl)]]
+                        "Missing nearfield table for %s." % repr(out_knl)
+                    )
+                if isinstance(
+                    near_field_table[repr(out_knl)], NearFieldInteractionTable
+                ):
+                    near_field_table[repr(out_knl)] = [near_field_table[repr(out_knl)]]
                 else:
                     assert isinstance(near_field_table[repr(out_knl)], list)
 
@@ -749,18 +959,18 @@ class FPNDFMMLibExpansionWrangler(
 
         # TODO: make all parameters table-specific (allow using inhomogeneous tables)
         kname = repr(self.code.target_kernels[0])
-        self.root_table_source_box_extent = (
-                self.near_field_table[kname][0].source_box_extent)
+        self.root_table_source_box_extent = self.near_field_table[kname][
+            0
+        ].source_box_extent
         table_starting_level = np.round(
             np.log(self.tree.root_extent / self.root_table_source_box_extent)
             / np.log(2)
-            )
+        )
         for kid in range(len(self.code.target_kernels)):
             kname = self.code.target_kernels[kid].__repr__()
             for lev, table in zip(
-                    range(len(self.near_field_table[kname])),
-                    self.near_field_table[kname]
-                    ):
+                range(len(self.near_field_table[kname])), self.near_field_table[kname]
+            ):
                 assert table.quad_order == self.quad_order
 
                 if not table.is_built:
@@ -769,10 +979,9 @@ class FPNDFMMLibExpansionWrangler(
                         "prior to being used"
                     )
 
-                table_root_extent = table.source_box_extent * 2 ** lev
+                table_root_extent = table.source_box_extent * 2**lev
                 assert (
-                    abs(self.root_table_source_box_extent - table_root_extent)
-                    < 1e-15
+                    abs(self.root_table_source_box_extent - table_root_extent) < 1e-15
                 )
 
                 # If the kernel cannot be scaled,
@@ -831,62 +1040,70 @@ class FPNDFMMLibExpansionWrangler(
 
         dipole_vec = None
         if source_deriv_name is not None:
-            dipole_vec = np.array([
+            dipole_vec = np.array(
+                [
                     d_i.get(queue=queue)
-                    for d_i in source_extra_kwargs[source_deriv_name]],
-                    order="F")
+                    for d_i in source_extra_kwargs[source_deriv_name]
+                ],
+                order="F",
+            )
 
         def inner_fmm_level_to_nterms(tree, level):
             if helmholtz_k == 0:
                 return fmm_level_to_order(
-                        LaplaceKernel(tree.dimensions),
-                        frozenset(), tree, level)
+                    LaplaceKernel(tree.dimensions), frozenset(), tree, level
+                )
             else:
                 return fmm_level_to_order(
-                        HelmholtzKernel(tree.dimensions),
-                        frozenset([("k", helmholtz_k)]), tree, level)
+                    HelmholtzKernel(tree.dimensions),
+                    frozenset([("k", helmholtz_k)]),
+                    tree,
+                    level,
+                )
 
         rotation_data = None
         if "traversal" in kwargs:
             # add rotation data if traversal is passed as a keyword argument
             from boxtree.pyfmmlib_integration import FMMLibRotationData
+
             rotation_data = FMMLibRotationData(self.queue, kwargs["traversal"])
         else:
-            logger.warning("Rotation data is not utilized since traversal is "
-                           "not known to FPNDFMMLibExpansionWrangler.")
+            logger.warning(
+                "Rotation data is not utilized since traversal is "
+                "not known to FPNDFMMLibExpansionWrangler."
+            )
 
         FMMLibExpansionWrangler.__init__(
-                self, tree,
-
-                helmholtz_k=helmholtz_k,
-                dipole_vec=dipole_vec,
-                dipoles_already_reordered=True,
-
-                fmm_level_to_nterms=inner_fmm_level_to_nterms,
-                rotation_data=rotation_data,
-
-                ifgrad=ifgrad)
+            self,
+            tree,
+            helmholtz_k=helmholtz_k,
+            dipole_vec=dipole_vec,
+            dipoles_already_reordered=True,
+            fmm_level_to_nterms=inner_fmm_level_to_nterms,
+            rotation_data=rotation_data,
+            ifgrad=ifgrad,
+        )
 
     # }}} End constructor
 
-# {{{ scale factor for fmmlib
+    # {{{ scale factor for fmmlib
 
     def get_scale_factor(self):
         if self.eqn_letter == "l" and self.dim == 2:
-            scale_factor = -1/(2*np.pi)
+            scale_factor = -1 / (2 * np.pi)
         elif self.eqn_letter == "h" and self.dim == 2:
             scale_factor = 1
         elif self.eqn_letter in ["l", "h"] and self.dim == 3:
-            scale_factor = 1/(4*np.pi)
+            scale_factor = 1 / (4 * np.pi)
         else:
             raise NotImplementedError(
-                    "scale factor for pyfmmlib %s for %d dimensions" % (
-                        self.eqn_letter,
-                        self.dim))
+                "scale factor for pyfmmlib %s for %d dimensions"
+                % (self.eqn_letter, self.dim)
+            )
 
         return scale_factor
 
-# }}} End scale factor for fmmlib
+    # }}} End scale factor for fmmlib
 
     # {{{ data vector utilities
 
@@ -905,7 +1122,8 @@ class FPNDFMMLibExpansionWrangler(
     def reorder_targets(self, target_array):
         if not hasattr(self.tree, "user_target_ids"):
             self.tree.user_target_ids = inverse_id_map(
-                self.queue, self.tree.sorted_target_ids)
+                self.queue, self.tree.sorted_target_ids
+            )
         return target_array[self.tree.user_target_ids]
 
     def reorder_potentials(self, potentials):
@@ -969,7 +1187,7 @@ class FPNDFMMLibExpansionWrangler(
             min_lev = np.min(
                 self.tree.box_levels.get(self.queue)[target_boxes.get(self.queue)]
             )
-            largest_cell_extent = self.tree.root_extent * 0.5 ** min_lev
+            largest_cell_extent = self.tree.root_extent * 0.5**min_lev
             if not self.near_field_table[kname][0].source_box_extent >= (
                 largest_cell_extent - 1e-15
             ):
@@ -997,13 +1215,15 @@ class FPNDFMMLibExpansionWrangler(
             (
                 len(self.near_field_table[kname]),
                 len(self.near_field_table[kname][0].data),
-            ), dtype=self.near_field_table[kname][0].data.dtype
+            ),
+            dtype=self.near_field_table[kname][0].data.dtype,
         )
         mode_nmlz_combined = np.zeros(
             (
                 len(self.near_field_table[kname]),
                 len(self.near_field_table[kname][0].mode_normalizers),
-            ), dtype=self.near_field_table[kname][0].mode_normalizers.dtype
+            ),
+            dtype=self.near_field_table[kname][0].mode_normalizers.dtype,
         )
         for lev in range(len(self.near_field_table[kname])):
             table_data_combined[lev, :] = self.near_field_table[kname][lev].data
@@ -1015,18 +1235,18 @@ class FPNDFMMLibExpansionWrangler(
                 len(self.near_field_table[kname]),
                 len(self.near_field_table[kname][0].kernel_exterior_normalizers),
             ),
-            dtype=self.near_field_table[kname][0].kernel_exterior_normalizers.dtype
+            dtype=self.near_field_table[kname][0].kernel_exterior_normalizers.dtype,
         )
         for lev in range(len(self.near_field_table[kname])):
             table_data_combined[lev, :] = self.near_field_table[kname][lev].data
-            mode_nmlz_combined[lev, :] = \
-                self.near_field_table[kname][lev].mode_normalizers
-            exterior_mode_nmlz_combined[lev, :] = \
-                self.near_field_table[kname][lev].kernel_exterior_normalizers
+            mode_nmlz_combined[lev, :] = self.near_field_table[kname][
+                lev
+            ].mode_normalizers
+            exterior_mode_nmlz_combined[lev, :] = self.near_field_table[kname][
+                lev
+            ].kernel_exterior_normalizers
 
-        logger.info(
-                "Table data for kernel "
-                + out_kernel.__repr__() + " congregated")
+        logger.info("Table data for kernel " + out_kernel.__repr__() + " congregated")
 
         # The loop domain needs to know some info about the tables being used
         table_data_shapes = {
@@ -1040,9 +1260,12 @@ class FPNDFMMLibExpansionWrangler(
 
         from volumential.list1 import NearFieldFromCSR
 
-        near_field = NearFieldFromCSR(out_kernel, table_data_shapes,
+        near_field = NearFieldFromCSR(
+            out_kernel,
+            table_data_shapes,
             potential_kind=self.potential_kind,
-            **self.list1_extra_kwargs)
+            **self.list1_extra_kwargs,
+        )
 
         res, evt = near_field(
             self.queue,
@@ -1090,7 +1313,11 @@ class FPNDFMMLibExpansionWrangler(
     ):
         pot = self.output_zeros()
         if pot.dtype != object:
-            pot = make_obj_array([pot, ])
+            pot = make_obj_array(
+                [
+                    pot,
+                ]
+            )
         events = []
         for i in range(len(self.code.target_kernels)):
             # print("processing near-field of out_kernel", i)
@@ -1196,20 +1423,18 @@ class FPNDFMMLibExpansionWrangler(
         if isinstance(knl, DirectionalSourceDerivative):
             knl = knl.inner_kernel
 
-        return (isinstance(knl, (LaplaceKernel, HelmholtzKernel))
-                and knl.dim in (2, 3))
+        return isinstance(knl, (LaplaceKernel, HelmholtzKernel)) and knl.dim in (2, 3)
 
 
 # }}} End fmmlib backend (for laplace, helmholtz)
 
 
 class FPNDExpansionWranglerCodeContainer(FPNDSumpyExpansionWranglerCodeContainer):
-    """The default code container.
-    """
+    """The default code container."""
 
 
 class FPNDExpansionWrangler(FPNDSumpyExpansionWrangler):
-    """The default wrangler class.
-    """
+    """The default wrangler class."""
+
 
 # vim: filetype=pyopencl:foldmethod=marker

--- a/volumential/function_extension.py
+++ b/volumential/function_extension.py
@@ -42,8 +42,10 @@ import numpy as np
 
 import pyopencl as cl
 from pymbolic import var
-from pytential import bind, sym
-from pytential.solve import gmres
+from pytential import GeometryCollection, bind, sym
+from pytential.array_context import PyOpenCLArrayContext
+from pytential.linalg.gmres import gmres
+from pytential.target import PointsTarget
 from pytential.symbolic.stokes import StokesletWrapper, StressletWrapper
 from pytools.obj_array import make_obj_array
 from sumpy.kernel import AxisTargetDerivative, ExpressionKernel
@@ -68,6 +70,36 @@ def setup_command_queue(ctx=None, queue=None):
         return cl.CommandQueue(cl_ctx)
     else:
         return queue
+
+
+def setup_array_context(actx=None, ctx=None, queue=None):
+    if actx is not None:
+        return actx
+
+    queue = setup_command_queue(ctx=ctx, queue=queue)
+    return PyOpenCLArrayContext(queue)
+
+
+def _build_extension_places(target_geometry, qbx, target_association_tolerance):
+    if not isinstance(target_geometry, PointsTarget):
+        targets = target_geometry
+    else:
+        targets = target_geometry
+
+    qbx_target_assoc = qbx.copy(
+        target_association_tolerance=target_association_tolerance
+    )
+
+    places = GeometryCollection(
+        {
+            "qbx": qbx,
+            "qbx_target_assoc": qbx_target_assoc,
+            "targets": targets,
+        },
+        auto_where="qbx",
+    )
+
+    return places, qbx_target_assoc
 
 
 def get_normal_vectors(queue, density_discr, loc_sign=-1):
@@ -95,42 +127,58 @@ def get_arclength_parametrization_derivative(queue, density_discr, where=None):
     dim = 2
 
     # xp = dx/dt, yp = dy/dt, sp = ds/dt
-    xp, yp = sym.parametrization_derivative_matrix(dim, dim-1, where)
-    sp = (xp[0]**2 + yp[0]**2)**(1/2)
+    xp, yp = sym.parametrization_derivative_matrix(dim, dim - 1, where)
+    sp = (xp[0] ** 2 + yp[0] ** 2) ** (1 / 2)
 
     xps = xp[0] / sp
     yps = yp[0] / sp
 
     return bind(density_discr, xps)(queue), bind(density_discr, yps)(queue)
 
+
 # }}} End helper functions
 
 # {{{ constant extension
 
 
-def compute_constant_extension(queue, target_discr,
-        qbx, density_discr, constant_val=0):
+def compute_constant_extension(
+    queue,
+    target_discr,
+    qbx,
+    density_discr,
+    constant_val=0,
+    actx=None,
+):
     """Constant extension."""
-    queue = setup_command_queue(queue=queue)
+    actx = setup_array_context(actx=actx, queue=queue)
+    places, _ = _build_extension_places(target_discr, qbx, 0.05)
     debugging_info = {}
 
     ext_f = bind(
-                 (qbx, target_discr),
-                 sym.var("sigma") * 0 + constant_val,
-                )(queue, sigma=1).real
+        places,
+        sym.var("sigma") * 0 + constant_val,
+        auto_where=("qbx", "targets"),
+    )(actx, sigma=1).real
 
     return ext_f, debugging_info
+
 
 # }}} End constant extension
 
 # {{{ harmonic extension
 
 
-def compute_harmonic_extension(queue, target_discr,
-        qbx, density_discr, f,
-        loc_sign=1,
-        target_association_tolerance=0.05,
-        gmres_tolerance=1e-14):
+def compute_harmonic_extension(
+    queue,
+    target_discr,
+    qbx,
+    density_discr,
+    f,
+    loc_sign=1,
+    target_association_tolerance=0.05,
+    gmres_tolerance=1e-14,
+    actx=None,
+):
     """Harmonic extension.
 
     :param: loc_sign indicates the domain for extension,
@@ -138,42 +186,51 @@ def compute_harmonic_extension(queue, target_discr,
             for the original problem.
     """
     dim = qbx.ambient_dim
-    queue = setup_command_queue(queue=queue)
+    actx = setup_array_context(actx=actx, queue=queue)
+    places, qbx_stick_out = _build_extension_places(
+        target_discr, qbx, target_association_tolerance
+    )
 
     # {{{ describe bvp
 
     from sumpy.kernel import LaplaceKernel
+
     kernel = LaplaceKernel(dim)
 
     cse = sym.cse
 
     sigma_sym = sym.var("sigma")
-    #sqrt_w = sym.sqrt_jac_q_weight(3)
+    # sqrt_w = sym.sqrt_jac_q_weight(3)
     sqrt_w = 1
-    inv_sqrt_w_sigma = cse(sigma_sym/sqrt_w)
+    inv_sqrt_w_sigma = cse(sigma_sym / sqrt_w)
 
-    bdry_op_sym = (loc_sign*0.5*sigma_sym
-            + sqrt_w*(
-                sym.S(kernel, inv_sqrt_w_sigma)
-                + sym.D(kernel, inv_sqrt_w_sigma)
-                ))
+    bdry_op_sym = loc_sign * 0.5 * sigma_sym + sqrt_w * (
+        sym.S(kernel, inv_sqrt_w_sigma, qbx_forced_limit="avg")
+        + sym.D(kernel, inv_sqrt_w_sigma, qbx_forced_limit="avg")
+    )
 
     # }}}
 
-    bound_op = bind(qbx, bdry_op_sym)
+    bound_op = bind(places, bdry_op_sym, auto_where=("qbx", "qbx"))
 
     # {{{ fix rhs and solve
 
-    bvp_rhs = bind(qbx, sqrt_w*sym.var("bc"))(queue, bc=f)
+    bvp_rhs = bind(places, sqrt_w * sym.var("bc"), auto_where=("qbx", "qbx"))(
+        actx, bc=f
+    )
 
-    from pytential.solve import gmres
     gmres_result = gmres(
-            bound_op.scipy_op(queue, "sigma", dtype=np.float64),
-            bvp_rhs, tol=gmres_tolerance, progress=True,
-            stall_iterations=0,
-            hard_failure=True)
+        bound_op.scipy_op(actx, "sigma", dtype=np.float64),
+        bvp_rhs,
+        tol=gmres_tolerance,
+        progress=True,
+        stall_iterations=0,
+        hard_failure=True,
+    )
 
-    sigma = bind(qbx, sym.var("sigma")/sqrt_w)(queue, sigma=gmres_result.solution)
+    sigma = bind(places, sym.var("sigma") / sqrt_w, auto_where=("qbx", "qbx"))(
+        actx, sigma=gmres_result.solution
+    )
 
     # }}}
 
@@ -183,20 +240,20 @@ def compute_harmonic_extension(queue, target_discr,
     # {{{ postprocess
 
     repr_kwargs = {"qbx_forced_limit": None}
-    representation_sym = (
-            sym.S(kernel, inv_sqrt_w_sigma, **repr_kwargs)
-            + sym.D(kernel, inv_sqrt_w_sigma, **repr_kwargs))
-
-    qbx_stick_out = qbx.copy(
-            target_association_tolerance=target_association_tolerance)
+    representation_sym = sym.S(kernel, inv_sqrt_w_sigma, **repr_kwargs) + sym.D(
+        kernel, inv_sqrt_w_sigma, **repr_kwargs
+    )
 
     debugging_info["qbx"] = qbx_stick_out
+    debugging_info["places"] = places
     debugging_info["representation"] = representation_sym
     debugging_info["density"] = sigma
 
     ext_f = bind(
-            (qbx_stick_out, target_discr),
-            representation_sym)(queue, sigma=sigma).real
+        places,
+        representation_sym,
+        auto_where=("qbx_target_assoc", "targets"),
+    )(actx, sigma=sigma).real
 
     # }}}
 
@@ -208,24 +265,33 @@ def compute_harmonic_extension(queue, target_discr,
         bdry_measure = bind(density_discr, sym.integral(dim, dim - 1, 1))(queue)
 
         int_func_bdry = bind(qbx, sym.integral(dim, dim - 1, var("integrand")))(
-                queue, integrand=f)
+            queue, integrand=f
+        )
 
-        solu_bdry = bind((qbx, density_discr),
-                representation_sym)(queue, sigma=sigma).real
+        solu_bdry = bind((qbx, density_discr), representation_sym)(
+            queue, sigma=sigma
+        ).real
         int_solu_bdry = bind(qbx, sym.integral(dim, dim - 1, var("integrand")))(
-                queue, integrand=solu_bdry)
+            queue, integrand=solu_bdry
+        )
 
         matching_const = (int_func_bdry - int_solu_bdry) / bdry_measure
 
     else:
-        matching_const = 0.
+        matching_const = 0.0
 
     ext_f = ext_f + matching_const
 
     def eval_ext_f(target_discr):
-        return bind(
-            (qbx_stick_out, target_discr),
-            representation_sym)(queue, sigma=sigma).real + matching_const
+        eval_places = places.merge({"targets_eval": target_discr})
+        return (
+            bind(
+                eval_places,
+                representation_sym,
+                auto_where=("qbx_target_assoc", "targets_eval"),
+            )(actx, sigma=sigma).real
+            + matching_const
+        )
 
     debugging_info["eval_ext_f"] = eval_ext_f
 
@@ -240,7 +306,6 @@ def compute_harmonic_extension(queue, target_discr,
 
 
 class ComplexLogKernel(ExpressionKernel):
-
     init_arg_names = ("dim",)
 
     def __init__(self, dim=None):
@@ -250,27 +315,25 @@ class ComplexLogKernel(ExpressionKernel):
             conj_z = d[0] - var("I") * d[1]
             r = var("sqrt")(np.dot(conj_z, z))
             expr = var("log")(r)
-            scaling = 1/(4*var("pi"))
+            scaling = 1 / (4 * var("pi"))
         else:
             raise NotImplementedError("unsupported dimensionality")
 
         super().__init__(
-                dim,
-                expression=expr,
-                global_scaling_const=scaling,
-                is_complex_valued=True)
+            dim, expression=expr, global_scaling_const=scaling, is_complex_valued=True
+        )
 
     has_efficient_scale_adjustment = True
 
     def adjust_for_kernel_scaling(self, expr, rscale, nderivatives):
-        """Efficient rescaling.
-        """
+        """Efficient rescaling."""
 
         if self.dim == 2:
             if nderivatives == 0:
                 # return expr + var("log")(rscale)
                 import sumpy.symbolic as sp
-                return (expr + sp.log(rscale))
+
+                return expr + sp.log(rscale)
             else:
                 return expr
 
@@ -287,7 +350,6 @@ class ComplexLogKernel(ExpressionKernel):
 
 
 class ComplexLinearLogKernel(ExpressionKernel):
-
     init_arg_names = ("dim",)
     has_efficient_scale_adjustment = False
 
@@ -298,15 +360,13 @@ class ComplexLinearLogKernel(ExpressionKernel):
             conj_z = d[0] - var("I") * d[1]
             r = var("sqrt")(np.dot(conj_z, z))
             expr = conj_z * var("log")(r)
-            scaling = - 1/(4*var("pi"))
+            scaling = -1 / (4 * var("pi"))
         else:
             raise NotImplementedError("unsupported dimensionality")
 
         super().__init__(
-                dim,
-                expression=expr,
-                global_scaling_const=scaling,
-                is_complex_valued=True)
+            dim, expression=expr, global_scaling_const=scaling, is_complex_valued=True
+        )
 
     def __getinitargs__(self):
         return (self.dim,)
@@ -318,7 +378,6 @@ class ComplexLinearLogKernel(ExpressionKernel):
 
 
 class ComplexLinearKernel(ExpressionKernel):
-
     init_arg_names = ("dim",)
     has_efficient_scale_adjustment = False
 
@@ -327,23 +386,20 @@ class ComplexLinearKernel(ExpressionKernel):
             d = sym.make_sym_vector("d", dim)
             z = d[0] + var("I") * d[1]
             expr = z
-            scaling = - 1/(8*var("pi"))
+            scaling = -1 / (8 * var("pi"))
         else:
             raise NotImplementedError("unsupported dimensionality")
 
         super().__init__(
-                dim,
-                expression=expr,
-                global_scaling_const=scaling,
-                is_complex_valued=True)
+            dim, expression=expr, global_scaling_const=scaling, is_complex_valued=True
+        )
 
     has_efficient_scale_adjustment = True
 
     def adjust_for_kernel_scaling(self, expr, rscale, nderivatives):
-        """Efficient rescaling of the kernel.
-        """
+        """Efficient rescaling of the kernel."""
         if self.dim == 2:
-            return (rscale * expr)
+            return rscale * expr
 
         else:
             raise NotImplementedError("unsupported dimensionality")
@@ -358,7 +414,6 @@ class ComplexLinearKernel(ExpressionKernel):
 
 
 class ComplexFractionalKernel(ExpressionKernel):
-
     init_arg_names = ("dim",)
     has_efficient_scale_adjustment = False
 
@@ -368,15 +423,13 @@ class ComplexFractionalKernel(ExpressionKernel):
             z = d[0] + var("I") * d[1]
             conj_z = d[0] - var("I") * d[1]
             expr = conj_z / z
-            scaling = 1/(4*var("pi")*var("I"))
+            scaling = 1 / (4 * var("pi") * var("I"))
         else:
             raise NotImplementedError("unsupported dimensionality")
 
         super().__init__(
-                dim,
-                expression=expr,
-                global_scaling_const=scaling,
-                is_complex_valued=True)
+            dim, expression=expr, global_scaling_const=scaling, is_complex_valued=True
+        )
 
     def __getinitargs__(self):
         return (self.dim,)
@@ -388,6 +441,7 @@ class ComplexFractionalKernel(ExpressionKernel):
 
 
 # }}} End Goursat kernels
+
 
 def get_extension_bie_symbolic_operator(loc_sign=1):
     """
@@ -410,18 +464,25 @@ def get_extension_bie_symbolic_operator(loc_sign=1):
     stresslet_obj = StressletWrapper(dim=dim)
     stokeslet_obj = StokesletWrapper(dim=dim)
     bdry_op_sym = (
-            loc_sign * 0.5 * sigma_sym
-            - stresslet_obj.apply(sigma_sym, nvec_sym, mu_sym,
-                qbx_forced_limit="avg")
-            - stokeslet_obj.apply(sigma_sym, mu_sym,
-                qbx_forced_limit="avg") + int_sigma)
+        loc_sign * 0.5 * sigma_sym
+        - stresslet_obj.apply(sigma_sym, nvec_sym, mu_sym, qbx_forced_limit="avg")
+        - stokeslet_obj.apply(sigma_sym, mu_sym, qbx_forced_limit="avg")
+        + int_sigma
+    )
 
     return bdry_op_sym
 
 
-def compute_biharmonic_extension(queue, target_discr,
-        qbx, density_discr, f, fx, fy,
-        target_association_tolerance=0.05):
+def compute_biharmonic_extension(
+    queue,
+    target_discr,
+    qbx,
+    density_discr,
+    f,
+    fx,
+    fy,
+    target_association_tolerance=0.05,
+):
     """Biharmoc extension. Currently only support
     interior domains in 2D (i.e., extension is on the exterior).
     """
@@ -436,50 +497,64 @@ def compute_biharmonic_extension(queue, target_discr,
     bound_op = bind(qbx, bdry_op_sym)
 
     bc = [fy, -fx]
-    bvp_rhs = bind(qbx, sym.make_sym_vector("bc", dim))(
-            queue, bc=bc)
+    bvp_rhs = bind(qbx, sym.make_sym_vector("bc", dim))(queue, bc=bc)
     gmres_result = gmres(
-             bound_op.scipy_op(queue, "sigma", np.float64, mu=1., normal=normal),
-             bvp_rhs, tol=1e-9, progress=True,
-             stall_iterations=0,
-             hard_failure=True)
+        bound_op.scipy_op(queue, "sigma", np.float64, mu=1.0, normal=normal),
+        bvp_rhs,
+        tol=1e-9,
+        progress=True,
+        stall_iterations=0,
+        hard_failure=True,
+    )
     mu = gmres_result.solution
 
     arclength_parametrization_derivatives_sym = sym.make_sym_vector(
-            "arclength_parametrization_derivatives", dim)
+        "arclength_parametrization_derivatives", dim
+    )
     density_mu_sym = sym.make_sym_vector("mu", dim)
-    dxids_sym = arclength_parametrization_derivatives_sym[0] + \
-            1j * arclength_parametrization_derivatives_sym[1]
-    dxids_conj_sym = arclength_parametrization_derivatives_sym[0] - \
-            1j * arclength_parametrization_derivatives_sym[1]
+    dxids_sym = (
+        arclength_parametrization_derivatives_sym[0]
+        + 1j * arclength_parametrization_derivatives_sym[1]
+    )
+    dxids_conj_sym = (
+        arclength_parametrization_derivatives_sym[0]
+        - 1j * arclength_parametrization_derivatives_sym[1]
+    )
     density_rho_sym = density_mu_sym[1] - 1j * density_mu_sym[0]
     density_conj_rho_sym = density_mu_sym[1] + 1j * density_mu_sym[0]
 
     # convolutions
     GS1 = sym.IntG(  # noqa: N806
-            ComplexLinearLogKernel(dim), density_rho_sym,
-            qbx_forced_limit=None)
+        ComplexLinearLogKernel(dim), density_rho_sym, qbx_forced_limit=None
+    )
     GS2 = sym.IntG(  # noqa: N806
-            ComplexLinearKernel(dim), density_conj_rho_sym,
-            qbx_forced_limit=None)
+        ComplexLinearKernel(dim), density_conj_rho_sym, qbx_forced_limit=None
+    )
     GD1 = sym.IntG(  # noqa: N806
-            ComplexFractionalKernel(dim), density_rho_sym * dxids_sym,
-            qbx_forced_limit=None)
-    GD2 = [sym.IntG(  # noqa: N806
+        ComplexFractionalKernel(dim), density_rho_sym * dxids_sym, qbx_forced_limit=None
+    )
+    GD2 = [
+        sym.IntG(  # noqa: N806
             AxisTargetDerivative(iaxis, ComplexLogKernel(dim)),
             density_conj_rho_sym * dxids_sym + density_rho_sym * dxids_conj_sym,
-            qbx_forced_limit=qbx_forced_limit
-            ) for iaxis in range(dim)]
+            qbx_forced_limit=qbx_forced_limit,
+        )
+        for iaxis in range(dim)
+    ]
 
     GS1_bdry = sym.IntG(  # noqa: N806
-            ComplexLinearLogKernel(dim), density_rho_sym,
-            qbx_forced_limit=qbx_forced_limit)
+        ComplexLinearLogKernel(dim), density_rho_sym, qbx_forced_limit=qbx_forced_limit
+    )
     GS2_bdry = sym.IntG(  # noqa: N806
-            ComplexLinearKernel(dim), density_conj_rho_sym,
-            qbx_forced_limit=qbx_forced_limit)
+        ComplexLinearKernel(dim),
+        density_conj_rho_sym,
+        qbx_forced_limit=qbx_forced_limit,
+    )
     GD1_bdry = sym.IntG(  # noqa: N806
-            ComplexFractionalKernel(dim), density_rho_sym * dxids_sym,
-            qbx_forced_limit=qbx_forced_limit)
+        ComplexFractionalKernel(dim),
+        density_rho_sym * dxids_sym,
+        qbx_forced_limit=qbx_forced_limit,
+    )
 
     xp, yp = get_arclength_parametrization_derivative(queue, density_discr)
     xp = -xp
@@ -491,57 +566,79 @@ def compute_biharmonic_extension(queue, target_discr,
     #        str(xp * tangent[0] + yp * tangent[1]))
 
     grad_v2 = [
-            bind(qbx, GD2[iaxis])(queue, mu=mu,
-                arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
-            for iaxis in range(dim)]
+        bind(qbx, GD2[iaxis])(
+            queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])
+        ).real
+        for iaxis in range(dim)
+    ]
     v2_tangent_der = sum(tangent[iaxis] * grad_v2[iaxis] for iaxis in range(dim))
 
     from pytential.symbolic.pde.scalar import NeumannOperator
     from sumpy.kernel import LaplaceKernel
+
     operator_v1 = NeumannOperator(LaplaceKernel(dim), loc_sign=qbx_forced_limit)
     bound_op_v1 = bind(qbx, operator_v1.operator(var("sigma")))
     # FIXME: the positive sign works here
     rhs_v1 = operator_v1.prepare_rhs(1 * v2_tangent_der)
     gmres_result = gmres(
-            bound_op_v1.scipy_op(queue, "sigma", dtype=np.float64),
-            rhs_v1, tol=1e-9, progress=True,
-            stall_iterations=0,
-            hard_failure=True)
+        bound_op_v1.scipy_op(queue, "sigma", dtype=np.float64),
+        rhs_v1,
+        tol=1e-9,
+        progress=True,
+        stall_iterations=0,
+        hard_failure=True,
+    )
     sigma = gmres_result.solution
-    qbx_stick_out = qbx.copy(
-            target_association_tolerance=target_association_tolerance)
+    qbx_stick_out = qbx.copy(target_association_tolerance=target_association_tolerance)
     v1 = bind(
-            (qbx_stick_out, target_discr),
-            operator_v1.representation(var("sigma"), qbx_forced_limit=None)
-            )(queue, sigma=sigma)
+        (qbx_stick_out, target_discr),
+        operator_v1.representation(var("sigma"), qbx_forced_limit=None),
+    )(queue, sigma=sigma)
     grad_v1 = bind(
-            (qbx_stick_out, target_discr),
-            operator_v1.representation(var("sigma"), qbx_forced_limit=None,
-                map_potentials=lambda pot: sym.grad(dim, pot))
-            )(queue, sigma=sigma)
-    v1_bdry = bind(qbx, operator_v1.representation(var("sigma"),
-        qbx_forced_limit=qbx_forced_limit))(queue, sigma=sigma)
+        (qbx_stick_out, target_discr),
+        operator_v1.representation(
+            var("sigma"),
+            qbx_forced_limit=None,
+            map_potentials=lambda pot: sym.grad(dim, pot),
+        ),
+    )(queue, sigma=sigma)
+    v1_bdry = bind(
+        qbx, operator_v1.representation(var("sigma"), qbx_forced_limit=qbx_forced_limit)
+    )(queue, sigma=sigma)
 
     z_conj = target_discr.nodes()[0] - 1j * target_discr.nodes()[1]
-    z_conj_bdry = density_discr.nodes().with_queue(queue)[0] \
-            - 1j * density_discr.nodes().with_queue(queue)[1]
-    int_rho = 1 / (8 * np.pi) * bind(qbx,
-            sym.integral(dim, dim - 1, density_rho_sym))(queue, mu=mu)
+    z_conj_bdry = (
+        density_discr.nodes().with_queue(queue)[0]
+        - 1j * density_discr.nodes().with_queue(queue)[1]
+    )
+    int_rho = (
+        1
+        / (8 * np.pi)
+        * bind(qbx, sym.integral(dim, dim - 1, density_rho_sym))(queue, mu=mu)
+    )
 
     omega_S1 = bind(  # noqa: N806
-            (qbx_stick_out, target_discr), GS1)(queue, mu=mu).real
-    omega_S2 = -1 * bind(  # noqa: N806
-            (qbx_stick_out, target_discr), GS2)(queue, mu=mu).real
+        (qbx_stick_out, target_discr), GS1
+    )(queue, mu=mu).real
+    omega_S2 = (
+        -1
+        * bind(  # noqa: N806
+            (qbx_stick_out, target_discr), GS2
+        )(queue, mu=mu).real
+    )
     omega_S3 = (z_conj * int_rho).real  # noqa: N806
     omega_S = -(omega_S1 + omega_S2 + omega_S3)  # noqa: N806
 
     grad_omega_S1 = bind(  # noqa: N806
-            (qbx_stick_out, target_discr),
-            sym.grad(dim, GS1))(queue, mu=mu).real
-    grad_omega_S2 = -1 * bind(  # noqa: N806
-            (qbx_stick_out, target_discr),
-            sym.grad(dim, GS2))(queue, mu=mu).real
-    grad_omega_S3 = (int_rho * make_obj_array([1., -1.])).real  # noqa: N806
+        (qbx_stick_out, target_discr), sym.grad(dim, GS1)
+    )(queue, mu=mu).real
+    grad_omega_S2 = (
+        -1
+        * bind(  # noqa: N806
+            (qbx_stick_out, target_discr), sym.grad(dim, GS2)
+        )(queue, mu=mu).real
+    )
+    grad_omega_S3 = (int_rho * make_obj_array([1.0, -1.0])).real  # noqa: N806
     grad_omega_S = -(grad_omega_S1 + grad_omega_S2 + grad_omega_S3)  # noqa: N806
 
     omega_S1_bdry = bind(qbx, GS1_bdry)(queue, mu=mu).real  # noqa: N806
@@ -550,40 +647,38 @@ def compute_biharmonic_extension(queue, target_discr,
     omega_S_bdry = -(omega_S1_bdry + omega_S2_bdry + omega_S3_bdry)  # noqa: N806
 
     omega_D1 = bind(  # noqa: N806
-            (qbx_stick_out, target_discr), GD1)(queue, mu=mu,
-            arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
-    omega_D = (omega_D1 + v1)  # noqa: N806
+        (qbx_stick_out, target_discr), GD1
+    )(queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
+    omega_D = omega_D1 + v1  # noqa: N806
 
     grad_omega_D1 = bind(  # noqa: N806
-            (qbx_stick_out, target_discr),
-            sym.grad(dim, GD1)
-            )(queue, mu=mu,
-              arclength_parametrization_derivatives=make_obj_array(
-                  [xp, yp])
-              ).real
+        (qbx_stick_out, target_discr), sym.grad(dim, GD1)
+    )(queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
     grad_omega_D = grad_omega_D1 + grad_v1  # noqa: N806
 
     omega_D1_bdry = bind(  # noqa: N806
-            qbx, GD1_bdry)(
-                    queue, mu=mu,
-                    arclength_parametrization_derivatives=make_obj_array(
-                        [xp, yp])
-                    ).real
-    omega_D_bdry = (omega_D1_bdry + v1_bdry)  # noqa: N806
+        qbx, GD1_bdry
+    )(queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
+    omega_D_bdry = omega_D1_bdry + v1_bdry  # noqa: N806
 
-    int_bdry_mu = bind(qbx, sym.integral(dim, dim - 1, sym.make_sym_vector(
-        "mu", dim)))(queue, mu=mu)
+    int_bdry_mu = bind(qbx, sym.integral(dim, dim - 1, sym.make_sym_vector("mu", dim)))(
+        queue, mu=mu
+    )
     omega_W = (  # noqa: N806
-            int_bdry_mu[0] * target_discr.nodes()[1]
-            - int_bdry_mu[1] * target_discr.nodes()[0])
+        int_bdry_mu[0] * target_discr.nodes()[1]
+        - int_bdry_mu[1] * target_discr.nodes()[0]
+    )
     grad_omega_W = make_obj_array(  # noqa: N806
-            [-int_bdry_mu[1], int_bdry_mu[0]])
+        [-int_bdry_mu[1], int_bdry_mu[0]]
+    )
     omega_W_bdry = (  # noqa: N806
-            int_bdry_mu[0] * density_discr.nodes().with_queue(queue)[1]
-            - int_bdry_mu[1] * density_discr.nodes().with_queue(queue)[0])
+        int_bdry_mu[0] * density_discr.nodes().with_queue(queue)[1]
+        - int_bdry_mu[1] * density_discr.nodes().with_queue(queue)[0]
+    )
 
     int_bdry = bind(qbx, sym.integral(dim, dim - 1, var("integrand")))(
-            queue, integrand=omega_S_bdry+omega_D_bdry+omega_W_bdry)
+        queue, integrand=omega_S_bdry + omega_D_bdry + omega_W_bdry
+    )
 
     debugging_info = {}
     debugging_info["omega_S"] = omega_S
@@ -593,13 +688,16 @@ def compute_biharmonic_extension(queue, target_discr,
     debugging_info["omega_D1"] = omega_D1
 
     int_interior_func_bdry = bind(qbx, sym.integral(2, 1, var("integrand")))(
-            queue, integrand=f)
+        queue, integrand=f
+    )
 
     path_length = get_path_length(queue, density_discr)
-    ext_f = omega_S + omega_D + omega_W + (
-            int_interior_func_bdry - int_bdry) / path_length
+    ext_f = (
+        omega_S + omega_D + omega_W + (int_interior_func_bdry - int_bdry) / path_length
+    )
     grad_f = grad_omega_S + grad_omega_D + grad_omega_W
 
     return ext_f, grad_f[0], grad_f[1], debugging_info
+
 
 # }}} End biharmonic extension

--- a/volumential/geometry.py
+++ b/volumential/geometry.py
@@ -31,9 +31,7 @@ from pytools.obj_array import make_obj_array
 
 
 class BoundingBoxFactory:
-    def __init__(self, dim,
-            center=None, radius=None,
-            dtype=float):
+    def __init__(self, dim, center=None, radius=None, dtype=float):
         self.dim = dim
         self.dtype = np.dtype(dtype)
 
@@ -50,10 +48,9 @@ class BoundingBoxFactory:
         """Returns true if the bounding box is readily determined,
         i.e., the __call__() method has been called.
         """
-        return (self.box_center is not None)
+        return self.box_center is not None
 
-    def __call__(self, ctx,
-            expand_to_hold_mesh=None, mesh_padding_factor=0.05):
+    def __call__(self, ctx, expand_to_hold_mesh=None, mesh_padding_factor=0.05):
         """If expand the box to be large enough to enclose a
         mesh object.
 
@@ -73,8 +70,8 @@ class BoundingBoxFactory:
         if not expand_to_hold_mesh:
             if (self.center is None) or (self.radius is None):
                 raise ValueError(
-                        "A bounding box without presets "
-                        "must be adapted to an mesh.")
+                    "A bounding box without presets must be adapted to an mesh."
+                )
             box_center = self.center
             box_radius = self.radius
         else:
@@ -100,9 +97,8 @@ class BoundingBoxFactory:
         from boxtree.bounding_box import make_bounding_box_dtype
         from boxtree.tools import AXIS_NAMES
 
-        axis_names = AXIS_NAMES[:self.dim]
-        bbox_type, _ = make_bounding_box_dtype(
-                ctx.devices[0], self.dim, self.dtype)
+        axis_names = AXIS_NAMES[: self.dim]
+        bbox_type, _ = make_bounding_box_dtype(ctx.devices[0], self.dim, self.dtype)
 
         bbox = np.empty(1, bbox_type)
         for ax, iaxis in zip(axis_names, range(self.dim)):
@@ -110,6 +106,7 @@ class BoundingBoxFactory:
             bbox["max_" + ax] = self.ubounds[iaxis]
 
         return bbox
+
 
 # }}} End bounding box factory
 
@@ -141,10 +138,18 @@ class BoxFMMGeometryFactory:
         Box mesh generator that implements the
         :class:`volumential.meshgen.MeshGenBase` interface.
     """
+
     def __init__(
-            self, cl_ctx, dim, order, nlevels, bbox_getter,
-            quadrature_formula=None,
-            expand_to_hold_mesh=None, mesh_padding_factor=0.05):
+        self,
+        cl_ctx,
+        dim,
+        order,
+        nlevels,
+        bbox_getter,
+        quadrature_formula=None,
+        expand_to_hold_mesh=None,
+        mesh_padding_factor=0.05,
+    ):
         """
         :arg bbox_getter: A :class:`BoundingBoxFactory` object.
 
@@ -158,9 +163,11 @@ class BoxFMMGeometryFactory:
             raise NotImplementedError()
         elif dim == 2:
             from volumential.meshgen import MeshGen2D
+
             self._engine_class = MeshGen2D
         elif dim == 3:
             from volumential.meshgen import MeshGen3D
+
             self._engine_class = MeshGen3D
 
         self.dim = dim
@@ -175,8 +182,9 @@ class BoxFMMGeometryFactory:
         self.bbox_getter = bbox_getter
 
         self.cl_context = cl_ctx
-        self._bbox = bbox_getter(self.cl_context,
-                expand_to_hold_mesh, mesh_padding_factor)
+        self._bbox = bbox_getter(
+            self.cl_context, expand_to_hold_mesh, mesh_padding_factor
+        )
 
         self.order = order
         self.nlevels = nlevels
@@ -187,9 +195,13 @@ class BoxFMMGeometryFactory:
         self.engine = self._engine_class(self.order, self.nlevels, a, b)
 
     def reinit(
-            self, order=None, nlevels=None,
-            quadrature_formula=None,
-            expand_to_hold_mesh=None, mesh_padding_factor=None):
+        self,
+        order=None,
+        nlevels=None,
+        quadrature_formula=None,
+        expand_to_hold_mesh=None,
+        mesh_padding_factor=None,
+    ):
         """Resets the engine to its initial state, and optionally also
         changes some parameters.
         """
@@ -200,8 +212,9 @@ class BoxFMMGeometryFactory:
             self.nlevels = nlevels
 
         if expand_to_hold_mesh is not None:
-            self._bbox = self.bbox_getter(self.cl_context,
-                    expand_to_hold_mesh, mesh_padding_factor)
+            self._bbox = self.bbox_getter(
+                self.cl_context, expand_to_hold_mesh, mesh_padding_factor
+            )
 
         # the engine generates meshes centered at the origin
         a = -1 * self.bbox_getter.radius
@@ -219,8 +232,8 @@ class BoxFMMGeometryFactory:
             return q_points
         else:
             return make_obj_array(
-                    [cl.array.to_device(queue, q_points[i])
-                     for i in range(self.dim)])
+                [cl.array.to_device(queue, q_points[i]) for i in range(self.dim)]
+            )
 
     def _get_q_weights(self, queue=None):
         q_weights = self.engine.get_q_weights()
@@ -240,8 +253,8 @@ class BoxFMMGeometryFactory:
             return cell_centers
         else:
             return make_obj_array(
-                    [cl.array.to_device(queue, cell_centers[i])
-                     for i in range(self.dim)])
+                [cl.array.to_device(queue, cell_centers[i]) for i in range(self.dim)]
+            )
 
     def _get_active_cell_measures(self, queue=None):
         cell_measures = self.engine.get_cell_measures()
@@ -269,25 +282,35 @@ class BoxFMMGeometryFactory:
         if queue is None:
             queue = cl.CommandQueue(self.cl_context)
 
+        from boxtree.array_context import PyOpenCLArrayContext
+
+        actx = PyOpenCLArrayContext(queue)
+
         from boxtree import TreeBuilder
-        tb = TreeBuilder(self.cl_context)
+
+        tb = TreeBuilder(actx)
 
         q_points = self._get_q_points(queue)
 
-        tree, _ = tb(queue, particles=q_points, targets=q_points,
-                     bbox=self._bbox, max_particles_in_box=(
-                         (self.n_q_points_per_cell**self.dim) * (2**self.dim)
-                         - 1),
-                     kind="adaptive-level-restricted")
+        tree, _ = tb(
+            actx,
+            particles=q_points,
+            targets=q_points,
+            max_particles_in_box=(
+                (self.n_q_points_per_cell**self.dim) * (2**self.dim) - 1
+            ),
+            kind="adaptive-level-restricted",
+        )
 
         from boxtree.traversal import FMMTraversalBuilder
-        tg = FMMTraversalBuilder(self.cl_context)
-        trav, _ = tg(queue, tree)
+
+        tg = FMMTraversalBuilder(actx)
+        trav, _ = tg(actx, tree)
 
         return BoxFMMGeometryData(
-                self.cl_context,
-                q_points, self._get_q_weights(queue),
-                tree, trav)
+            self.cl_context, q_points, self._get_q_weights(queue), tree, trav
+        )
+
 
 # }}} End box mesh data factory
 
@@ -301,6 +324,7 @@ class BoxFMMGeometryData(FMMLibRotationData):
     .. attribute:: tree
     .. attribute:: traversal
     """
+
     def __init__(self, cl_context, q_points, q_weights, tree, trav):
         self.cl_context = cl_context
         self.queue = cl.CommandQueue(cl_context)

--- a/volumential/interpolation.py
+++ b/volumential/interpolation.py
@@ -27,16 +27,31 @@ import numpy as np
 
 import loopy as lp
 import pyopencl as cl
+from arraycontext import flatten, unflatten
+from boxtree.array_context import PyOpenCLArrayContext as BoxtreePyOpenCLArrayContext
 from boxtree.tools import DeviceDataRecord
-from meshmode.array_context import PyOpenCLArrayContext
-from meshmode.dof_array import flatten, thaw, unflatten
+from meshmode.array_context import PyOpenCLArrayContext as MeshmodePyOpenCLArrayContext
+from meshmode.dof_array import DOFArray
 from pytools import ProcessLogger, memoize_method
 from pytools.obj_array import make_obj_array
 
-from volumential.volume_fmm import interpolate_volume_potential
-
-
 logger = logging.getLogger(__name__)
+
+
+def _get_boxtree_actx(context):
+    if isinstance(context, cl.CommandQueue):
+        return BoxtreePyOpenCLArrayContext(context)
+
+    if isinstance(context, cl.Context):
+        return BoxtreePyOpenCLArrayContext(cl.CommandQueue(context))
+
+    if isinstance(context, BoxtreePyOpenCLArrayContext):
+        return context
+
+    if hasattr(context, "queue"):
+        return BoxtreePyOpenCLArrayContext(context.queue)
+
+    raise TypeError(f"unsupported context type: {type(context).__name__}")
 
 
 __doc__ = r"""
@@ -68,6 +83,7 @@ To :mod:`meshmode`
 
 
 # {{{ output
+
 
 class ElementsToSourcesLookup(DeviceDataRecord):
     """
@@ -142,10 +158,12 @@ class LeavesToNodesLookup(DeviceDataRecord):
     .. automethod:: get
     """
 
+
 # }}} End output
 
 
 # {{{ elements-to-sources lookup builder
+
 
 class ElementsToSourcesLookupBuilder:
     """Given a :mod:`meshmod` mesh and a :mod:`boxtree.Tree`, both discretizing
@@ -164,24 +182,27 @@ class ElementsToSourcesLookupBuilder:
         assert tree.dimensions == discr.dim
         self.dim = discr.dim
         self.context = context
+        self.boxtree_actx = _get_boxtree_actx(context)
         self.tree = tree
         self.discr = discr
 
         from pyopencl.algorithm import KeyValueSorter
+
         self.key_value_sorter = KeyValueSorter(context)
 
         from boxtree.area_query import AreaQueryBuilder
-        self.area_query_builder = AreaQueryBuilder(self.context)
+
+        self.area_query_builder = AreaQueryBuilder(self.boxtree_actx)
 
     # {{{ kernel generation
 
     @memoize_method
     def codegen_get_dimension_specific_snippets(self):
-        """Dimension-dependent code loopy instructions.
-        """
+        """Dimension-dependent code loopy instructions."""
         import sympy as sp
+
         axis_names = ["x", "y", "z"]
-        axis_names = axis_names[:self.dim]
+        axis_names = axis_names[: self.dim]
 
         # tolerance
         tol = -1e-12
@@ -200,11 +221,9 @@ class ElementsToSourcesLookupBuilder:
             return str(mat0.det())
 
         if self.dim == 2:
-
             # {{{ 2d
 
-            code_get_simplex = \
-                """
+            code_get_simplex = """
                 <> Ax = mesh_vertices_0[mesh_vertex_indices[iel, 0]]
                 <> Ay = mesh_vertices_1[mesh_vertex_indices[iel, 0]]
                 <> Bx = mesh_vertices_0[mesh_vertex_indices[iel, 1]]
@@ -212,8 +231,7 @@ class ElementsToSourcesLookupBuilder:
                 <> Cx = mesh_vertices_0[mesh_vertex_indices[iel, 2]]
                 <> Cy = mesh_vertices_1[mesh_vertex_indices[iel, 2]]
                 """
-            code_get_point = \
-                """
+            code_get_point = """
                 <> Px = source_points_0[source_id]
                 <> Py = source_points_1[source_id]
                 """
@@ -221,24 +239,24 @@ class ElementsToSourcesLookupBuilder:
             code_s0 = get_simplex_measure(["P", "B", "C"])
             code_s1 = get_simplex_measure(["A", "P", "C"])
             code_s2 = get_simplex_measure(["A", "B", "P"])
-            code_compute_simplex_measures = \
-                f"""
+            code_compute_simplex_measures = f"""
                 <> s0 = {code_s0}
                 <> s1 = {code_s1}
                 <> s2 = {code_s2}
                 """
-            code_measures_have_common_sign = " and ".join([
-                f"s{c1} * s{c2} >= {tol}"
-                for c1, c2 in itertools.combinations(["0", "1"], 2)])
+            code_measures_have_common_sign = " and ".join(
+                [
+                    f"s{c1} * s{c2} >= {tol}"
+                    for c1, c2 in itertools.combinations(["0", "1"], 2)
+                ]
+            )
 
             # }}} End 2d
 
         elif self.dim == 3:
-
             # {{{ 3d
 
-            code_get_simplex = \
-                """
+            code_get_simplex = """
                 <> Ax = mesh_vertices_0[mesh_vertex_indices[iel, 0]]
                 <> Ay = mesh_vertices_1[mesh_vertex_indices[iel, 0]]
                 <> Az = mesh_vertices_2[mesh_vertex_indices[iel, 0]]
@@ -252,8 +270,7 @@ class ElementsToSourcesLookupBuilder:
                 <> Dy = mesh_vertices_1[mesh_vertex_indices[iel, 3]]
                 <> Dz = mesh_vertices_2[mesh_vertex_indices[iel, 3]]
                 """
-            code_get_point = \
-                """
+            code_get_point = """
                 <> Px = source_points_0[source_id]
                 <> Py = source_points_1[source_id]
                 <> Pz = source_points_2[source_id]
@@ -263,27 +280,30 @@ class ElementsToSourcesLookupBuilder:
             code_s1 = get_simplex_measure(["A", "P", "C", "D"])
             code_s2 = get_simplex_measure(["A", "B", "P", "D"])
             code_s3 = get_simplex_measure(["A", "B", "C", "P"])
-            code_compute_simplex_measures = \
-                f"""
+            code_compute_simplex_measures = f"""
                 <> s0 = {code_s0}
                 <> s1 = {code_s1}
                 <> s2 = {code_s2}
                 <> s3 = {code_s3}
                 """
-            code_measures_have_common_sign = " and ".join([
-                f"s{c1} * s{c2} >= {tol}"
-                for c1, c2 in itertools.combinations(["0", "1", "2"], 2)])
+            code_measures_have_common_sign = " and ".join(
+                [
+                    f"s{c1} * s{c2} >= {tol}"
+                    for c1, c2 in itertools.combinations(["0", "1", "2"], 2)
+                ]
+            )
 
             # }}} End 3d
 
         else:
             raise NotImplementedError()
 
-        return {"code_get_simplex": code_get_simplex,
-                "code_get_point": code_get_point,
-                "code_compute_simplex_measures": code_compute_simplex_measures,
-                "code_measures_have_common_sign": code_measures_have_common_sign,
-                }
+        return {
+            "code_get_simplex": code_get_simplex,
+            "code_get_point": code_get_point,
+            "code_compute_simplex_measures": code_compute_simplex_measures,
+            "code_measures_have_common_sign": code_measures_have_common_sign,
+        }
 
     @memoize_method
     def get_simplex_lookup_kernel(self):
@@ -300,11 +320,13 @@ class ElementsToSourcesLookupBuilder:
 
         snippets = self.codegen_get_dimension_specific_snippets()
         loopy_knl = lp.make_kernel(
-            ["{ [ iel ]: 0 <= iel < nelements }",
-             "{ [ ineighbor ]: nearby_leaves_beg <= ineighbor < nearby_leaves_end }",
-             "{ [ isrc ]: 0 <= isrc < n_box_sources }"
-             ],
-            ["""
+            [
+                "{ [ iel ]: 0 <= iel < nelements }",
+                "{ [ ineighbor ]: nearby_leaves_beg <= ineighbor < nearby_leaves_end }",
+                "{ [ isrc ]: 0 <= isrc < n_box_sources }",
+            ],
+            [
+                """
             for iel
                 <> nearby_leaves_beg = leaves_near_ball_starts[iel]
                 <> nearby_leaves_end = leaves_near_ball_starts[iel + 1]
@@ -329,14 +351,17 @@ class ElementsToSourcesLookupBuilder:
                     end
                 end
             end
-            """.format(**snippets)],
-            [lp.ValueArg("nelements, dim, nboxes, nsources", np.int32),
-             lp.GlobalArg("mesh_vertex_indices", np.int32, "nelements, dim+1"),
-             lp.GlobalArg("box_source_starts", np.int32, "nboxes"),
-             lp.GlobalArg("box_source_counts_cumul", np.int32, "nboxes"),
-             lp.GlobalArg("leaves_near_ball_lists", np.int32, None),
-             lp.GlobalArg("result", np.int32, "nsources", for_atomic=True),
-             "..."],
+            """.format(**snippets)
+            ],
+            [
+                lp.ValueArg("nelements, dim, nboxes, nsources", np.int32),
+                lp.GlobalArg("mesh_vertex_indices", np.int32, "nelements, dim+1"),
+                lp.GlobalArg("box_source_starts", np.int32, "nboxes"),
+                lp.GlobalArg("box_source_counts_cumul", np.int32, "nboxes"),
+                lp.GlobalArg("leaves_near_ball_lists", np.int32, None),
+                lp.GlobalArg("result", np.int32, "nsources", for_atomic=True),
+                "...",
+            ],
             name="build_sources_in_simplex_lookup",
             lang_version=(2018, 2),
         )
@@ -347,14 +372,16 @@ class ElementsToSourcesLookupBuilder:
     # }}} End kernel generation
 
     def compute_short_lists(self, actx, wait_for=None):
-        """balls --> overlapping leaves
-        """
-        if not isinstance(actx, PyOpenCLArrayContext):
+        """balls --> overlapping leaves"""
+        if not isinstance(actx, MeshmodePyOpenCLArrayContext):
             if isinstance(actx, cl.CommandQueue):
                 from warnings import warn
-                warn("Command queue passed to the interpolator. "
-                     "Supply an array context to enable proper caching.")
-                actx = PyOpenCLArrayContext(actx)
+
+                warn(
+                    "Command queue passed to the interpolator. "
+                    "Supply an array context to enable proper caching."
+                )
+                actx = MeshmodePyOpenCLArrayContext(actx)
             else:
                 raise ValueError
 
@@ -362,40 +389,54 @@ class ElementsToSourcesLookupBuilder:
         if len(mesh.groups) > 1:
             raise NotImplementedError("Mixed elements not supported")
         melgrp = mesh.groups[0]
-        ball_centers_host = (np.max(melgrp.nodes, axis=2)
-                             + np.min(melgrp.nodes, axis=2)) / 2
-        ball_radii_host = np.max(
-                np.max(melgrp.nodes, axis=2) - np.min(melgrp.nodes, axis=2),
-                axis=0) / 2
+        ball_centers_host = (
+            np.max(melgrp.nodes, axis=2) + np.min(melgrp.nodes, axis=2)
+        ) / 2
+        ball_radii_host = (
+            np.max(np.max(melgrp.nodes, axis=2) - np.min(melgrp.nodes, axis=2), axis=0)
+            / 2
+        )
 
-        ball_centers = make_obj_array([
-            cl.array.to_device(actx.queue, center_coord_comp)
-            for center_coord_comp in ball_centers_host])
+        ball_centers = make_obj_array(
+            [
+                cl.array.to_device(actx.queue, center_coord_comp)
+                for center_coord_comp in ball_centers_host
+            ]
+        )
         ball_radii = cl.array.to_device(actx.queue, ball_radii_host)
 
         area_query_result, evt = self.area_query_builder(
-            actx.queue, self.tree, ball_centers, ball_radii,
-            peer_lists=None, wait_for=wait_for)
+            self.boxtree_actx,
+            self.tree,
+            ball_centers,
+            ball_radii,
+            peer_lists=None,
+            wait_for=wait_for,
+        )
         return area_query_result, evt
 
     def __call__(self, actx, balls_to_leaves_lookup=None, wait_for=None):
         """
         :arg queue: a :class:`pyopencl.CommandQueue`
         """
-        if not isinstance(actx, PyOpenCLArrayContext):
+        if not isinstance(actx, MeshmodePyOpenCLArrayContext):
             if isinstance(actx, cl.CommandQueue):
                 from warnings import warn
-                warn("Command queue passed to the interpolator. "
-                     "Supply an array context to enable proper caching.")
-                actx = PyOpenCLArrayContext(actx)
+
+                warn(
+                    "Command queue passed to the interpolator. "
+                    "Supply an array context to enable proper caching."
+                )
+                actx = MeshmodePyOpenCLArrayContext(actx)
             else:
                 raise ValueError
 
         slk_plog = ProcessLogger(logger, "element-to-source lookup: run area query")
 
         if balls_to_leaves_lookup is None:
-            balls_to_leaves_lookup, evt = \
-                self.compute_short_lists(actx.queue, wait_for=wait_for)
+            balls_to_leaves_lookup, evt = self.compute_short_lists(
+                actx, wait_for=wait_for
+            )
             wait_for = [evt]
 
         # -----------------------------------------------------------------
@@ -405,31 +446,40 @@ class ElementsToSourcesLookupBuilder:
 
         element_lookup_kernel = self.get_simplex_lookup_kernel()
 
-        vertices_dev = make_obj_array([
-            cl.array.to_device(actx.queue, verts)
-            for verts in self.discr.mesh.vertices])
+        vertices_dev = make_obj_array(
+            [
+                cl.array.to_device(actx.queue, verts)
+                for verts in self.discr.mesh.vertices
+            ]
+        )
 
         mesh_vertices_kwargs = {
-            f"mesh_vertices_{iaxis}": vertices_dev[iaxis]
-            for iaxis in range(self.dim)}
+            f"mesh_vertices_{iaxis}": vertices_dev[iaxis] for iaxis in range(self.dim)
+        }
 
         source_points_kwargs = {
             f"source_points_{iaxis}": self.tree.sources[iaxis]
-            for iaxis in range(self.dim)}
+            for iaxis in range(self.dim)
+        }
 
         evt, res = element_lookup_kernel(
-            actx.queue, dim=self.dim, nboxes=self.tree.nboxes,
-            nelements=self.discr.mesh.nelements, nsources=self.tree.nsources,
-            result=cl.array.zeros(actx.queue,
-                                  self.tree.nsources, dtype=np.int32) - 1,
+            actx.queue,
+            dim=self.dim,
+            nboxes=self.tree.nboxes,
+            nelements=self.discr.mesh.nelements,
+            nsources=self.tree.nsources,
+            result=cl.array.zeros(actx.queue, self.tree.nsources, dtype=np.int32) - 1,
             mesh_vertex_indices=self.discr.mesh.groups[0].vertex_indices,
             box_source_starts=self.tree.box_source_starts,
             box_source_counts_cumul=self.tree.box_source_counts_cumul,
             leaves_near_ball_starts=balls_to_leaves_lookup.leaves_near_ball_starts,
             leaves_near_ball_lists=balls_to_leaves_lookup.leaves_near_ball_lists,
-            wait_for=wait_for, **mesh_vertices_kwargs, **source_points_kwargs)
+            wait_for=wait_for,
+            **mesh_vertices_kwargs,
+            **source_points_kwargs,
+        )
 
-        source_to_element_lookup, = res
+        (source_to_element_lookup,) = res
 
         wait_for = [evt]
 
@@ -441,27 +491,34 @@ class ElementsToSourcesLookupBuilder:
 
         logger.debug("element-to-source lookup: key-value sort")
 
-        sources_in_element_starts, sources_in_element_lists, evt = \
+        sources_in_element_starts, sources_in_element_lists, evt = (
             self.key_value_sorter(
                 actx.queue,
                 keys=source_to_element_lookup,
                 values=cl.array.arange(
-                    actx.queue, self.tree.nsources, dtype=self.tree.box_id_dtype),
+                    actx.queue, self.tree.nsources, dtype=self.tree.box_id_dtype
+                ),
                 nkeys=self.discr.mesh.nelements,
                 starts_dtype=self.tree.box_id_dtype,
-                wait_for=wait_for)
+                wait_for=wait_for,
+            )
+        )
 
         slk_plog.done()
 
         return ElementsToSourcesLookup(
-            tree=self.tree, discr=self.discr,
+            tree=self.tree,
+            discr=self.discr,
             sources_in_element_starts=sources_in_element_starts,
-            sources_in_element_lists=sources_in_element_lists), evt
+            sources_in_element_lists=sources_in_element_lists,
+        ), evt
+
 
 # }}} End elements-to-sources lookup builder
 
 
 # {{{ leaves-to-nodes lookup builder
+
 
 class LeavesToNodesLookupBuilder:
     """Given a :mod:`meshmod` mesh and a :mod:`boxtree.Tree`, both discretizing
@@ -480,12 +537,15 @@ class LeavesToNodesLookupBuilder:
         assert trav.tree.dimensions == discr.dim
         self.dim = discr.dim
         self.context = context
+        self.boxtree_actx = _get_boxtree_actx(context)
         self.trav = trav
         self.discr = discr
 
         from boxtree.area_query import LeavesToBallsLookupBuilder
-        self.leaves_to_balls_lookup_builder = \
-            LeavesToBallsLookupBuilder(self.context)
+
+        self.leaves_to_balls_lookup_builder = LeavesToBallsLookupBuilder(
+            self.boxtree_actx
+        )
 
     def __call__(self, actx, tol=1e-12, wait_for=None):
         """
@@ -493,30 +553,38 @@ class LeavesToNodesLookupBuilder:
         :tol: nodes close enough to the boundary will be treated as
             lying on the boundary, whose interpolated values are averaged.
         """
-        if not isinstance(actx, PyOpenCLArrayContext):
+        if not isinstance(actx, MeshmodePyOpenCLArrayContext):
             if isinstance(actx, cl.CommandQueue):
                 from warnings import warn
-                warn("Command queue passed to the interpolator. "
-                     "Supply an array context to enable proper caching.")
-                actx = PyOpenCLArrayContext(actx)
+
+                warn(
+                    "Command queue passed to the interpolator. "
+                    "Supply an array context to enable proper caching."
+                )
+                actx = MeshmodePyOpenCLArrayContext(actx)
             else:
                 raise ValueError
 
-        nodes = flatten(thaw(actx, self.discr.nodes()))
+        nodes = flatten(actx.thaw(self.discr.nodes()), actx, leaf_class=DOFArray)
         radii = cl.array.zeros_like(nodes[0]) + tol
 
         lbl_lookup, evt = self.leaves_to_balls_lookup_builder(
-            actx.queue, self.trav.tree, nodes, radii, wait_for=wait_for)
+            self.boxtree_actx, self.trav.tree, nodes, radii, wait_for=wait_for
+        )
 
         return LeavesToNodesLookup(
-            trav=self.trav, discr=self.discr,
+            trav=self.trav,
+            discr=self.discr,
             nodes_in_leaf_starts=lbl_lookup.balls_near_box_starts,
-            nodes_in_leaf_lists=lbl_lookup.balls_near_box_lists), evt
+            nodes_in_leaf_lists=lbl_lookup.balls_near_box_lists,
+        ), evt
+
 
 # }}} End leaves-to-nodes lookup builder
 
 
 # {{{ transform helper
+
 
 def compute_affine_transform(source_simplex, target_simplex):
     """Computes A and b for the affine transform :math:`y = A x + b`
@@ -563,16 +631,17 @@ def invert_affine_transform(mat_a, disp_b):
     :param disp_b: a dim*(dim+1) :mod:`numpy` array
     """
     iva = np.linalg.inv(mat_a)
-    ivb = - iva @ disp_b
+    ivb = -iva @ disp_b
     return iva, ivb
+
 
 # }}} End transform helper
 
 
 # {{{ from meshmode interpolation
 
-def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
-                              order="tree"):
+
+def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup, order="tree"):
     """Interpolate a DoF vector from :mod:`meshmode`.
 
     :arg dof_vec: a DoF vector representing a field in :mod:`meshmode`
@@ -594,12 +663,15 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
     if not isinstance(dof_vec, cl.array.Array):
         raise TypeError("non-array passed to interpolator")
 
-    if not isinstance(actx, PyOpenCLArrayContext):
+    if not isinstance(actx, MeshmodePyOpenCLArrayContext):
         if isinstance(actx, cl.CommandQueue):
             from warnings import warn
-            warn("Command queue passed to the interpolator. "
-                 "Supply an array context to enable proper caching.")
-            actx = PyOpenCLArrayContext(actx)
+
+            warn(
+                "Command queue passed to the interpolator. "
+                "Supply an array context to enable proper caching."
+            )
+            actx = MeshmodePyOpenCLArrayContext(actx)
         else:
             raise ValueError
 
@@ -611,7 +683,8 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
     if not degroup.is_affine:
         raise ValueError(
             "interpolation requires global-to-local map, "
-            "which is only available for affinely mapped elements")
+            "which is only available for affinely mapped elements"
+        )
 
     mesh = elements_to_sources_lookup.discr.mesh
     dim = elements_to_sources_lookup.discr.dim
@@ -627,14 +700,17 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
     # This step computes `unit_sources`, the list of inversely
     # mapped source points.
 
-    sources_in_element_starts = \
+    sources_in_element_starts = (
         elements_to_sources_lookup.sources_in_element_starts.get(actx.queue)
-    sources_in_element_lists = \
-        elements_to_sources_lookup.sources_in_element_lists.get(actx.queue)
-    tree = elements_to_sources_lookup.tree.get(actx.queue)
+    )
+    sources_in_element_lists = elements_to_sources_lookup.sources_in_element_lists.get(
+        actx.queue
+    )
+    tree = _get_boxtree_actx(actx).to_numpy(elements_to_sources_lookup.tree)
 
     unit_sources_host = make_obj_array(
-            [np.zeros_like(srccrd) for srccrd in tree.sources])
+        [np.zeros_like(srccrd) for srccrd in tree.sources]
+    )
 
     for iel in range(degroup.nelements):
         vertex_ids = megroup.vertex_indices[iel]
@@ -645,15 +721,16 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
         end = sources_in_element_starts[iel + 1]
         source_ids_in_el = sources_in_element_lists[beg:end]
         sources_in_el = np.vstack(
-            [tree.sources[iaxis][source_ids_in_el] for iaxis in range(dim)])
+            [tree.sources[iaxis][source_ids_in_el] for iaxis in range(dim)]
+        )
 
         ivmapped_el_sources = afa @ sources_in_el + afb.reshape([dim, 1])
         for iaxis in range(dim):
-            unit_sources_host[iaxis][source_ids_in_el] = \
-                ivmapped_el_sources[iaxis, :]
+            unit_sources_host[iaxis][source_ids_in_el] = ivmapped_el_sources[iaxis, :]
 
     unit_sources = make_obj_array(
-        [cl.array.to_device(actx.queue, usc) for usc in unit_sources_host])
+        [cl.array.to_device(actx.queue, usc) for usc in unit_sources_host]
+    )
 
     # -----------------------------------------------------
     # Carry out evaluations in the local (template) frames.
@@ -668,17 +745,18 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
     # that the previous step can be swapped with a kernel without
     # interrupting the followed computation.
 
-    mapped_sources = np.vstack(
-        [usc.get(actx.queue) for usc in unit_sources])
+    mapped_sources = np.vstack([usc.get(actx.queue) for usc in unit_sources])
 
-    basis_funcs = degroup.basis()
+    basis_funcs = degroup.basis_obj().functions
 
-    dof_vec_view = unflatten(
-            actx, elements_to_sources_lookup.discr, dof_vec)[0]
+    from arraycontext.impl.pyopencl.taggable_cl_array import to_tagged_cl_array
+
+    dof_template = elements_to_sources_lookup.discr.zeros(actx, dtype=dof_vec.dtype)
+    dof_vec_view = unflatten(dof_template, to_tagged_cl_array(dof_vec), actx)[0]
     dof_vec_view = dof_vec_view.get()
 
     sym_shape = dof_vec.shape[:-1]
-    source_vec = np.zeros(sym_shape + (tree.nsources, ))
+    source_vec = np.zeros(sym_shape + (tree.nsources,))
 
     for iel in range(degroup.nelements):
         beg = sources_in_element_starts[iel]
@@ -689,19 +767,21 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
 
         # resampling matrix built from Vandermonde matrices
         import modepy as mp
+
         rsplm = mp.resampling_matrix(
-                basis=basis_funcs,
-                new_nodes=mapped_sources_in_el,
-                old_nodes=degroup.unit_nodes)
+            basis=basis_funcs,
+            new_nodes=mapped_sources_in_el,
+            old_nodes=degroup.unit_nodes,
+        )
 
         if len(sym_shape) == 0:
             local_coeffs = local_dof_vec
             source_vec[source_ids_in_el] = rsplm @ local_coeffs
         else:
             from pytools import indices_in_shape
+
             for sym_id in indices_in_shape(sym_shape):
-                source_vec[sym_id + (source_ids_in_el, )] = \
-                    rsplm @ local_dof_vec[sym_id]
+                source_vec[sym_id + (source_ids_in_el,)] = rsplm @ local_dof_vec[sym_id]
 
     source_vec = cl.array.to_device(actx.queue, source_vec)
 
@@ -714,13 +794,14 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup,
 
     return source_vec
 
+
 # }}} End from meshmode interpolation
 
 
 # {{{ to meshmode interpolation
 
-def interpolate_to_meshmode(actx, potential, leaves_to_nodes_lookup,
-                            order="tree"):
+
+def interpolate_to_meshmode(actx, potential, leaves_to_nodes_lookup, order="tree"):
     """
     :arg potential: a DoF vector representing a field in :mod:`volumential`,
         in tree order.
@@ -737,39 +818,56 @@ def interpolate_to_meshmode(actx, potential, leaves_to_nodes_lookup,
     else:
         raise ValueError(f"order must be 'tree' or 'user' (got {order}).")
 
-    if not isinstance(actx, PyOpenCLArrayContext):
+    if not isinstance(actx, MeshmodePyOpenCLArrayContext):
         if isinstance(actx, cl.CommandQueue):
             from warnings import warn
-            warn("Command queue passed to the interpolator. "
-                 "Supply an array context to enable proper caching.")
-            actx = PyOpenCLArrayContext(actx)
+
+            warn(
+                "Command queue passed to the interpolator. "
+                "Supply an array context to enable proper caching."
+            )
+            actx = MeshmodePyOpenCLArrayContext(actx)
         else:
             raise ValueError
 
-    target_points = flatten(thaw(actx, leaves_to_nodes_lookup.discr.nodes()))
+    target_points = flatten(
+        actx.thaw(leaves_to_nodes_lookup.discr.nodes()),
+        actx,
+        leaf_class=DOFArray,
+    )
 
     traversal = leaves_to_nodes_lookup.trav
     tree = leaves_to_nodes_lookup.trav.tree
 
     dim = tree.dimensions
 
+    from volumential.volume_fmm import interpolate_volume_potential
+
     # infer q_order from tree
     pts_per_box = tree.ntargets // traversal.ntarget_boxes
     assert pts_per_box * traversal.ntarget_boxes == tree.ntargets
 
     # allow for +/- 0.25 floating point error
-    q_order = int(pts_per_box**(1 / dim) + 0.25)
+    q_order = int(pts_per_box ** (1 / dim) + 0.25)
     assert q_order**dim == pts_per_box
 
     interp_p = interpolate_volume_potential(
-            target_points=target_points, traversal=traversal,
-            wrangler=None, potential=potential,
-            potential_in_tree_order=potential_in_tree_order,
-            dim=dim, tree=tree, queue=actx.queue, q_order=q_order,
-            dtype=potential.dtype, lbl_lookup=None,
-            balls_near_box_starts=leaves_to_nodes_lookup.nodes_in_leaf_starts,
-            balls_near_box_lists=leaves_to_nodes_lookup.nodes_in_leaf_lists)
+        target_points=target_points,
+        traversal=traversal,
+        wrangler=None,
+        potential=potential,
+        potential_in_tree_order=potential_in_tree_order,
+        dim=dim,
+        tree=tree,
+        queue=actx.queue,
+        q_order=q_order,
+        dtype=potential.dtype,
+        lbl_lookup=None,
+        balls_near_box_starts=leaves_to_nodes_lookup.nodes_in_leaf_starts,
+        balls_near_box_lists=leaves_to_nodes_lookup.nodes_in_leaf_lists,
+    )
 
     return interp_p
+
 
 # }}} End to meshmode interpolation

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -28,6 +28,7 @@ __doc__ = """
 """
 
 import logging
+from dataclasses import fields
 
 import numpy as np
 
@@ -44,8 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 class NearFieldEvalBase(KernelCacheWrapper):
-    """Base class of near-field evalulator.
-    """
+    """Base class of near-field evalulator."""
 
     default_name = "near_field_eval_base"
 
@@ -57,7 +57,7 @@ class NearFieldEvalBase(KernelCacheWrapper):
         options=None,
         name=None,
         device=None,
-        **kwargs
+        **kwargs,
     ):
         """potential_kind:
 
@@ -95,11 +95,13 @@ class NearFieldEvalBase(KernelCacheWrapper):
 
         # Do not infer scaling rules when user defined rules are present
         if ("kernel_scaling_code" in self.extra_kwargs) or (
-                "kernel_displacement_code" in self.extra_kwargs):
+            "kernel_displacement_code" in self.extra_kwargs
+        ):
             self.extra_kwargs["infer_kernel_scaling"] = False
             # the two codes must be simultaneously given
             assert ("kernel_scaling_code" in self.extra_kwargs) and (
-                "kernel_displacement_code" in self.extra_kwargs)
+                "kernel_displacement_code" in self.extra_kwargs
+            )
 
         self.kname = self.integral_kernel.__repr__()
         self.dim = self.integral_kernel.dim
@@ -124,6 +126,31 @@ class NearFieldFromCSR(NearFieldEvalBase):
     """
 
     default_name = "near_field_from_csr"
+
+    def _base_kernel(self):
+        return self.integral_kernel.get_base_kernel()
+
+    def _is_laplace_kernel(self, dim):
+        from sumpy.kernel import LaplaceKernel
+
+        return isinstance(self._base_kernel(), LaplaceKernel) and self.dim == dim
+
+    def _is_constant_kernel(self, dim):
+        return self.kname in {f"CstKnl{dim}D", f"ConstantKernel{dim}D"} or (
+            self._base_kernel().__class__.__name__ == "ConstantKernel"
+            and self.dim == dim
+        )
+
+    def _is_axis_target_derivative_of_laplace(self, dim):
+        from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
+
+        return (
+            isinstance(self.integral_kernel, AxisTargetDerivative)
+            and isinstance(
+                self.integral_kernel.inner_kernel.get_base_kernel(), LaplaceKernel
+            )
+            and self.dim == dim
+        )
 
     def codegen_vec_component(self, d=None):
         if d is None:
@@ -151,44 +178,38 @@ class NearFieldFromCSR(NearFieldEvalBase):
         return code
 
     def codegen_compute_scaling(self, box_name="sbox"):
-        """box_name: the name of the box whose extent is used.
-        """
+        """box_name: the name of the box whose extent is used."""
         if ("infer_kernel_scaling" in self.extra_kwargs) and (
             self.extra_kwargs["infer_kernel_scaling"]
         ):
             # Laplace 2D
-            if self.kname == "LapKnl2D":
+            if self._is_laplace_kernel(2):
                 logger.info("scaling for LapKnl2D")
                 code = "BOX_extent * BOX_extent / \
                         (table_root_extent * table_root_extent)"
 
-            elif self.kname in (
-                    "AxisTargetDerivative(0, LapKnl2D)",
-                    "AxisTargetDerivative(1, LapKnl2D)"):
+            elif self._is_axis_target_derivative_of_laplace(2):
                 logger.info("scaling for Grad(LapKnl2D)")
                 code = "BOX_extent / table_root_extent"
 
             # Constant 2D
-            elif self.kname == "CstKnl2D":
+            elif self._is_constant_kernel(2):
                 logger.info("scaling for CstKnl2D")
                 code = "BOX_extent * BOX_extent / \
                         (table_root_extent * table_root_extent)"
 
             # Laplace 3D
-            elif self.kname == "LapKnl3D":
+            elif self._is_laplace_kernel(3):
                 logger.info("scaling for Lapknl3D")
                 code = "BOX_extent * BOX_extent / \
                         (table_root_extent * table_root_extent)"
 
-            elif self.kname in (
-                    "AxisTargetDerivative(0, LapKnl3D)",
-                    "AxisTargetDerivative(1, LapKnl3D)",
-                    "AxisTargetDerivative(2, LapKnl3D)"):
+            elif self._is_axis_target_derivative_of_laplace(3):
                 logger.info("scaling for Grad(LapKnl3D)")
                 code = "BOX_extent / table_root_extent"
 
             # Constant 3D
-            elif self.kname == "CstKnl3D":
+            elif self._is_constant_kernel(3):
                 logger.info("scaling for CstKnl3D")
                 code = "BOX_extent * BOX_extent * BOX_extent / \
                         (table_root_extent * table_root_extent * table_root_extent)"
@@ -206,9 +227,11 @@ class NearFieldFromCSR(NearFieldEvalBase):
         elif "kernel_scaling_code" in self.extra_kwargs:
             # user-defined scaling rule
             assert isinstance(self.extra_kwargs["kernel_scaling_code"], str)
-            logger.info("Using scaling rule %s for %s.",
-                        self.extra_kwargs["kernel_scaling_code"], self.kname
-                        )
+            logger.info(
+                "Using scaling rule %s for %s.",
+                self.extra_kwargs["kernel_scaling_code"],
+                self.kname,
+            )
             return self.extra_kwargs["kernel_scaling_code"]
         else:
             logger.info("not scaling for " + self.kname)
@@ -220,24 +243,25 @@ class NearFieldFromCSR(NearFieldEvalBase):
             self.extra_kwargs["infer_kernel_scaling"]
         ):
             # Laplace 2D
-            if self.kname == "LapKnl2D":
+            if self._is_laplace_kernel(2):
                 logger.info("displacement for laplace 2D")
                 s = "-0.5 / PI * scaling * \
                         log(BOX_extent / table_root_extent) * \
                         mode_nmlz[table_lev, sid]"
                 import math
+
                 code = s.replace("PI", str(math.pi))
 
             # Constant 2D
-            elif self.kname == "CstKnl2D":
+            elif self._is_constant_kernel(2):
                 logger.info("no displacement for CstKnl2D")
                 code = "0.0"
             # Laplace 3D
-            elif self.kname == "LapKnl3D":
+            elif self._is_laplace_kernel(3):
                 logger.info("no displacement for LapKnl3D")
                 code = "0.0"
             # Constant 3D
-            elif self.kname == "CstKnl3D":
+            elif self._is_constant_kernel(3):
                 logger.info("no displacement for CstKnl3D")
                 code = "0.0"
             else:
@@ -250,12 +274,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 code = "0.0"
         elif "kernel_displacement_code" in self.extra_kwargs:
             # user-defined displacement rule
-            assert isinstance(
-                    self.extra_kwargs["kernel_displacement_code"], str)
-            logger.info("Using displacement %s for %s.",
-                        self.extra_kwargs["kernel_displacement_code"],
-                        self.kname
-                        )
+            assert isinstance(self.extra_kwargs["kernel_displacement_code"], str)
+            logger.info(
+                "Using displacement %s for %s.",
+                self.extra_kwargs["kernel_displacement_code"],
+                self.kname,
+            )
             code = self.extra_kwargs["kernel_displacement_code"]
         else:
             logger.info("no displacement for " + self.kname)
@@ -269,10 +293,10 @@ class NearFieldFromCSR(NearFieldEvalBase):
             self.extra_kwargs["infer_kernel_scaling"]
         ):
             if (
-                self.kname == "LapKnl2D"
-                or self.kname == "LapKnl3D"
-                or self.kname == "CstKnl2D"
-                or self.kname == "CstKnl3D"
+                self._is_laplace_kernel(2)
+                or self._is_laplace_kernel(3)
+                or self._is_constant_kernel(2)
+                or self._is_constant_kernel(3)
             ):
                 logger.info("scaling from table[0] for " + self.kname)
                 code = "0.0"
@@ -322,7 +346,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
             for tbox
                 <> target_box_id    = target_boxes[tbox]
                 <> box_target_beg   = box_target_starts[target_box_id]
-                <> n_box_targets    = box_target_counts_cumul[target_box_id]
+                <> n_box_targets    = box_target_counts_nonchild[target_box_id]
 
                 <> sbox_begin = neighbor_source_boxes_starts[tbox]
                 <> sbox_end   = neighbor_source_boxes_starts[tbox+1]
@@ -336,17 +360,17 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
                 for tid, sbox
                     <> source_box_id  = source_boxes[sbox]
-                    <> n_box_sources  = box_source_counts_cuml[source_box_id]
+                    <> n_box_sources  = box_source_counts_nonchild[source_box_id]
                     <> box_source_beg = box_source_starts[source_box_id]
 
                     <> sbox_level  = box_levels[source_box_id]
                     <> sbox_extent = root_extent * (1.0 / (2**sbox_level))
 
                     table_lev_tmp = GET_TABLE_LEVEL {id=tab_lev_tmp}
-                    table_lev = round(table_lev_tmp) {id=tab_lev,dep=tab_lev_tmp}
+                    table_lev = table_lev_tmp + 0.5 {id=tab_lev,dep=tab_lev_tmp}
 
                     vec_id_tmp = COMPUTE_VEC_ID {id=vec_id_tmp}
-                    vec_id = round(vec_id_tmp) {id=vec_id,dep=vec_id_tmp}
+                    vec_id = vec_id_tmp + 0.5 {id=vec_id,dep=vec_id_tmp}
                     <> case_id = case_indices[vec_id] {dep=vec_id}
 
                     <> scaling = COMPUTE_SCALING
@@ -356,17 +380,17 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         <> tgt_scaling = COMPUTE_TGT_SCALING
                         <> tgt_displacement = COMPUTE_TGT_DISPLACEMENT
                         tgt_table_lev_tmp = GET_TGT_TABLE_LEVEL {id=tgttab_lev_tmp}
-                        tgt_table_lev = round(tgt_table_lev_tmp) \
+                        tgt_table_lev = tgt_table_lev_tmp + 0.5 \
                                 {id=tgttab_lev,dep=tgttab_lev_tmp}
-                        <> ext_nmlz = exterior_mode_nmlz[tgt_table_lev, tid] \
+                        <> target_point_id = target_point_ids[target_id]
+                        <> ext_nmlz = exterior_mode_nmlz[tgt_table_lev, target_point_id] \
                                 * tgt_scaling + tgt_displacement \
                                 {id=extnmlz,dep=tgttab_lev}
 
                         <> source_id = box_source_beg + sid
-                        <> pair_id = sid * n_box_targets + tid
-                        <> entry_id = case_id * \
-                                      (n_box_targets * n_box_sources) \
-                                      + pair_id
+                        <> source_mode_id = source_mode_ids[source_id]
+                        <> pair_id = source_mode_id * n_q_points + target_point_id
+                        <> entry_id = case_id * (n_q_points * n_q_points) + pair_id
 
                         <> displacement = COMPUTE_DISPLACEMENT
 
@@ -399,13 +423,13 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
                 end
             end
-            """
-            .replace("COMPUTE_VEC_ID", self.codegen_vec_id())
+            """.replace("COMPUTE_VEC_ID", self.codegen_vec_id())
             .replace("COMPUTE_SCALING", self.codegen_compute_scaling())
             .replace("COMPUTE_DISPLACEMENT", self.codegen_compute_displacement())
             .replace("COMPUTE_TGT_SCALING", self.codegen_compute_scaling("tbox"))
-            .replace("COMPUTE_TGT_DISPLACEMENT",
-                    self.codegen_compute_displacement("tbox"))
+            .replace(
+                "COMPUTE_TGT_DISPLACEMENT", self.codegen_compute_displacement("tbox")
+            )
             .replace("GET_TABLE_LEVEL", self.codegen_get_table_level())
             .replace("GET_TGT_TABLE_LEVEL", self.codegen_get_table_level("tbox"))
             .replace("EXTERIOR_PART", self.codegen_exterior_part()),
@@ -417,24 +441,33 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 loopy.TemporaryVariable("tgt_table_lev", np.int32),
                 loopy.TemporaryVariable("tgt_table_lev_tmp", np.float64),
                 loopy.ValueArg("encoding_base", np.int32),
-                loopy.GlobalArg("mode_nmlz", potential_dtype,
-                                "n_tables, n_q_points"),
-                loopy.GlobalArg("exterior_mode_nmlz", potential_dtype,
-                                "n_tables, n_q_points"),
-                loopy.GlobalArg("table_data", potential_dtype,
-                                "n_tables, n_table_entries"),
+                loopy.GlobalArg("mode_nmlz", potential_dtype, "n_tables, n_q_points"),
+                loopy.GlobalArg(
+                    "exterior_mode_nmlz", potential_dtype, "n_tables, n_q_points"
+                ),
+                loopy.GlobalArg(
+                    "table_data", potential_dtype, "n_tables, n_table_entries"
+                ),
                 loopy.GlobalArg("source_boxes", np.int32, "n_source_boxes"),
                 loopy.GlobalArg("box_centers", None, "dim, aligned_nboxes"),
+                loopy.GlobalArg(
+                    "box_source_counts_nonchild", np.int32, "aligned_nboxes"
+                ),
+                loopy.GlobalArg(
+                    "box_target_counts_nonchild", np.int32, "aligned_nboxes"
+                ),
+                loopy.GlobalArg("source_mode_ids", np.int32, "n_source_particles"),
+                loopy.GlobalArg("target_point_ids", np.int32, "n_target_particles"),
                 loopy.ValueArg("aligned_nboxes", np.int32),
                 loopy.ValueArg("table_root_extent", np.float64),
                 loopy.ValueArg(
-                    "dim, n_source_boxes, n_tables, " "n_q_points, n_table_entries",
+                    "dim, n_source_boxes, n_tables, n_q_points, n_table_entries, n_source_particles, n_target_particles",
                     np.int32,
                 ),
                 "...",
             ],
             name="near_field",
-            lang_version=(2018, 2)
+            lang_version=(2018, 2),
         )
 
         # lpknl = loopy.set_options(lpknl, write_code=True)
@@ -445,6 +478,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
     def get_cache_key(self):
         return (
             type(self).__name__,
+            "kernel-v6",
             self.name,
             self.kname,
             "complex_kernel=" + str(self.integral_kernel.is_complex_valued),
@@ -455,25 +489,19 @@ class NearFieldFromCSR(NearFieldEvalBase):
         )
 
     def get_optimized_kernel(self, ncpus=None):
-        if ncpus is None:
-            import multiprocessing
-
-            # NOTE: this detects the number of logical cores, disable hyperthreading
-            # for the optimal performance.
-            ncpus = multiprocessing.cpu_count()
         knl = self.get_kernel()
-        knl = loopy.split_iname(knl, "tbox", ncpus, inner_tag="g.0")
         return knl
 
     def __call__(self, queue, **kwargs):
         knl = self.get_cached_optimized_kernel()
+        entry_knl = knl.default_entrypoint
 
         result = kwargs.pop("result")
         box_centers = kwargs.pop("box_centers")
         box_levels = kwargs.pop("box_levels")
-        box_source_counts_cumul = kwargs.pop("box_source_counts_cumul")
+        box_source_counts_nonchild = kwargs.pop("box_source_counts_nonchild")
         box_source_starts = kwargs.pop("box_source_starts")
-        box_target_counts_cumul = kwargs.pop("box_target_counts_cumul")
+        box_target_counts_nonchild = kwargs.pop("box_target_counts_nonchild")
         box_target_starts = kwargs.pop("box_target_starts")
         case_indices = kwargs.pop("case_indices")
         encoding_base = kwargs.pop("encoding_base")
@@ -487,11 +515,13 @@ class NearFieldFromCSR(NearFieldEvalBase):
         mode_coefs = kwargs.pop("mode_coefs")
         table_data_combined = kwargs.pop("table_data_combined")
         target_boxes = kwargs.pop("target_boxes")
+        source_mode_ids = kwargs.pop("source_mode_ids")
+        target_point_ids = kwargs.pop("target_point_ids")
 
-        integral_kernel_init_kargs = dict(
-            zip(self.integral_kernel.init_arg_names,
-                self.integral_kernel.__getinitargs__())
-        )
+        integral_kernel_init_kargs = {
+            field.name: getattr(self.integral_kernel, field.name)
+            for field in fields(self.integral_kernel)
+        }
 
         # help loopy's type inference
         for key, val in integral_kernel_init_kargs.items():
@@ -502,7 +532,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
         extra_knl_args_from_init = {}
         for key, val in integral_kernel_init_kargs.items():
-            if key in knl.arg_dict:
+            if key in entry_knl.arg_dict:
                 extra_knl_args_from_init[key] = val
 
         evt, res = knl(
@@ -516,9 +546,9 @@ class NearFieldFromCSR(NearFieldEvalBase):
             # db_entry_id=np.zeros(out_pot.shape),
             box_centers=box_centers,
             box_levels=box_levels,
-            box_source_counts_cuml=box_source_counts_cumul,
+            box_source_counts_nonchild=box_source_counts_nonchild,
             box_source_starts=box_source_starts,
-            box_target_counts_cumul=box_target_counts_cumul,
+            box_target_counts_nonchild=box_target_counts_nonchild,
             box_target_starts=box_target_starts,
             case_indices=case_indices,
             n_tables=self.n_tables,
@@ -533,12 +563,16 @@ class NearFieldFromCSR(NearFieldEvalBase):
             root_extent=root_extent,
             source_boxes=neighbor_source_boxes_lists,
             n_source_boxes=len(neighbor_source_boxes_lists),
+            source_mode_ids=source_mode_ids,
+            n_source_particles=len(source_mode_ids),
             source_coefs=mode_coefs,
             table_data=table_data_combined,
             target_boxes=target_boxes,
+            target_point_ids=target_point_ids,
+            n_target_particles=len(target_point_ids),
             table_root_extent=table_root_extent,
-            **extra_knl_args_from_init
-            )
+            **extra_knl_args_from_init,
+        )
 
         res["result"].add_event(evt)
         if isinstance(result, cl.array.Array):

--- a/volumential/meshgen.py
+++ b/volumential/meshgen.py
@@ -34,9 +34,10 @@ Mesh generation
 import logging
 
 import numpy as np
-
 import pyopencl as cl
 from pytools.obj_array import make_obj_array
+
+from volumential.tree_interactive_build import BoxTree, QuadratureOnBoxTree
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ class MeshGenBase:
 
         # plug in dimension-specific details
         self.dimension_specific_setup()
-        self.n_q_points = self.degree ** self.dim
+        self.n_q_points = self.degree**self.dim
 
         self.boxtree = BoxTree()
         self.boxtree.generate_uniform_boxtree(
@@ -94,9 +95,19 @@ class MeshGenBase:
             root_extent=self.root_extent,
             root_vertex=self.root_vertex,
         )
-        self.quadrature = QuadratureOnBoxTree(
-            self.boxtree, self.quadrature_formula
-        )
+        self.quadrature = QuadratureOnBoxTree(self.boxtree, self.quadrature_formula)
+
+    def _leaf_boxes(self):
+        return self.boxtree.active_boxes.get()
+
+    def _leaf_levels(self):
+        return self.boxtree.box_levels.get()[self._leaf_boxes()]
+
+    def _leaf_centers(self):
+        return self.boxtree.box_centers.get()[:, self._leaf_boxes()].T
+
+    def _leaf_side_lengths(self):
+        return self.boxtree.root_extent / (2 ** self._leaf_levels())
 
     def dimension_specific_setup(self):
         pass
@@ -116,15 +127,13 @@ class MeshGenBase:
         return self.quadrature.get_q_weights(self.queue)
 
     def get_q_weights(self):
-        q_weights_dev = self.get_q_weights_dev()
-        return q_weights_dev.get(self.queue)
+        return self.get_q_weights_dev().get(self.queue)
 
     def get_cell_measures_dev(self):
         return self.quadrature.get_cell_measures(self.queue)
 
     def get_cell_measures(self):
-        cell_measures_dev = self.get_cell_measures_dev()
-        return cell_measures_dev.get(self.queue)
+        return self.get_cell_measures_dev().get(self.queue)
 
     def get_cell_centers_dev(self):
         return self.quadrature.get_cell_centers(self.queue)
@@ -147,17 +156,45 @@ class MeshGenBase:
     def n_active_cells(self):
         return self.boxtree.n_active_boxes
 
-    def update_mesh(
-        self, criteria, top_fraction_of_cells, bottom_fraction_of_cells
-    ):
-        # TODO
-        raise NotImplementedError
+    def update_mesh(self, criteria, top_fraction_of_cells, bottom_fraction_of_cells):
+        criteria = np.asarray(criteria)
+        leaf_boxes = self._leaf_boxes()
+
+        if len(criteria) != len(leaf_boxes):
+            raise ValueError("criteria must match the number of active cells")
+
+        nleaves = len(leaf_boxes)
+        if nleaves == 0:
+            return
+
+        refine_count = min(nleaves, int(np.ceil(top_fraction_of_cells * nleaves)))
+        coarsen_count = min(nleaves, int(np.floor(bottom_fraction_of_cells * nleaves)))
+
+        refine_flags = np.zeros(self.boxtree.nboxes, dtype=bool)
+        coarsen_flags = np.zeros(self.boxtree.nboxes, dtype=bool)
+
+        order = np.argsort(criteria)
+
+        if refine_count:
+            refine_leaf_boxes = leaf_boxes[order[-refine_count:]]
+            refine_flags[refine_leaf_boxes] = True
+
+        if coarsen_count:
+            coarsen_leaf_boxes = leaf_boxes[order[:coarsen_count]]
+            coarsen_flags[coarsen_leaf_boxes] = True
+
+        coarsen_flags[refine_flags] = False
+
+        self.boxtree.refine_and_coarsen(
+            refine_flags=refine_flags,
+            coarsen_flags=coarsen_flags,
+            error_on_ignored_flags=False,
+        )
 
     def print_info(self, logging_func=logger.info):
         logging_func("Number of cells: " + str(self.n_cells()))
         logging_func("Number of active cells: " + str(self.n_active_cells()))
-        logging_func("Number of quad points per cell: "
-                + str(self.n_q_points))
+        logging_func("Number of quad points per cell: " + str(self.n_q_points))
 
     def generate_gmsh(self, filename):
         """
@@ -182,8 +219,12 @@ except ImportError as e:
     logger.warning("Meshgen via Deal.II is not present or unusable.")
 
     try:
-        logger.info("Trying out BoxTree.TreeInteractiveBuild interface.")
-        import boxtree.tree_interactive_build  # noqa: F401
+        logger.info("Trying out current boxtree tree-of-boxes interface.")
+        from boxtree import (
+            make_tree_of_boxes_root,
+            refine_and_coarsen_tree_of_boxes,
+            uniformly_refine_tree_of_boxes,
+        )
         from modepy import LegendreGaussQuadrature
 
         provider = "meshgen_boxtree"
@@ -195,8 +236,7 @@ except ImportError as e:
 
     else:
         # {{{ Meshgen via BoxTree
-        logger.info("Using Meshgen via BoxTree interface.")
-        from boxtree.tree_interactive_build import BoxTree, QuadratureOnBoxTree
+        logger.info("Using meshgen via current boxtree tree-of-boxes interface.")
 
         def greet():
             return "Hello from Meshgen via BoxTree!"
@@ -213,32 +253,22 @@ except ImportError as e:
             if "level" in kwargs:
                 nlevels = kwargs["level"]
 
-            tree = BoxTree()
-            tree.generate_uniform_boxtree(
-                queue, nlevels=nlevels, root_extent=2, root_vertex=np.zeros(dim) - 1
-            )
-            quad_rule = LegendreGaussQuadrature(degree - 1)
-            quad = QuadratureOnBoxTree(tree, quad_rule)
-            q_weights = quad.get_q_weights(queue).get(queue)
-            q_points_dev = quad.get_q_points(queue)
-            n_all_q_points = len(q_weights)
-            q_points = np.zeros((n_all_q_points, dim))
-            for d in range(dim):
-                q_points[:, d] = q_points_dev[d].get(queue)
+            mesh_cls = {1: MeshGen1D, 2: MeshGen2D, 3: MeshGen3D}[dim]
+            mesh = mesh_cls(degree, nlevels, a=-1, b=1, queue=queue)
+            q_points = mesh.get_q_points()
+            q_weights = mesh.get_q_weights()
 
             # Adding a placeholder for deprecated point radii
             return (q_points, q_weights, None)
 
         class MeshGen1D(MeshGenBase):
-            """Meshgen in 1D
-            """
+            """Meshgen in 1D"""
 
             def dimension_specific_setup(self):
                 assert self.dim == 1
 
         class MeshGen2D(MeshGenBase):
-            """Meshgen in 2D
-            """
+            """Meshgen in 2D"""
 
             def dimension_specific_setup(self):
                 if self.dim == 1:
@@ -249,8 +279,7 @@ except ImportError as e:
                     assert self.dim == 2
 
         class MeshGen3D(MeshGenBase):
-            """Meshgen in 3D
-            """
+            """Meshgen in 3D"""
 
             def dimension_specific_setup(self):
                 if self.dim == 1:
@@ -269,13 +298,14 @@ else:
 
     def make_uniform_cubic_grid(degree, level, dim, queue=None):
         from volumential.meshgen_dealii import make_uniform_cubic_grid as _mucg
+
         return _mucg(degree, level, dim)
 
 
 # {{{ mesh utils
 
-def build_geometry_info(ctx, queue, dim, q_order, mesh,
-                             bbox=None, a=None, b=None):
+
+def build_geometry_info(ctx, queue, dim, q_order, mesh, bbox=None, a=None, b=None):
     """Build tree, traversal and other geo info for FMM computation,
     given the box mesh over/encompassing the domain.
 
@@ -305,31 +335,36 @@ def build_geometry_info(ctx, queue, dim, q_order, mesh,
     q_points = np.ascontiguousarray(np.transpose(q_points))
 
     q_points = make_obj_array(
-            [cl.array.to_device(queue, q_points[i])
-                for i in range(dim)])
+        [cl.array.to_device(queue, q_points[i]) for i in range(dim)]
+    )
     q_weights = cl.array.to_device(queue, q_weights)
 
     if bbox is None:
         assert np.isscalar(a) and np.isscalar(b)
-        bbox = np.array([[a, b], ] * dim)
+        bbox = np.array([[a, b]] * dim)
 
     from boxtree import TreeBuilder
-    tb = TreeBuilder(ctx)
+    from boxtree.array_context import PyOpenCLArrayContext
+
+    actx = PyOpenCLArrayContext(queue)
+
+    tb = TreeBuilder(actx)
 
     tree, _ = tb(
-        queue,
+        actx,
         particles=q_points,
         targets=q_points,
-        bbox=bbox,
         max_particles_in_box=q_order**dim * (2**dim) - 1,
         kind="adaptive-level-restricted",
     )
 
     from boxtree.traversal import FMMTraversalBuilder
-    tg = FMMTraversalBuilder(ctx)
-    trav, _ = tg(queue, tree)
+
+    tg = FMMTraversalBuilder(actx)
+    trav, _ = tg(actx, tree)
 
     return q_points, q_weights, tree, trav
+
 
 # }}} End mesh utils
 

--- a/volumential/singular_integral_2d.py
+++ b/volumential/singular_integral_2d.py
@@ -21,11 +21,10 @@ THE SOFTWARE.
 """
 
 import logging
+from numbers import Number
 
 import numpy as np
 import scipy as sp
-import scipy.integrate as sint
-from scipy.integrate import quadrature as quad  # noqa:F401
 
 
 __doc__ = """The 2D singular integrals are computed using the transform
@@ -41,6 +40,114 @@ logger = logging.getLogger(__name__)
 quad_points_x = np.array([])
 quad_points_y = np.array([])
 quad_weights = np.array([])
+
+
+def _to_float_or_array(value):
+    if isinstance(value, Number):
+        return float(value)
+
+    arr = np.asarray(value)
+    if arr.ndim == 0 or arr.size == 1:
+        return float(arr.reshape(-1)[0])
+
+    return arr
+
+
+def _meets_tolerance(current, previous, tol, rtol):
+    delta = np.asarray(current) - np.asarray(previous)
+    err = np.linalg.norm(np.ravel(delta), ord=np.inf)
+    scale = np.linalg.norm(np.ravel(np.asarray(current)), ord=np.inf)
+    return err <= tol or err <= rtol * scale, err
+
+
+def adaptive_quadrature(
+    func,
+    a,
+    b,
+    args=(),
+    tol=1.49e-08,
+    rtol=1.49e-08,
+    maxiter=50,
+    vec_func=False,
+    miniter=1,
+):
+    """Approximate the removed ``scipy.integrate.quadrature`` API.
+
+    The legacy code relied on quadrature order refinement semantics from older
+    SciPy. Recreate the essential behavior by increasing the fixed Gauss order
+    until successive iterates stabilize.
+    """
+
+    if maxiter < 1:
+        raise ValueError("maxiter must be positive")
+
+    miniter = max(1, miniter)
+    maxiter = max(miniter, maxiter)
+
+    def wrapped_func(x, *fargs):
+        x_arr = np.atleast_1d(np.asarray(x))
+
+        if vec_func:
+            result = func(x_arr, *fargs)
+        else:
+            result = np.array([func(xi, *fargs) for xi in x_arr])
+
+        result = np.asarray(result)
+        if np.ndim(x) == 0:
+            return result.reshape(-1)[0]
+
+        return result
+
+    previous = None
+    current = None
+    err = np.inf
+    had_comparison = False
+
+    for order in range(miniter, maxiter + 1):
+        current = _to_float_or_array(
+            sp.integrate.fixed_quad(wrapped_func, a, b, args=args, n=order)[0]
+        )
+
+        if previous is not None:
+            had_comparison = True
+            converged, err = _meets_tolerance(current, previous, tol, rtol)
+            if converged:
+                return current, err
+
+        previous = current
+
+    if current is None:
+        raise RuntimeError("adaptive quadrature did not execute any iterations")
+
+    if not had_comparison:
+        err = 0.0
+
+    return current, err
+
+
+quad = adaptive_quadrature
+
+
+def _tensor_product_fixed_quad(
+    func, a, b, c, d, args=(), order_o=1, order_i=1, vec_func=False
+):
+    x_nodes, x_weights = np.polynomial.legendre.leggauss(order_i)
+    y_nodes, y_weights = np.polynomial.legendre.leggauss(order_o)
+
+    x_mapped = 0.5 * (b - a) * x_nodes + 0.5 * (a + b)
+    y_mapped = 0.5 * (d - c) * y_nodes + 0.5 * (c + d)
+
+    if vec_func:
+        x_grid, y_grid = np.meshgrid(x_mapped, y_mapped, indexing="xy")
+        values = np.asarray(func(x_grid, y_grid, *args))
+    else:
+        values = np.empty((order_o, order_i), dtype=np.float64)
+        for iy, y_val in enumerate(y_mapped):
+            for ix, x_val in enumerate(x_mapped):
+                values[iy, ix] = _to_float_or_array(func(x_val, y_val, *args))
+
+    weights = np.outer(y_weights, x_weights)
+    return 0.25 * (b - a) * (d - c) * np.sum(weights * values, axis=(-2, -1))
 
 
 def update_qquad_leggauss_formula(deg1, deg2):
@@ -120,33 +227,41 @@ def qquad(
     l2 = d - c
     assert l1 > 0
     assert l2 > 0
-    toli = tol / l2
-    rtoli = rtol / l2
 
     if method == "Adaptive":
+        previous = None
+        val = None
+        err = np.inf
+        had_comparison = False
+        max_steps = max(maxiteri - miniteri, maxitero - minitero) + 1
 
-        # Using lambda for readability
-        def outer_integrand(y):
-            return sint.quadrature(
-                lambda x: func(x, y, *args),
+        for istep in range(max_steps):
+            order_i = min(maxiteri, miniteri + istep)
+            order_o = min(maxitero, minitero + istep)
+            val = _tensor_product_fixed_quad(
+                func,
                 a,
                 b,
-                (),
-                toli,
-                rtoli,
-                maxiteri,
-                vec_func,
-                miniteri,
-            )[0]
+                c,
+                d,
+                args=args,
+                order_o=order_o,
+                order_i=order_i,
+                vec_func=vec_func,
+            )
 
-        # Is there a simple way to retrieve err info from the inner quad calls?
+            if previous is not None:
+                had_comparison = True
+                converged, err = _meets_tolerance(val, previous, tol, rtol)
+                if converged:
+                    break
 
-        val, err = sint.quadrature(
-            outer_integrand, c, d, (), tol, rtol, maxitero, vec_func, minitero
-        )
+            previous = val
+
+        if not had_comparison:
+            err = 0.0
 
     elif method == "Gauss":
-
         # Gauss quadrature with orders equal to maxiters
 
         # Using lambda for readability
@@ -164,7 +279,6 @@ def qquad(
         assert err is None
 
     else:
-
         raise NotImplementedError("Unsupported quad method: " + method)
 
     return (val, err)
@@ -177,22 +291,22 @@ def qquad(
 
 def solve_affine_map_2d(source_tria, target_tria):
     """Computes the affine map and its inverse that maps the source_tria to
-       target_tria.
+    target_tria.
 
-       :param source_tria: The triangle to be mapped.
-       :type source_tria:
-            tuple(tuple(float,float),tuple(float,float),tuple(float,float)).
-       :param target_tria: The triangle to map to.
-       :type target_tria:
-            tuple(tuple(float,float),tuple(float,float),tuple(float,float)).
+    :param source_tria: The triangle to be mapped.
+    :type source_tria:
+         tuple(tuple(float,float),tuple(float,float),tuple(float,float)).
+    :param target_tria: The triangle to map to.
+    :type target_tria:
+         tuple(tuple(float,float),tuple(float,float),tuple(float,float)).
 
-       :returns:
-        - **mapping**: the forward map.
-        - **J**: the Jacobian.
-        - **invmap**: the inverse map.
-        - **invJ**: the Jacobian of inverse map.
-       :rtype:
-        tuple(lambda, float, lambda, float)
+    :returns:
+     - **mapping**: the forward map.
+     - **J**: the Jacobian.
+     - **invmap**: the inverse map.
+     - **invJ**: the Jacobian of inverse map.
+    :rtype:
+     tuple(lambda, float, lambda, float)
     """
     assert len(source_tria) == 3
     for p in source_tria:
@@ -261,15 +375,15 @@ def solve_affine_map_2d(source_tria, target_tria):
 
 def tria2rect_map_2d():
     """Returns the mapping and its inverse that maps a template triangle to a
-       template rectangle.
+    template rectangle.
 
-            - Template triangle [T]: (0,0)--(1,0)--(0,1)--(0,0)
-            - Template rectangle [R]: (0,0)--(1,0)--(1,pi/2)--(0,pi/2)--(0,0)
+         - Template triangle [T]: (0,0)--(1,0)--(0,1)--(0,0)
+         - Template rectangle [R]: (0,0)--(1,0)--(1,pi/2)--(0,pi/2)--(0,0)
 
-       :returns: The mapping, its Jacobian, its inverse, and the Jacobian of its
-                inverse. Note that the Jacobians are returned as lambdas since
-                they are not constants.
-       :rtype: tuple(lambda, lambda, lambda, lambda)
+    :returns: The mapping, its Jacobian, its inverse, and the Jacobian of its
+             inverse. Note that the Jacobians are returned as lambdas since
+             they are not constants.
+    :rtype: tuple(lambda, lambda, lambda, lambda)
     """
 
     # (x,y) --> (rho, theta): T --> R
@@ -293,11 +407,11 @@ def tria2rect_map_2d():
 def is_in_t(pt):
     """Checks if a point is in the template triangle T.
 
-       :param pt: The point to be checked.
-       :type pt: tuple(float,float).
+    :param pt: The point to be checked.
+    :type pt: tuple(float,float).
 
-       :returns: True if pt is in T.
-       :rtype: bool.
+    :returns: True if pt is in T.
+    :rtype: bool.
     """
     flag = True
     if pt[0] < 0 or pt[1] < 0:
@@ -310,11 +424,11 @@ def is_in_t(pt):
 def is_in_r(pt, a=0, b=1, c=0, d=np.pi / 2):
     """Checks if a point is in the (template) rectangle R.
 
-       :param pt: The point to be checked.
-       :type pt: tuple(float,float).
+    :param pt: The point to be checked.
+    :type pt: tuple(float,float).
 
-       :returns: True if pt is in R.
-       :rtype: bool.
+    :returns: True if pt is in R.
+    :rtype: bool.
     """
     flag = True
     if pt[0] < a or pt[1] < c:

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -49,12 +49,13 @@ class ConstantKernel(ExpressionKernel):
         expr = 1
         scaling = 1
 
-        super().__init__(
-            dim, expression=expr,
-            global_scaling_const=scaling, is_complex_valued=False
-        )
+        super().__init__(dim, expression=expr, global_scaling_const=scaling)
 
     has_efficient_scale_adjustment = True
+
+    @property
+    def is_complex_valued(self):
+        return False
 
     def adjust_for_kernel_scaling(self, expr, rscale, nderivatives):
         return expr / rscale
@@ -87,11 +88,15 @@ class NearFieldInteractionTableManager:
     back to read-only if that fails.
     """
 
-    def __init__(self, dataset_filename="nft.hdf5",
-            root_extent=1, dtype=np.float64,
-            read_only="auto", **kwargs):
-        """Constructor.
-        """
+    def __init__(
+        self,
+        dataset_filename="nft.hdf5",
+        root_extent=1,
+        dtype=np.float64,
+        read_only="auto",
+        **kwargs,
+    ):
+        """Constructor."""
         self.dtype = dtype
 
         self.filename = dataset_filename
@@ -102,6 +107,7 @@ class NearFieldInteractionTableManager:
                 self.datafile = hdf.File(self.filename, "a")
             except OSError as e:
                 from warnings import warn
+
                 warn("Trying to open in read/write mode failed: %s" % str(e))
                 warn("Opening table dataset %s in read-only mode." % self.filename)
                 self.datafile = hdf.File(self.filename, "r")
@@ -115,9 +121,7 @@ class NearFieldInteractionTableManager:
 
         # If the file exists, it must be for the same root_extent
         if "root_extent" in self.datafile.attrs:
-            if not abs(
-                    self.datafile.attrs["root_extent"] - self.root_extent
-                    ) < 1e-15:
+            if not abs(self.datafile.attrs["root_extent"] - self.root_extent) < 1e-15:
                 raise RuntimeError(
                     "The table cache file "
                     + self.filename
@@ -159,7 +163,7 @@ class NearFieldInteractionTableManager:
         force_recompute=False,
         compute_method=None,
         queue=None,
-        **kwargs
+        **kwargs,
     ):
         """Primary user interface. Get the specified table regardless of how.
         In the case of a cache miss or a forced re-computation, the method
@@ -206,7 +210,7 @@ class NearFieldInteractionTableManager:
                 source_box_level,
                 compute_method,
                 queue=queue,
-                **kwargs
+                **kwargs,
             )
 
         elif force_recompute:
@@ -219,23 +223,21 @@ class NearFieldInteractionTableManager:
                 source_box_level,
                 compute_method,
                 queue=queue,
-                **kwargs
+                **kwargs,
             )
 
         else:
             try:
-
                 table = self.load_saved_table(
                     dim,
                     kernel_type,
                     q_order,
                     source_box_level,
                     compute_method,
-                    **kwargs
+                    **kwargs,
                 )
 
             except KeyError:
-
                 import traceback
 
                 logger.debug(traceback.format_exc())
@@ -249,7 +251,7 @@ class NearFieldInteractionTableManager:
                     source_box_level,
                     compute_method,
                     queue=queue,
-                    **kwargs
+                    **kwargs,
                 )
 
             # Ensure loaded table matches requirements specified in kwargs
@@ -317,10 +319,9 @@ class NearFieldInteractionTableManager:
         q_order,
         source_box_level=0,
         compute_method=None,
-        **kwargs
+        **kwargs,
     ):
-        """Load a table saved in the hdf5 file.
-        """
+        """Load a table saved in the hdf5 file."""
 
         q_order = int(q_order)
         assert q_order >= 1
@@ -372,7 +373,7 @@ class NearFieldInteractionTableManager:
             kernel_type=self.get_kernel_function_type(dim, kernel_type),
             sumpy_kernel=sumpy_knl,
             source_box_extent=self.root_extent * (2 ** (-source_box_level)),
-            **self.table_extra_kwargs
+            **self.table_extra_kwargs,
         )
 
         assert abs(table.source_box_extent - grp.attrs["source_box_extent"]) < 1e-15
@@ -384,8 +385,7 @@ class NearFieldInteractionTableManager:
         if "mode_normalizers" in grp:
             table.mode_normalizers[...] = grp["mode_normalizers"]
         if "kernel_exterior_normalizers" in grp:
-            table.kernel_exterior_normalizers[...] = \
-                    grp["kernel_exterior_normalizers"]
+            table.kernel_exterior_normalizers[...] = grp["kernel_exterior_normalizers"]
 
         tmp_case_vecs = np.array(table.interaction_case_vecs)
         tmp_case_vecs[...] = grp["interaction_case_vecs"]
@@ -438,8 +438,7 @@ class NearFieldInteractionTableManager:
         return knl_func
 
     def get_sumpy_kernel(self, dim, kernel_type):
-        """Sumpy (symbolic) version of the kernel.
-        """
+        """Sumpy (symbolic) version of the kernel."""
 
         if kernel_type == "Laplace":
             from sumpy.kernel import LaplaceKernel
@@ -487,7 +486,9 @@ class NearFieldInteractionTableManager:
 
         elif kernel_type == "Cahn-Hilliard-Laplacian":
             from sumpy.kernel import (
-                FactorizedBiharmonicKernel, LaplacianTargetDerivative)
+                FactorizedBiharmonicKernel,
+                LaplacianTargetDerivative,
+            )
 
             return LaplacianTargetDerivative(FactorizedBiharmonicKernel(dim))
 
@@ -498,8 +499,10 @@ class NearFieldInteractionTableManager:
 
         elif kernel_type == "Cahn-Hilliard-Laplacian-Dx":
             from sumpy.kernel import (
-                AxisTargetDerivative, FactorizedBiharmonicKernel,
-                LaplacianTargetDerivative)
+                AxisTargetDerivative,
+                FactorizedBiharmonicKernel,
+                LaplacianTargetDerivative,
+            )
 
             return AxisTargetDerivative(
                 0, LaplacianTargetDerivative(FactorizedBiharmonicKernel(dim))
@@ -507,8 +510,10 @@ class NearFieldInteractionTableManager:
 
         elif kernel_type == "Cahn-Hilliard-Laplacian-Dy":
             from sumpy.kernel import (
-                AxisTargetDerivative, FactorizedBiharmonicKernel,
-                LaplacianTargetDerivative)
+                AxisTargetDerivative,
+                FactorizedBiharmonicKernel,
+                LaplacianTargetDerivative,
+            )
 
             return AxisTargetDerivative(
                 1, LaplacianTargetDerivative(FactorizedBiharmonicKernel(dim))
@@ -548,8 +553,7 @@ class NearFieldInteractionTableManager:
             return None
 
     def update_dataset(self, group, dataset_name, data_array):
-        """Update stored data.
-        """
+        """Update stored data."""
         if data_array is None:
             logger.debug("No data to save for %s" % dataset_name)
             return
@@ -574,10 +578,9 @@ class NearFieldInteractionTableManager:
         compute_method=None,
         cl_ctx=None,
         queue=None,
-        **kwargs
+        **kwargs,
     ):
-        """Performs the precomputation and stores the results.
-        """
+        """Performs the precomputation and stores the results."""
 
         if compute_method is None:
             logger.debug("Using default compute_method (Transform)")
@@ -620,7 +623,7 @@ class NearFieldInteractionTableManager:
             sumpy_kernel=sumpy_knl,
             build_method=compute_method,
             source_box_extent=self.root_extent * (2 ** (-source_box_level)),
-            **self.table_extra_kwargs
+            **self.table_extra_kwargs,
         )
 
         if 0:
@@ -644,8 +647,7 @@ class NearFieldInteractionTableManager:
         grp.attrs["dim"] = table.dim
         grp.attrs["n_pairs"] = table.n_pairs
         grp.attrs["source_box_level"] = source_box_level
-        grp.attrs["source_box_extent"] = self.root_extent * (
-                2 ** (-source_box_level))
+        grp.attrs["source_box_extent"] = self.root_extent * (2 ** (-source_box_level))
 
         for key, kval in kwargs.items():
             if isinstance(kval, (int, float, complex, str)):
@@ -654,10 +656,10 @@ class NearFieldInteractionTableManager:
         self.update_dataset(grp, "q_points", table.q_points)
         self.update_dataset(grp, "data", table.data)
         self.update_dataset(grp, "mode_normalizers", table.mode_normalizers)
-        self.update_dataset(grp, "kernel_exterior_normalizers",
-                table.kernel_exterior_normalizers)
-        self.update_dataset(grp, "interaction_case_vecs",
-                table.interaction_case_vecs)
+        self.update_dataset(
+            grp, "kernel_exterior_normalizers", table.kernel_exterior_normalizers
+        )
+        self.update_dataset(grp, "interaction_case_vecs", table.interaction_case_vecs)
         self.update_dataset(grp, "case_indices", table.case_indices)
 
         distinct_numbers = set()

--- a/volumential/tree_interactive_build.py
+++ b/volumential/tree_interactive_build.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import numpy as np
+
+import pyopencl as cl
+import pyopencl.array
+from pytools.obj_array import make_obj_array
+
+from boxtree import (
+    Tree,
+    box_flags_enum,
+    make_tree_of_boxes_root,
+    refine_and_coarsen_tree_of_boxes,
+    uniformly_refine_tree_of_boxes,
+)
+
+
+_COARSENING_DISABLED_WARNING = (
+    "Current upstream boxtree tree-of-boxes coarsening is incompatible with "
+    "volumential's historical adaptive mesh workflow; retrying with refinement "
+    "only."
+)
+
+
+def _leaf_boxes_numpy(tob):
+    return np.where(np.all(tob.box_child_ids == 0, axis=0))[0]
+
+
+def _box_size(root_extent, level):
+    return root_extent * (0.5 ** int(level))
+
+
+def _are_adjacent(root_extent, levels, centers, ibox, jbox, tol=1.0e-15):
+    si = _box_size(root_extent, levels[ibox])
+    sj = _box_size(root_extent, levels[jbox])
+    dist = np.max(np.abs(centers[:, ibox] - centers[:, jbox]))
+    return dist <= 0.5 * (si + sj) + tol
+
+
+def _enforce_level_restriction(tob):
+    while True:
+        leaves = _leaf_boxes_numpy(tob)
+        refine_flags = np.zeros(tob.nboxes, dtype=bool)
+
+        for i, ibox in enumerate(leaves):
+            for jbox in leaves[i + 1 :]:
+                li = int(tob.box_levels[ibox])
+                lj = int(tob.box_levels[jbox])
+                if abs(li - lj) <= 1:
+                    continue
+                if not _are_adjacent(
+                    tob.root_extent, tob.box_levels, tob.box_centers, ibox, jbox
+                ):
+                    continue
+                if li < lj:
+                    refine_flags[ibox] = True
+                else:
+                    refine_flags[jbox] = True
+
+        if not np.any(refine_flags):
+            box_levels = tob.box_levels
+            box_centers = tob.box_centers
+            has_children = np.any(tob.box_child_ids != 0, axis=0)
+            leaves_set = set(map(int, leaves))
+
+            for ilevel in np.unique(box_levels.astype(np.int32)):
+                level_boxes = np.where(box_levels == ilevel)[0]
+                nonleaf_level_boxes = [
+                    ibox for ibox in level_boxes if has_children[ibox]
+                ]
+                leaf_level_boxes = [ibox for ibox in level_boxes if ibox in leaves_set]
+                for ibox in nonleaf_level_boxes:
+                    for jbox in leaf_level_boxes:
+                        if ibox == jbox:
+                            continue
+                        if _are_adjacent(
+                            tob.root_extent, box_levels, box_centers, ibox, jbox
+                        ):
+                            refine_flags[jbox] = True
+
+            if not np.any(refine_flags):
+                return tob
+
+        tob = refine_and_coarsen_tree_of_boxes(tob, refine_flags=refine_flags)
+
+
+def _enforce_same_level_colleagues(tob):
+    while True:
+        box_levels = tob.box_levels
+        box_centers = tob.box_centers
+        has_children = np.any(tob.box_child_ids != 0, axis=0)
+        refine_flags = np.zeros(tob.nboxes, dtype=bool)
+
+        for ibox in range(tob.nboxes):
+            if not has_children[ibox]:
+                continue
+
+            level = int(box_levels[ibox])
+            for jbox in range(tob.nboxes):
+                if int(box_levels[jbox]) != level:
+                    continue
+                if not has_children[jbox]:
+                    continue
+                if ibox == jbox:
+                    continue
+                if not _are_adjacent(
+                    tob.root_extent, box_levels, box_centers, ibox, jbox
+                ):
+                    continue
+
+                for child in tob.box_child_ids[:, ibox]:
+                    if child != 0 and np.all(tob.box_child_ids[:, child] == 0):
+                        refine_flags[int(child)] = True
+                for child in tob.box_child_ids[:, jbox]:
+                    if child != 0 and np.all(tob.box_child_ids[:, child] == 0):
+                        refine_flags[int(child)] = True
+
+        if not np.any(refine_flags):
+            return tob
+
+        tob = refine_and_coarsen_tree_of_boxes(tob, refine_flags=refine_flags)
+
+
+class BoxTree:
+    """Compatibility wrapper for the old boxtree interactive build API.
+
+    This vendors the small portion of the old ``xywei/boxtree`` API that
+    ``volumential`` relied on for adaptive mesh generation, while using current
+    upstream ``boxtree.tree_of_boxes`` data structures internally.
+    """
+
+    def __init__(self):
+        self.queue: cl.CommandQueue | None = None
+        self.root_vertex = None
+        self.root_extent = None
+        self.box_id_dtype = np.int32
+        self.box_level_dtype = np.int32
+        self.coord_dtype = np.float64
+        self._tree = None
+
+    def generate_uniform_boxtree(
+        self,
+        queue,
+        root_vertex=np.zeros(2),
+        root_extent=1,
+        nlevels=1,
+        box_id_dtype=np.int32,
+        box_level_dtype=np.int32,
+        coord_dtype=np.float64,
+    ):
+        self.queue = queue
+        self.root_vertex = np.asarray(root_vertex, dtype=coord_dtype)
+        self.root_extent = coord_dtype(root_extent)
+        self.box_id_dtype = box_id_dtype
+        self.box_level_dtype = box_level_dtype
+        self.coord_dtype = coord_dtype
+
+        bbox = (self.root_vertex, self.root_vertex + self.root_extent)
+        tree = make_tree_of_boxes_root(bbox)
+        for _ in range(max(0, nlevels - 1)):
+            tree = uniformly_refine_tree_of_boxes(tree)
+
+        self._tree = tree
+        self._sync_device_views()
+
+    def refine_and_coarsen(
+        self, refine_flags, coarsen_flags, error_on_ignored_flags=False
+    ):
+        if isinstance(refine_flags, cl.array.Array):
+            refine_flags = refine_flags.get()
+        if isinstance(coarsen_flags, cl.array.Array):
+            coarsen_flags = coarsen_flags.get()
+
+        refine_flags = np.asarray(refine_flags, dtype=bool)
+        coarsen_flags = np.asarray(coarsen_flags, dtype=bool)
+
+        try:
+            self._tree = refine_and_coarsen_tree_of_boxes(
+                self._tree,
+                refine_flags=refine_flags,
+                coarsen_flags=coarsen_flags,
+                error_on_ignored_flags=error_on_ignored_flags,
+            )
+        except OverflowError:
+            import warnings
+
+            warnings.warn(_COARSENING_DISABLED_WARNING, stacklevel=2)
+            self._tree = refine_and_coarsen_tree_of_boxes(
+                self._tree,
+                refine_flags=refine_flags,
+                coarsen_flags=np.zeros_like(coarsen_flags),
+                error_on_ignored_flags=error_on_ignored_flags,
+            )
+        self._sync_device_views()
+
+    def _sync_device_views(self):
+        assert self.queue is not None
+        assert self._tree is not None
+
+        self._tree = _enforce_level_restriction(self._tree)
+        self._tree = _prune_unreachable_boxes(self._tree)
+
+        box_levels = np.asarray(self._tree.box_levels, dtype=self.box_level_dtype)
+        box_centers = np.asarray(self._tree.box_centers, dtype=self.coord_dtype)
+        active_boxes = np.asarray(self._tree.leaf_boxes, dtype=self.box_id_dtype)
+
+        self.box_levels = cl.array.to_device(self.queue, box_levels)
+        self.box_centers = cl.array.to_device(self.queue, box_centers)
+        self.active_boxes = cl.array.to_device(self.queue, active_boxes)
+
+        nlevels = int(box_levels.max()) + 1 if box_levels.size else 0
+        level_boxes = []
+        for ilevel in range(nlevels):
+            ids = np.where(box_levels == ilevel)[0].astype(self.box_id_dtype)
+            level_boxes.append(cl.array.to_device(self.queue, ids))
+        self.level_boxes = make_obj_array(level_boxes)
+
+    @property
+    def dimensions(self):
+        return self._tree.dimensions
+
+    @property
+    def nboxes(self):
+        return self._tree.nboxes
+
+    @property
+    def nlevels(self):
+        return int(np.max(self._tree.box_levels)) + 1
+
+    @property
+    def n_active_boxes(self):
+        return len(self._tree.leaf_boxes)
+
+    def get_box_extent(self, ibox):
+        if isinstance(ibox, cl.array.Array):
+            ibox = int(ibox.get())
+
+        level = int(self._tree.box_levels[ibox])
+        box_size = self.root_extent / (2**level)
+        center = self._tree.box_centers[:, ibox]
+        extent_low = center - 0.5 * box_size
+        extent_high = center + 0.5 * box_size
+        return extent_low.astype(self.coord_dtype), extent_high.astype(self.coord_dtype)
+
+
+class QuadratureOnBoxTree:
+    def __init__(self, boxtree, quadrature_formula=None):
+        self.boxtree = boxtree
+
+        if quadrature_formula is None:
+            from modepy import LegendreGaussQuadrature
+
+            quadrature_formula = LegendreGaussQuadrature(0)
+
+        self.quadrature_formula = quadrature_formula
+
+    def _reference_nodes(self):
+        return np.asarray(self.quadrature_formula.nodes)
+
+    def _reference_weights(self):
+        return np.asarray(self.quadrature_formula.weights)
+
+    def _leaf_boxes(self):
+        return np.asarray(self.boxtree._tree.leaf_boxes)
+
+    def _leaf_levels(self):
+        return np.asarray(self.boxtree._tree.box_levels[self._leaf_boxes()])
+
+    def _leaf_centers(self):
+        return np.asarray(self.boxtree._tree.box_centers[:, self._leaf_boxes()])
+
+    def get_q_points(self, queue):
+        q_nodes = self._reference_nodes()
+        dim = self.boxtree.dimensions
+        centers = self._leaf_centers().T
+        side_lengths = self.boxtree.root_extent / (2 ** self._leaf_levels())
+
+        if dim == 1:
+            grids = [q_nodes[:, None]]
+        else:
+            grids = np.meshgrid(*([q_nodes] * dim), indexing="ij")
+
+        ref_points = np.vstack([g.ravel() for g in grids]).T
+        q_points = (
+            centers[:, None, :]
+            + 0.5 * side_lengths[:, None, None] * ref_points[None, :, :]
+        )
+        q_points = q_points.reshape(-1, dim).T
+        return make_obj_array(
+            [cl.array.to_device(queue, np.ascontiguousarray(comp)) for comp in q_points]
+        )
+
+    def get_q_weights(self, queue):
+        dim = self.boxtree.dimensions
+        q_weights_1d = self._reference_weights()
+        grids = np.meshgrid(*([q_weights_1d] * dim), indexing="ij")
+        ref_weights = np.prod(np.array(grids), axis=0).ravel()
+        side_lengths = self.boxtree.root_extent / (2 ** self._leaf_levels())
+        weights = (
+            ((0.5 * side_lengths) ** dim)[:, None] * ref_weights[None, :]
+        ).ravel()
+        return cl.array.to_device(queue, weights.astype(self.boxtree.coord_dtype))
+
+    def get_cell_centers(self, queue):
+        centers = self._leaf_centers()
+        return make_obj_array(
+            [cl.array.to_device(queue, np.ascontiguousarray(comp)) for comp in centers]
+        )
+
+    def get_cell_measures(self, queue):
+        dim = self.boxtree.dimensions
+        side_lengths = self.boxtree.root_extent / (2 ** self._leaf_levels())
+        measures = (side_lengths**dim).astype(self.boxtree.coord_dtype)
+        return cl.array.to_device(queue, measures)
+
+
+def _leaf_dfs_order(box_child_ids, ibox=0):
+    children = [int(ch) for ch in box_child_ids[:, ibox] if int(ch) != 0]
+    if not children:
+        return [ibox]
+
+    result = []
+    for child in children:
+        result.extend(_leaf_dfs_order(box_child_ids, child))
+    return result
+
+
+def _level_order_boxes(box_child_ids):
+    result = []
+    current = [0]
+    while current:
+        result.extend(current)
+        nxt = []
+        for ibox in current:
+            nxt.extend(int(ch) for ch in box_child_ids[:, ibox] if int(ch) != 0)
+        current = nxt
+    return result
+
+
+def _prune_unreachable_boxes(tob):
+    reachable = _level_order_boxes(tob.box_child_ids)
+    if len(reachable) == tob.nboxes:
+        return tob
+
+    reachable = np.array(reachable, dtype=np.int32)
+    old_to_new = np.full(tob.nboxes, -1, dtype=np.int32)
+    old_to_new[reachable] = np.arange(len(reachable), dtype=np.int32)
+
+    box_centers = tob.box_centers[:, reachable]
+    box_levels = tob.box_levels[reachable]
+    old_parents = tob.box_parent_ids[reachable]
+    box_parent_ids = np.where(old_parents < 0, -1, old_to_new[old_parents])
+    old_child_ids = tob.box_child_ids[:, reachable]
+    box_child_ids = np.where(old_child_ids == 0, 0, old_to_new[old_child_ids])
+
+    from boxtree.tree import TreeOfBoxes
+
+    return TreeOfBoxes(
+        box_centers=box_centers,
+        root_extent=tob.root_extent,
+        box_parent_ids=box_parent_ids,
+        box_child_ids=box_child_ids,
+        box_levels=box_levels,
+        box_flags=np.asarray(
+            _compute_box_flags(box_child_ids), dtype=box_flags_enum.dtype
+        ),
+        level_start_box_nrs=None,
+        box_id_dtype=tob.box_id_dtype,
+        box_level_dtype=tob.box_level_dtype,
+        coord_dtype=tob.coord_dtype,
+        sources_have_extent=tob.sources_have_extent,
+        targets_have_extent=tob.targets_have_extent,
+        extent_norm=tob.extent_norm,
+        stick_out_factor=tob.stick_out_factor,
+        _is_pruned=tob._is_pruned,
+    )
+
+
+def _compute_box_flags(box_child_ids):
+    box_flags = np.full(
+        box_child_ids.shape[1],
+        box_flags_enum.IS_SOURCE_BOX | box_flags_enum.IS_TARGET_BOX,
+        dtype=box_flags_enum.dtype,
+    )
+    has_children = np.any(box_child_ids != 0, axis=0)
+    box_flags[has_children] |= (
+        box_flags_enum.HAS_SOURCE_CHILD_BOXES | box_flags_enum.HAS_TARGET_CHILD_BOXES
+    )
+    box_flags[~has_children] |= box_flags_enum.IS_LEAF_BOX
+    return box_flags
+
+
+def build_particle_tree_from_box_tree(actx, box_tree, q_points_host):
+    tob = box_tree._tree
+    dim = tob.dimensions
+    n_q_points = q_points_host.shape[0] // len(tob.leaf_boxes)
+    box_level_dtype = np.dtype(np.uint8)
+
+    box_order_old = _level_order_boxes(tob.box_child_ids)
+    old_to_new = np.empty(tob.nboxes, dtype=tob.box_id_dtype)
+    for new_id, old_id in enumerate(box_order_old):
+        old_to_new[old_id] = new_id
+
+    leaf_order_old = _leaf_dfs_order(tob.box_child_ids)
+    leaf_order_old = [
+        ibox for ibox in leaf_order_old if np.all(tob.box_child_ids[:, ibox] == 0)
+    ]
+    old_leaf_boxes = list(map(int, tob.leaf_boxes))
+    old_leaf_pos = {ibox: i for i, ibox in enumerate(old_leaf_boxes)}
+    particle_perm = np.concatenate(
+        [
+            np.arange(
+                old_leaf_pos[ibox] * n_q_points,
+                (old_leaf_pos[ibox] + 1) * n_q_points,
+                dtype=tob.box_id_dtype,
+            )
+            for ibox in leaf_order_old
+        ]
+    )
+    inverse_particle_perm = np.empty_like(particle_perm)
+    inverse_particle_perm[particle_perm] = np.arange(
+        len(particle_perm), dtype=tob.box_id_dtype
+    )
+
+    leaf_pos = {ibox: i for i, ibox in enumerate(leaf_order_old)}
+
+    box_target_starts = np.zeros(tob.nboxes, dtype=tob.box_id_dtype)
+    box_target_counts_nonchild = np.zeros(tob.nboxes, dtype=tob.box_id_dtype)
+    box_target_counts_cumul = np.zeros(tob.nboxes, dtype=tob.box_id_dtype)
+
+    def assign_particle_ranges(ibox):
+        children = [int(ch) for ch in tob.box_child_ids[:, ibox] if int(ch) != 0]
+        if not children:
+            start = leaf_pos[ibox] * n_q_points
+            count = n_q_points
+            box_target_starts[ibox] = start
+            box_target_counts_nonchild[ibox] = count
+            box_target_counts_cumul[ibox] = count
+            return start, count
+
+        child_ranges = [assign_particle_ranges(ch) for ch in children]
+        starts = [start for start, _ in child_ranges]
+        counts = [count for _, count in child_ranges]
+        start = min(starts)
+        stop = max(st + ct for st, ct in child_ranges)
+        assert sum(counts) == stop - start
+        box_target_starts[ibox] = start
+        box_target_counts_nonchild[ibox] = 0
+        box_target_counts_cumul[ibox] = stop - start
+        return start, stop - start
+
+    assign_particle_ranges(0)
+
+    box_source_starts = box_target_starts.copy()
+    box_source_counts_nonchild = box_target_counts_nonchild.copy()
+    box_source_counts_cumul = box_target_counts_cumul.copy()
+
+    def equalize_levels(ibox):
+        children = [int(ch) for ch in tob.box_child_ids[:, ibox] if int(ch) != 0]
+        if not children:
+            return int(tob.box_levels[ibox])
+
+        child_levels = [equalize_levels(ch) for ch in children]
+        max_level = max(child_levels)
+        for child, child_level in zip(children, child_levels):
+            if child_level < max_level:
+                box_target_counts_nonchild[child] = 0
+                box_source_counts_nonchild[child] = 0
+                box_target_counts_cumul[child] = box_target_counts_cumul[child]
+                box_source_counts_cumul[child] = box_source_counts_cumul[child]
+        return max_level
+
+    equalize_levels(0)
+
+    reordered_points = q_points_host[particle_perm]
+    particle_id_dtype = np.int32
+
+    sources = make_obj_array(
+        [
+            actx.from_numpy(np.ascontiguousarray(reordered_points[:, iaxis]))
+            for iaxis in range(dim)
+        ]
+    )
+
+    level_counts = np.bincount(
+        np.asarray(tob.box_levels, dtype=np.int32),
+        minlength=int(np.max(tob.box_levels)) + 1,
+    )
+    level_start_box_nrs = np.zeros(len(level_counts) + 1, dtype=tob.box_id_dtype)
+    level_start_box_nrs[1:] = np.cumsum(level_counts)
+
+    aligned_nboxes = ((tob.nboxes + 31) // 32) * 32
+
+    box_centers = np.zeros((dim, aligned_nboxes), dtype=box_tree.coord_dtype)
+    box_centers[:, : tob.nboxes] = tob.box_centers[:, box_order_old]
+
+    box_child_ids = np.zeros((2**dim, aligned_nboxes), dtype=tob.box_id_dtype)
+    old_child_ids = tob.box_child_ids[:, box_order_old]
+    mapped_child_ids = np.where(old_child_ids != 0, old_to_new[old_child_ids], 0)
+    box_child_ids[:, : tob.nboxes] = mapped_child_ids
+
+    box_parent_ids = np.zeros(tob.nboxes, dtype=tob.box_id_dtype)
+    for parent in range(tob.nboxes):
+        for child in box_child_ids[:, parent]:
+            if child != 0:
+                box_parent_ids[int(child)] = parent
+
+    box_flags = np.zeros(tob.nboxes, dtype=box_flags_enum.dtype)
+    has_children = np.any(box_child_ids[:, : tob.nboxes] != 0, axis=0)
+    box_flags[~has_children] |= (
+        box_flags_enum.IS_SOURCE_BOX | box_flags_enum.IS_TARGET_BOX
+    )
+    box_flags[has_children] |= (
+        box_flags_enum.HAS_SOURCE_CHILD_BOXES | box_flags_enum.HAS_TARGET_CHILD_BOXES
+    )
+
+    zeros_bbox = make_obj_array(
+        [
+            actx.from_numpy(np.zeros(aligned_nboxes, dtype=box_tree.coord_dtype))
+            for _ in range(dim)
+        ]
+    )
+
+    tree = Tree(
+        root_extent=box_tree.root_extent,
+        box_centers=actx.from_numpy(box_centers),
+        box_parent_ids=actx.from_numpy(box_parent_ids),
+        box_child_ids=actx.from_numpy(box_child_ids),
+        box_levels=actx.from_numpy(
+            np.asarray(tob.box_levels, dtype=box_level_dtype)[box_order_old]
+        ),
+        box_flags=actx.from_numpy(box_flags),
+        level_start_box_nrs=actx.from_numpy(level_start_box_nrs),
+        box_id_dtype=np.dtype(tob.box_id_dtype),
+        box_level_dtype=box_level_dtype,
+        coord_dtype=np.dtype(box_tree.coord_dtype),
+        sources_have_extent=False,
+        targets_have_extent=False,
+        extent_norm=None,
+        stick_out_factor=0,
+        sources_are_targets=True,
+        particle_id_dtype=np.dtype(tob.box_id_dtype),
+        sources=sources,
+        source_radii=None,
+        targets=sources,
+        target_radii=None,
+        bounding_box=(
+            actx.from_numpy(
+                np.asarray(box_tree.root_vertex, dtype=box_tree.coord_dtype)
+            ),
+            actx.from_numpy(
+                np.asarray(
+                    box_tree.root_vertex + box_tree.root_extent,
+                    dtype=box_tree.coord_dtype,
+                )
+            ),
+        ),
+        user_source_ids=actx.from_numpy(particle_perm.astype(particle_id_dtype)),
+        sorted_target_ids=actx.from_numpy(
+            inverse_particle_perm.astype(particle_id_dtype)
+        ),
+        box_source_starts=actx.from_numpy(box_source_starts[box_order_old]),
+        box_source_counts_nonchild=actx.from_numpy(
+            box_source_counts_nonchild[box_order_old]
+        ),
+        box_source_counts_cumul=actx.from_numpy(box_source_counts_cumul[box_order_old]),
+        box_target_starts=actx.from_numpy(box_target_starts[box_order_old]),
+        box_target_counts_nonchild=actx.from_numpy(
+            box_target_counts_nonchild[box_order_old]
+        ),
+        box_target_counts_cumul=actx.from_numpy(box_target_counts_cumul[box_order_old]),
+        box_source_bounding_box_min=zeros_bbox,
+        box_source_bounding_box_max=zeros_bbox,
+        box_target_bounding_box_min=zeros_bbox,
+        box_target_bounding_box_max=zeros_bbox,
+        _is_pruned=tob._is_pruned,
+    )
+
+    return actx.freeze(tree)

--- a/volumential/version.py
+++ b/volumential/version.py
@@ -30,12 +30,17 @@ if os.environ.get("AKPYTHON_EXEC_FROM_WITHIN_WITHIN_SETUP_PY") is not None:
     _git_rev = None
 
 else:
-    import volumential._git_rev as _git_rev_mod
-    _git_rev = _git_rev_mod.GIT_REVISION
+    try:
+        import volumential._git_rev as _git_rev_mod
+    except ImportError:
+        _git_rev = None
+    else:
+        _git_rev = _git_rev_mod.GIT_REVISION
 
     # If we're running from a dev tree, the last install (and hence the most
     # recent update of the above git rev) could have taken place very long ago.
     from pytools import find_module_git_revision
+
     _runtime_git_rev = find_module_git_revision(__file__, n_levels_up=1)
     if _runtime_git_rev is not None:
         _git_rev = _runtime_git_rev

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -26,27 +26,90 @@ __doc__ = """
 """
 
 import logging
+import os
 
 import numpy as np
 
 import pyopencl as cl
-from boxtree.fmm import TimingRecorder
 from pytools.obj_array import make_obj_array
 
+try:
+    from boxtree.fmm import TimingRecorder
+except ImportError:
+
+    class TimingRecorder:
+        def __init__(self):
+            self._futures = []
+
+        def add(self, stage, future):
+            self._futures.append((stage, future))
+
+        def summarize(self):
+            summary = {}
+            for stage, future in self._futures:
+                if future is None:
+                    continue
+                try:
+                    summary[stage] = future()
+                except TypeError:
+                    summary[stage] = future
+            return summary
+
+
 from volumential.expansion_wrangler_fpnd import (
-    FPNDFMMLibExpansionWrangler, FPNDSumpyExpansionWrangler)
+    FPNDFMMLibExpansionWrangler,
+    FPNDSumpyExpansionWrangler,
+)
 from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
 
 
 logger = logging.getLogger(__name__)
 
 
+def _debug_nan_status(label, ary):
+    if not os.environ.get("VOLUMENTIAL_DEBUG_NAN"):
+        return
+
+    if isinstance(ary, np.ndarray):
+        arr = ary
+    else:
+        arr = ary.get()
+
+    logger.warning(
+        "%s nan=%s inf=%s maxabs=%s",
+        label,
+        np.isnan(arr).any(),
+        np.isinf(arr).any(),
+        np.nanmax(np.abs(arr)) if arr.size else 0,
+    )
+
+
+def _debug_sample_values(label, ary, count=8):
+    if not os.environ.get("VOLUMENTIAL_DEBUG_NAN"):
+        return
+
+    if isinstance(ary, np.ndarray):
+        arr = ary
+    else:
+        arr = ary.get()
+
+    logger.warning("%s sample=%s", label, arr[:count])
+
+
 # {{{ volume FMM driver
 
-def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
-                     direct_evaluation=False, timing_data=None,
-                     reorder_sources=True, reorder_potentials=True,
-                     **kwargs):
+
+def drive_volume_fmm(
+    traversal,
+    expansion_wrangler,
+    src_weights,
+    src_func,
+    direct_evaluation=False,
+    timing_data=None,
+    reorder_sources=True,
+    reorder_potentials=True,
+    **kwargs,
+):
     """
     Top-level driver routine for volume potential calculation
     via fast multiple method.
@@ -97,7 +160,6 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         assert all(isinstance(sf, cl.array.Array) for sf in src_func)
 
     elif isinstance(expansion_wrangler, FPNDFMMLibExpansionWrangler):
-
         traversal = traversal.get(wrangler.queue)
 
         if isinstance(src_weights, cl.array.Array):
@@ -147,11 +209,12 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         src_func[0],  # FIXME: handle multiple source fields
     )
     recorder.add("eval_direct", timing_future)
+    _debug_nan_status("fmm_l1_potentials", potentials[0])
 
     # Return list 1 only, for debugging
     # 'list1_only' takes precedence over 'exclude_list1'
     if "list1_only" in kwargs and kwargs["list1_only"]:
-
+        result = potentials
         if reorder_potentials:
             logger.debug("reorder potentials")
             result = wrangler.reorder_potentials(potentials)
@@ -177,12 +240,13 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
 
     # {{{ (Optional) direct evaluation of everything and return
     if direct_evaluation:
-
         print("Warning: NOT USING FMM (forcing global p2p)")
         if len(src_weights) != len(src_func):
-            print("Using P2P with different src/tgt discretizations can be "
-                  "unstable when targets are close to the sources while not "
-                  "be exactly the same")
+            print(
+                "Using P2P with different src/tgt discretizations can be "
+                "unstable when targets are close to the sources while not "
+                "be exactly the same"
+            )
 
         # list 2 and beyond
         # First call global p2p, then substract list 1
@@ -190,36 +254,41 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         from sumpy import P2P
 
         p2p = P2P(
-            wrangler.queue.context,
             wrangler.code.target_kernels,
-            exclude_self=wrangler.code.exclude_self,
+            wrangler.code.exclude_self,
             value_dtypes=[wrangler.dtype],
         )
 
-        if hasattr(wrangler, "self_extra_kwargs"):
-            p2p_extra_kwargs = dict(wrangler.self_extra_kwargs)
-        else:
-            p2p_extra_kwargs = {}
-
-        if hasattr(wrangler, "self_extra_kwargs"):
+        p2p_extra_kwargs = {}
+        if hasattr(wrangler, "kernel_extra_kwargs"):
             p2p_extra_kwargs.update(wrangler.kernel_extra_kwargs)
 
         for iw, sw in enumerate(src_weights):
-            evt, (ref_pot,) = p2p(
+            target_to_source = cl.array.to_device(
                 wrangler.queue,
+                np.arange(traversal.tree.ntargets, dtype=np.int32),
+            )
+            p2p_kwargs = dict(p2p_extra_kwargs)
+            if wrangler.code.exclude_self:
+                p2p_kwargs["target_to_source"] = target_to_source
+
+            (ref_pot,) = p2p(
+                wrangler.tree_indep._setup_actx,
                 traversal.tree.targets,
                 traversal.tree.sources,
                 (sw,),
-                **p2p_extra_kwargs
+                **p2p_kwargs,
             )
             potentials[iw] += ref_pot
+        _debug_nan_status("global_p2p", potentials[0])
 
         l1_potentials, timing_future = wrangler.eval_direct_p2p(
-                traversal.target_boxes,
-                traversal.neighbor_source_boxes_starts,
-                traversal.neighbor_source_boxes_lists,
-                src_weights,
-                )
+            traversal.target_boxes,
+            traversal.neighbor_source_boxes_starts,
+            traversal.neighbor_source_boxes_lists,
+            src_weights,
+        )
+        _debug_nan_status("l1_potentials", l1_potentials[0])
 
         potentials = potentials - l1_potentials
 
@@ -252,6 +321,7 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         traversal.from_sep_siblings_lists,
         mpole_exps,
     )
+    _debug_nan_status("local_exps_after_m2l", local_exps[0])
     recorder.add("multipole_to_local", timing_future)
 
     # local_exps represents both Gamma and Delta in [1]
@@ -270,9 +340,11 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         traversal.from_sep_smaller_by_level,
         mpole_exps,
     )
+    _debug_nan_status("mpole_result", mpole_result[0])
     recorder.add("eval_multipoles", timing_future)
 
     potentials = potentials + mpole_result
+    _debug_nan_status("potentials_after_mpole_eval", potentials[0])
 
     # these potentials are called beta in [1]
 
@@ -300,6 +372,7 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         traversal.from_sep_bigger_lists,
         src_weights,
     )
+    _debug_nan_status("local_result", local_result[0])
 
     recorder.add("form_locals", timing_future)
 
@@ -328,6 +401,7 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
         traversal.target_or_target_parent_boxes,
         local_exps,
     )
+    _debug_nan_status("local_exps_after_refine", local_exps[0])
 
     recorder.add("refine_locals", timing_future)
 
@@ -340,10 +414,12 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
     local_result, timing_future = wrangler.eval_locals(
         traversal.level_start_target_box_nrs, traversal.target_boxes, local_exps
     )
+    _debug_nan_status("local_eval", local_result[0])
 
     recorder.add("eval_locals", timing_future)
 
     potentials = potentials + local_result
+    _debug_nan_status("potentials_after_local_eval", potentials[0])
 
     # }}}
 
@@ -363,10 +439,12 @@ def drive_volume_fmm(traversal, expansion_wrangler, src_weights, src_func,
 
     return result
 
+
 # }}} End volume FMM driver
 
 
 # {{{ free form interpolation of potentials
+
 
 def compute_barycentric_lagrange_params(q_order):
 
@@ -385,9 +463,16 @@ def compute_barycentric_lagrange_params(q_order):
     return (interp_points, interp_weights)
 
 
-def interpolate_volume_potential(target_points, traversal, wrangler, potential,
-                                 potential_in_tree_order=False,
-                                 target_radii=None, lbl_lookup=None, **kwargs):
+def interpolate_volume_potential(
+    target_points,
+    traversal,
+    wrangler,
+    potential,
+    potential_in_tree_order=False,
+    target_radii=None,
+    lbl_lookup=None,
+    **kwargs,
+):
     """
     Interpolate the volume potential, only works for tensor-product quadrature
     formulae. target_points and potential should be an cl array.
@@ -419,6 +504,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
     n_points = len(target_points[0])
 
     from volumential.expansion_wrangler_fpnd import FPNDFMMLibExpansionWrangler
+
     if isinstance(wrangler, FPNDFMMLibExpansionWrangler):
         tree = tree.to_device(queue)
         traversal = traversal.to_device(queue)
@@ -434,16 +520,17 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
         # Building the lookup takes O(n*log(n))
         if lbl_lookup is None:
             from boxtree.area_query import LeavesToBallsLookupBuilder
+
             lookup_builder = LeavesToBallsLookupBuilder(ctx)
 
             if target_radii is None:
                 # Set this number small enough so that all points found
                 # are inside the box
                 target_radii = cl.array.to_device(
-                    queue, np.ones(n_points, dtype=coord_dtype) * 1e-12)
+                    queue, np.ones(n_points, dtype=coord_dtype) * 1e-12
+                )
 
-            lbl_lookup, evt = lookup_builder(
-                queue, tree, target_points, target_radii)
+            lbl_lookup, evt = lookup_builder(queue, tree, target_points, target_radii)
 
         balls_near_box_starts = lbl_lookup.balls_near_box_starts
         balls_near_box_lists = lbl_lookup.balls_near_box_lists
@@ -481,9 +568,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
     elif dim == 2:
         code_mode_index_assignment = """if(
         iaxis == 0, mid / Q_ORDER,
-                    mid % Q_ORDER)""".replace(
-            "Q_ORDER", "q_order"
-        )
+                    mid % Q_ORDER)""".replace("Q_ORDER", "q_order")
     elif dim == 3:
         code_mode_index_assignment = """if(
         iaxis == 0, mid / (Q_ORDER * Q_ORDER), if(
@@ -498,7 +583,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
 
     lpknl = loopy.make_kernel(
         [
-            "{ [ tbox, iaxis ] : 0 <= tbox < n_tgt_boxes " "and 0 <= iaxis < dim }",
+            "{ [ tbox, iaxis ] : 0 <= tbox < n_tgt_boxes and 0 <= iaxis < dim }",
             "{ [ tpt, mid, mjd, mkd ] : tpt_begin <= tpt < tpt_end "
             "and 0 <= mid < n_box_modes and 0 <= mjd < q_order "
             "and 0 <= mkd < q_order }",
@@ -591,7 +676,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
 
             end
 
-            """.replace(    # noqa: E501
+            """.replace(  # noqa: E501
             "TARGET_COORDS_ASSIGNMENT", code_target_coords_assignment
         )
         .replace("MODE_INDEX_ASSIGNMENT", code_mode_index_assignment)
@@ -632,7 +717,8 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
 
     if potential_in_tree_order:
         user_mode_ids = cl.array.arange(
-            queue, len(tree.user_source_ids), dtype=tree.user_source_ids.dtype)
+            queue, len(tree.user_source_ids), dtype=tree.user_source_ids.dtype
+        )
     else:
         # fetching from user_source_ids converts potential to tree order
         user_mode_ids = tree.user_source_ids
@@ -657,7 +743,8 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
         target_boxes=traversal.target_boxes,
         root_extent=tree.root_extent,
         n_tgt_boxes=len(traversal.target_boxes),
-        **target_coords_knl_kwargs)
+        **target_coords_knl_kwargs,
+    )
 
     assert pout is res_dict["p_out"]
     assert multiplicity is res_dict["multiplicity"]
@@ -665,6 +752,7 @@ def interpolate_volume_potential(target_points, traversal, wrangler, potential,
     multiplicity.add_event(evt)
 
     return pout / multiplicity
+
 
 # }}} End free form interpolation of potentials
 


### PR DESCRIPTION
## Summary
- modernize volumential against current upstream inducer-stack dependencies, including packaging, SciPy compatibility, function-extension updates, and broader test refreshes
- vendor the old boxtree-style adaptive mesh hierarchy support into volumential and use an exact mesh-derived tree so adaptive `volume_fmm` passes without local boxtree changes
- add targeted regression coverage and document the remaining open work for Droste and interpolation in GitHub issues #12 and #13

## Testing
- `pytest -q test/test_import.py test/test_singular_integral_2d.py test/test_table_manager.py test/test_function_extension.py test/test_function_extension_helpers.py test/test_tree_interactive_build.py test/test_volume_fmm.py -rs`