### PR TITLE
Prefer sumpy kernels over eager Python lambdas in table manager

### DIFF
--- a/test/test_table_manager_sqlite_migration.py
+++ b/test/test_table_manager_sqlite_migration.py
@@ -79,6 +79,182 @@ def test_get_kernel_function_uses_sumpy_route_for_laplace3d(tmp_path):
     assert np.isclose(value, 1.0 / (4.0 * np.pi))
 
 
+def test_resolve_kernel_bundle_skips_python_kernel_lookup_for_sumpy(
+    tmp_path, monkeypatch
+):
+    filename = tmp_path / "cache.sqlite"
+
+    with NFTable(str(filename), progress_bar=False) as table_manager:
+        monkeypatch.setattr(
+            table_manager,
+            "get_kernel_function",
+            lambda *args, **kwargs: pytest.fail(
+                "_resolve_kernel_bundle unexpectedly called get_kernel_function"
+            ),
+        )
+
+        bundle = table_manager._resolve_kernel_bundle(
+            TableRequest.from_args(3, "Laplace", 1),
+            {},
+            require_sumpy_kernel=False,
+        )
+
+    assert bundle.sumpy_kernel is not None
+    assert bundle.kernel_func is None
+
+
+def test_load_saved_table_uses_payload_without_python_kernel_lookup(
+    tmp_path, monkeypatch
+):
+    import volumential.table_manager as table_manager_module
+
+    filename = tmp_path / "cache.sqlite"
+
+    class PayloadBackedTable:
+        def __init__(
+            self,
+            quad_order,
+            dim,
+            kernel_func,
+            kernel_type,
+            sumpy_kernel,
+            source_box_extent,
+            precomputed_q_points=None,
+            **kwargs,
+        ):
+            self.quad_order = quad_order
+            self.dim = dim
+            self.kernel_func = kernel_func
+            self.kernel_type = kernel_type
+            self.integral_knl = sumpy_kernel
+            self.source_box_extent = source_box_extent
+
+            self.n_q_points = 1
+            self.n_pairs = 1
+            self.q_points = np.zeros((1, dim), dtype=np.float64)
+            if precomputed_q_points is not None:
+                self.q_points[:] = precomputed_q_points
+
+            self.data = np.zeros(1, dtype=np.float64)
+            self.mode_normalizers = np.zeros(1, dtype=np.float64)
+            self.kernel_exterior_normalizers = np.zeros(1, dtype=np.float64)
+            self.interaction_case_vecs = [[0] * dim]
+            self.case_indices = np.zeros(1, dtype=np.int32)
+            self.table_data_is_symmetry_reduced = False
+
+    from types import SimpleNamespace
+
+    payload_table = SimpleNamespace(
+        q_points=np.array([[0.5, 0.5, 0.5]], dtype=np.float64),
+        data=np.array([3.5], dtype=np.float64),
+        mode_normalizers=np.array([1.0], dtype=np.float64),
+        kernel_exterior_normalizers=np.array([0.0], dtype=np.float64),
+        interaction_case_vecs=[[0, 0, 0]],
+        case_indices=np.array([0], dtype=np.int32),
+        table_data_is_symmetry_reduced=False,
+    )
+    payload_blob = _serialize_table_payload(payload_table)
+
+    with NFTable(str(filename), progress_bar=False) as table_manager:
+        monkeypatch.setattr(
+            table_manager,
+            "get_kernel_function",
+            lambda *args, **kwargs: pytest.fail(
+                "load_saved_table unexpectedly called get_kernel_function"
+            ),
+        )
+        monkeypatch.setattr(
+            table_manager_module,
+            "NearFieldInteractionTable",
+            PayloadBackedTable,
+        )
+        monkeypatch.setattr(
+            table_manager,
+            "_load_record",
+            lambda *args, **kwargs: {
+                "dim": 3,
+                "quad_order": 1,
+                "build_method": "DuffyRadial",
+                "payload": payload_blob,
+                "source_box_extent": 1.0,
+                "source_box_level_stored": 0,
+                "n_q_points": 1,
+                "n_pairs": 1,
+                "case_encoding_base": 1,
+                "case_encoding_shift": 0,
+                "kernel_type_cached": "inv_power",
+            },
+        )
+        monkeypatch.setattr(
+            table_manager, "_load_record_kwargs", lambda *args, **kwargs: {}
+        )
+
+        loaded = table_manager.load_saved_table(3, "Laplace", q_order=1)
+
+    assert loaded.kernel_func is None
+    assert np.allclose(loaded.q_points, payload_table.q_points)
+    assert np.allclose(loaded.data, payload_table.data)
+
+
+def test_get_table_recompute_skips_python_kernel_lookup_for_sumpy(
+    tmp_path, monkeypatch
+):
+    import volumential.table_manager as table_manager_module
+
+    filename = tmp_path / "cache.sqlite"
+
+    class RecomputeTable:
+        def __init__(
+            self,
+            quad_order,
+            dim,
+            kernel_func,
+            kernel_type,
+            sumpy_kernel,
+            source_box_extent,
+            **kwargs,
+        ):
+            self.quad_order = quad_order
+            self.dim = dim
+            self.kernel_func = kernel_func
+            self.kernel_type = kernel_type
+            self.integral_knl = sumpy_kernel
+            self.source_box_extent = source_box_extent
+
+            self.n_q_points = 1
+            self.n_pairs = 1
+            self.q_points = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)
+            self.data = np.array([1.25], dtype=np.float64)
+            self.mode_normalizers = np.array([0.0], dtype=np.float64)
+            self.kernel_exterior_normalizers = np.array([0.0], dtype=np.float64)
+            self.interaction_case_vecs = [[0, 0, 0]]
+            self.case_indices = np.array([0], dtype=np.int32)
+            self.table_data_is_symmetry_reduced = False
+            self.is_built = False
+
+        def build_table(self, *args, **kwargs):
+            self.is_built = True
+
+    with NFTable(str(filename), progress_bar=False) as table_manager:
+        monkeypatch.setattr(
+            table_manager,
+            "get_kernel_function",
+            lambda *args, **kwargs: pytest.fail(
+                "get_table recompute unexpectedly called get_kernel_function"
+            ),
+        )
+        monkeypatch.setattr(
+            table_manager_module,
+            "NearFieldInteractionTable",
+            RecomputeTable,
+        )
+
+        table, is_recomputed = table_manager.get_table(3, "Laplace", q_order=1)
+
+    assert is_recomputed
+    assert table.kernel_func is None
+
+
 def test_get_table_rejects_legacy_knl_func_kwarg(tmp_path):
     filename = tmp_path / "cache.sqlite"
 

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -251,6 +251,7 @@ class NearFieldInteractionTable:
         build_method=_TABLE_BUILD_METHOD,
         source_box_extent=1,
         dtype=np.float64,
+        derive_kernel_func=True,
         progress_bar=True,
         **kwargs,
     ):
@@ -279,7 +280,7 @@ class NearFieldInteractionTable:
         self.build_method = _TABLE_BUILD_METHOD
         self._auto_build_queue = None
 
-        if kernel_func is None and sumpy_kernel is not None:
+        if kernel_func is None and sumpy_kernel is not None and derive_kernel_func:
             kernel_func = sumpy_kernel_to_lambda(sumpy_kernel)
 
         if dim == 1:
@@ -289,7 +290,7 @@ class NearFieldInteractionTable:
 
         elif dim == 2:
             # Constant kernel can be used for fun/testing
-            if kernel_func is None:
+            if kernel_func is None and sumpy_kernel is None:
                 kernel_func = constant_one
                 kernel_type = "const"
 
@@ -720,6 +721,21 @@ class NearFieldInteractionTable:
         radial_quad_order=61,
         mp_dps=50,
     ):
+        if self.kernel_func is None:
+            if self.integral_knl is None:
+                raise ValueError(
+                    "scalar DuffyRadial quadrature requires kernel_func or sumpy_kernel"
+                )
+            try:
+                self.kernel_func = sumpy_kernel_to_lambda(self.integral_knl)
+            except Exception as exc:
+                raise RuntimeError(
+                    "failed to derive kernel_func from sumpy_kernel for scalar "
+                    "DuffyRadial quadrature"
+                ) from exc
+
+        kernel_func = self.kernel_func
+
         entry_info = self.decode_index(entry_id)
         source_mode = self.get_mode(entry_info["source_mode_index"])
         target_point = self.find_target_point(
@@ -728,7 +744,7 @@ class NearFieldInteractionTable:
         )
 
         def integrand(x, y):
-            return source_mode(x, y) * self.kernel_func(
+            return source_mode(x, y) * kernel_func(
                 x - target_point[0], y - target_point[1]
             )
 
@@ -751,7 +767,7 @@ class NearFieldInteractionTable:
             def integrand_nd(*coords):
                 source_val = source_mode(*coords)
                 shifted = [coords[i] - target_point[i] for i in range(self.dim)]
-                return source_val * self.kernel_func(*shifted)
+                return source_val * kernel_func(*shifted)
 
             bounds = [(0.0, self.source_box_extent) for _ in range(self.dim)]
             integral, error = squad.box_quad_duffy_radial_nd(

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1023,16 +1023,8 @@ class NearFieldInteractionTableManager:
                 "for loopy table build."
             )
 
-        knl_func = None
-        if sumpy_knl is not None:
-            knl_func = self.get_kernel_function(
-                table_request.dim,
-                table_request.kernel_type,
-                sumpy_knl=sumpy_knl,
-            )
-
         return TableKernelBundle(
-            kernel_func=knl_func,
+            kernel_func=None,
             kernel_scale_type=kernel_scale_type,
             sumpy_kernel=sumpy_knl,
         )
@@ -1317,6 +1309,7 @@ class NearFieldInteractionTableManager:
                 kernel_func=kernel_bundle.kernel_func,
                 kernel_type=kernel_bundle.kernel_scale_type,
                 sumpy_kernel=kernel_bundle.sumpy_kernel,
+                derive_kernel_func=False,
                 source_box_extent=self._source_box_extent_for_level(
                     table_request.source_box_level
                 ),
@@ -1654,6 +1647,7 @@ class NearFieldInteractionTableManager:
             kernel_func=kernel_bundle.kernel_func,
             kernel_type=kernel_bundle.kernel_scale_type,
             sumpy_kernel=kernel_bundle.sumpy_kernel,
+            derive_kernel_func=False,
             build_method=_TABLE_BUILD_METHOD,
             source_box_extent=self._source_box_extent_for_level(
                 table_request.source_box_level


### PR DESCRIPTION
## Summary
- stop eagerly resolving `kernel_func` inside `_resolve_kernel_bundle`; table-manager load/recompute paths now carry symbolic kernels without forcing Python-lambda conversion up front
- allow `NearFieldInteractionTable` construction with `derive_kernel_func=False` and derive `kernel_func` lazily only when scalar Duffy quadrature actually needs it
- add regression tests that ensure load/recompute paths do not call `get_kernel_function` when a valid sumpy kernel is available

## Validation
Ran on `ipa` in `/home/xywei/Work/fmm/remote_runs/volumential-issue20-5lHnvp` using `/home/xywei/Work/fmm/.venv-qbx-test/bin/python`:
- `pytest -q test/test_table_manager_sqlite_migration.py`
- `pytest -q test/test_table_manager_sqlite_migration.py -k 'resolve_kernel_bundle_skips_python_kernel_lookup_for_sumpy or load_saved_table_uses_payload_without_python_kernel_lookup or get_table_recompute_skips_python_kernel_lookup_for_sumpy'`
- direct script smoke checks:
  - `get_table(3, 'Laplace', q_order=1, force_recompute=True)` works with no `knl_func`
  - payload-backed `load_saved_table(3, 'Laplace', q_order=1)` succeeds even when `get_kernel_function` is patched to raise

Closes #20