### PR TITLE
Fix CI Full failures and opt actions into Node24

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   pytest_mac:
     name: Testing (macOS)
@@ -31,6 +34,7 @@ jobs:
           export PY_EXE=python
           export LC_ALL=en_US.UTF-8
           export LANG=en_US.UTF-8
+          export PYOPENCL_CTX="portable:0"
 
           export PYTEST_FLAGS="--cov=volumential"
           export CISUPPORT_PARALLEL_PYTEST=no
@@ -85,7 +89,7 @@ jobs:
           environment-name: testing
           cache-downloads: true
           generate-run-shell: true
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             nft_laplace3d.sqlite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   typos:
     name: Typos

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1,6 +1,12 @@
 __copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
 
 __doc__ = """
+.. autoclass:: KernelSpec
+   :members:
+
+.. autoclass:: TableDiscretization
+   :members:
+
 .. autoclass:: TableRequest
    :members:
 


### PR DESCRIPTION
## Summary
- fix strict Sphinx docs failure by documenting `KernelSpec` and `TableDiscretization` in `volumential.table_manager`, so `TableRequest` field type cross-references resolve cleanly
- reduce macOS CI flakiness by pinning `PYOPENCL_CTX=\"portable:0\"` in the CI Full macOS job (alongside the existing parallel-pytest disable)
- address Node.js 20 deprecation warnings by opting workflows into Node 24 runtime (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`) and upgrading `actions/cache` from `v4` to `v5`

## Validation
- reviewed latest failed `main` run logs (`CI Full` run 23371684951) to confirm the docs warnings and macOS abort cause
- local syntax sanity check: `python -m compileall volumential/table_manager.py`