### PR TITLE
Fix queue-less leaves-to-nodes interpolation lookup

### DIFF
--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -37,6 +37,7 @@ from volumential.interpolation import (
     LeavesToNodesLookupBuilder,
     _count_missing_nodes_from_leaf_starts,
     _compute_leaves_to_nodes_lookup_tol,
+    _make_constant_array,
     interpolate_from_meshmode,
     interpolate_to_meshmode,
 )
@@ -357,6 +358,21 @@ def test_count_missing_nodes_from_leaf_starts_device(ctx_factory):
 
     starts_full = cl.array.to_device(queue, np.array([0, 1, 2, 5], dtype=np.int32))
     assert _count_missing_nodes_from_leaf_starts(starts_full, queue) == 0
+
+    starts_queue_less = cl.array.to_device(
+        queue, np.array([0, 1, 1, 4], dtype=np.int32)
+    ).with_queue(None)
+    assert _count_missing_nodes_from_leaf_starts(starts_queue_less, queue) == 1
+
+
+def test_make_constant_array_accepts_queue_less_reference(ctx_factory):
+    cl_ctx = ctx_factory()
+    queue = cl.CommandQueue(cl_ctx)
+
+    ref = cl.array.arange(queue, 7, dtype=np.float64).with_queue(None)
+    const = _make_constant_array(queue, ref, 1.25)
+
+    assert np.allclose(const.get(queue), np.full(ref.shape, 1.25, dtype=ref.dtype))
 
 
 # {{{ 2d tests

--- a/volumential/interpolation.py
+++ b/volumential/interpolation.py
@@ -71,12 +71,21 @@ def _compute_leaves_to_nodes_lookup_tol(tree, tol):
 
 
 def _count_missing_nodes_from_leaf_starts(leaf_starts, queue):
+    if hasattr(leaf_starts, "with_queue"):
+        leaf_starts = leaf_starts.with_queue(queue)
+
     if len(leaf_starts) <= 1:
         return 0
 
     hit_counts = leaf_starts[1:] - leaf_starts[:-1]
     missing_flags = (hit_counts == 0).astype(np.int32)
     return int(cl.array.sum(missing_flags).get(queue))
+
+
+def _make_constant_array(queue, template, value):
+    ary = cl.array.empty(queue, template.shape, dtype=template.dtype)
+    ary.fill(np.asarray(value, dtype=template.dtype))
+    return ary
 
 
 @lru_cache(maxsize=16)
@@ -917,8 +926,9 @@ class LeavesToNodesLookupBuilder:
                 raise ValueError
 
         nodes = flatten(actx.thaw(self.discr.nodes()), actx, leaf_class=DOFArray)
+        nodes = make_obj_array([coord.with_queue(actx.queue) for coord in nodes])
         lookup_tol = _compute_leaves_to_nodes_lookup_tol(self.trav.tree, tol)
-        radii = cl.array.zeros_like(nodes[0]) + lookup_tol
+        radii = _make_constant_array(actx.queue, nodes[0], lookup_tol)
 
         area_query, _ = self.leaves_to_balls_lookup_builder.area_query_builder(
             self.boxtree_actx,


### PR DESCRIPTION
## Summary
- make leaves-to-nodes lookup robust to queue-less `TaggableCLArray` inputs by attaching the active queue before device arithmetic
- avoid `zeros_like` on potentially queue-less node arrays by introducing `_make_constant_array` and using it to build lookup radii
- add interpolation regression tests covering queue-less `leaf_starts` and queue-less template arrays

## Validation
- ran on `ipa` using `/home/xywei/Work/fmm/.venv-qbx-test/bin/pytest`
- `pytest -q test/test_interpolation.py -k 'to_meshmode_interpolation'` passed (`54 passed, 89 deselected, 18 xfailed`)
- `pytest -q test/test_interpolation.py -k 'count_missing_nodes_from_leaf_starts_device or make_constant_array_accepts_queue_less_reference'` passed (`6 passed, 153 deselected, 2 xfailed`)

Closes #13