### PR TITLE
Stabilize CI Full macOS/docs and persist examples table cache

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -33,6 +33,7 @@ jobs:
           export LANG=en_US.UTF-8
 
           export PYTEST_FLAGS="--cov=volumential"
+          export CISUPPORT_PARALLEL_PYTEST=no
           export CI_TEST_CONDA_PREFIX="$CONDA_PREFIX"
           export CPATH="${CI_TEST_CONDA_PREFIX}/include${CPATH:+:${CPATH}}"
           export LIBRARY_PATH="${CI_TEST_CONDA_PREFIX}/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}"
@@ -84,6 +85,12 @@ jobs:
           environment-name: testing
           cache-downloads: true
           generate-run-shell: true
+      - uses: actions/cache@v4
+        with:
+          path: |
+            nft_laplace3d.sqlite
+            examples/nft_laplace3d.sqlite
+          key: laplace3d-table-cache-static-v1
       - name: Main Script
         shell: micromamba-shell {0}
         run: |

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1,6 +1,9 @@
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __doc__ = """
+.. autoclass:: TableRequest
+   :members:
+
 .. autoclass:: NearFieldInteractionTableManager
    :members:
 """


### PR DESCRIPTION
## Summary
- disable parallel pytest workers for the macOS CI Full job via `CISUPPORT_PARALLEL_PYTEST=no` to avoid xdist worker crashes
- expose `TableRequest` in module docs so Sphinx can resolve the `volumential.table_manager.TableRequest` cross-references in strict docs builds
- cache the Laplace 3D sqlite table artifact in the examples job with a static cache key so runs can reuse precomputed nearfield tables

## Testing
- python -m compileall volumential/table_manager.py