### PR TITLE
Clean up volume_fmm warnings and refresh AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,23 @@
 # Volumential Agent Guide
 
-This repository is an older volume-potential/FMM codebase built on the
-PyOpenCL + boxtree + sumpy + pytential stack. Treat it as research software with
-useful core ideas, uneven modernization, and a few stale interfaces.
+`volumential` is a research-oriented volume-potential/FMM package built around
+PyOpenCL + boxtree + sumpy + pytential. Prefer incremental stabilization over
+large rewrites.
 
-## Project Intent
+## Core Mental Model
 
-- `volumential` computes volume potentials in 2D/3D using fast multipole ideas.
-- The near-field story is table-driven: singular or nearly singular local
-  interactions are precomputed and cached.
-- The far-field story is wrangler-driven: boxtree traversals and expansion
-  wranglers execute the FMM passes.
-- The medium-term modernization goal is to make this package complement
-  `pytential` rather than duplicate it. Prefer integrations that make volume and
-  boundary workflows compose cleanly.
+- Near field: table-driven local interactions (`nearfield_potential_table.py`).
+- Far field: traversal + wrangler FMM passes (`volume_fmm.py`,
+  `expansion_wrangler_fpnd.py`).
+- Caching matters: table/cache key changes can invalidate stored kernels/tables.
 
-## Important Files
-
-- `volumential/volume_fmm.py`: top-level volume FMM driver and interpolation of
-  computed potentials.
-- `volumential/expansion_wrangler_interface.py`: expected wrangler API.
-- `volumential/expansion_wrangler_fpnd.py`: concrete wrangler implementations.
-- `volumential/nearfield_potential_table.py`: near-field interaction table
-  construction and lookup.
-- `volumential/table_manager.py`: SQLite-backed table caching and retrieval.
-- `volumential/geometry.py`: bounding boxes, tree setup, FMM geometry helpers.
-- `volumential/interpolation.py`: meshmode <-> box-grid interpolation helpers.
-- `volumential/function_extension.py`: pytential-facing extension logic; likely a
-  key integration point for future PDE workflows.
-- `volumential/singular_integral_2d.py`: Duffy/radial singular quadrature
-  kernels used by the active near-field table builder.
-- `test/`: best source of expected behavior for maintenance.
-- `examples/`: end-to-end usage patterns for Laplace volume potentials.
-
-## What To Read First
-
-When starting non-trivial work, read these in roughly this order:
+## Files To Know First
 
 1. `README.md`
-2. `volumential/__init__.py`
-3. `volumential/volume_fmm.py`
-4. `volumential/table_manager.py`
-5. `volumential/nearfield_potential_table.py`
-6. the most relevant test in `test/`
+2. `volumential/volume_fmm.py`
+3. `volumential/table_manager.py`
+4. `volumential/nearfield_potential_table.py`
+5. Most relevant test in `test/`
 
 For pytential integration work, also read:
 
@@ -51,71 +26,34 @@ For pytential integration work, also read:
 3. `test/test_interpolation.py`
 4. `test/test_function_extension.py`
 
-## Current Reality / Known Debt
+## Current Constraints
 
-- Packaging is pyproject-driven and uv-first; prefer `uv sync` over legacy
-  requirements-based installs.
-- The code assumes old inducer-stack APIs in places, especially around
-  `pytential`, `meshmode`, `arraycontext`, and `pyopencl`.
-- Some tests and modules already document drift. In particular,
-  `test/test_function_extension.py` notes that it needs updating for
-  `GeometryCollection`.
-- There are explicit `FIXME`s and partial implementations, especially around
-  multiple source fields, 3D paths, and optional build methods.
-- Interactive OpenCL context creation appears in a few places; avoid adding more
-  of that during modernization.
-- Historical contrib/native code has been removed; use the in-tree Python/OpenCL
-  implementations as the supported path.
-- `volumential/meshgen.py` depends on legacy boxtree behavior that has drifted
-  out of current upstream. In particular, the old
-  `boxtree.tree_interactive_build` fallback no longer exists in current
-  `inducer/boxtree`.
-- There is a historical fork at `xywei/boxtree`, but it appears stale and should
-  not be treated as an actively maintained compatibility target.
-
-## Preferred Modernization Direction
-
-- Favor a small, reliable public API over preserving every legacy entry point.
-- Keep the separation between near-field tables, geometry/traversal setup, and
-  FMM execution explicit.
-- Prefer `arraycontext`-friendly and pytential-friendly interfaces over raw,
-  ad hoc array handling.
-- Keep dependency and workflow updates centered in `pyproject.toml` and
-  `tool.uv.sources`.
-- When integrating with `pytential`, aim for workflows where boundary solves can
-  feed volume evaluation without bespoke glue in user code.
-- Add or revive tests before large refactors in the integration layers.
+- Packaging is `pyproject.toml` + uv-first (`uv sync` / `uv run`).
+- Most legacy API assumptions have been removed; remaining risk is integration
+  edge cases across pyopencl/meshmode/pytential boundaries.
+- `meshgen.py` uses in-tree compatibility code (`tree_interactive_build.py`)
+  layered on upstream boxtree primitives (not an external legacy fork).
+- OpenCL availability is environment-dependent; avoid adding more interactive
+  context creation paths.
 
 ## Working Conventions
 
-- Preserve numerical behavior unless the task is explicitly to change it.
-- Be careful with cached-table semantics in `table_manager.py`; changes to table
-  format, kernel definitions, or scaling rules may invalidate old SQLite caches.
-- When editing public behavior, update or add focused tests in `test/`.
-- Prefer extending current examples or adding small new ones over writing prose
-  docs first.
-- Avoid broad rewrites unless the user asks for them. Incremental stabilization
-  is safer here.
+- Preserve numerical behavior unless explicitly asked to change it.
+- Keep near-field, traversal setup, and FMM execution concerns separated.
+- Update/add focused tests with behavior changes.
+- Prefer small, reviewable edits over broad refactors.
 
-## Testing Guidance
+## Testing Heuristics
 
-- Start with the narrowest relevant test file under `test/`.
-- Good anchors:
+- Start with the narrowest relevant tests:
   - `test/test_volume_fmm.py`
   - `test/test_table_manager.py`
   - `test/test_nearfield_potential_table.py`
-  - `test/test_duffy_tanh_sinh.py`
-  - `test/test_nearfield_interaction_completeness.py`
   - `test/test_interpolation.py`
-- Expect GPU/OpenCL-dependent tests. If a test requires unavailable hardware or
-  drivers, say so clearly instead of papering over it.
-- If touching pytential integration, check for API drift first before assuming a
-  numerical bug.
+- If GPU/OpenCL tests cannot run, report that clearly and still run available
+  CPU/unit coverage.
 
-## When Unsure
+## Directional Preference
 
-- Use the tests and examples as the behavioral spec.
-- Prefer the pure Python/OpenCL path over reviving old contrib code.
-- If a design choice affects how `volumential` should complement `pytential`,
-  choose the option that reduces duplicate abstractions and improves composable
-  PDE workflows.
+When design is ambiguous, choose the option that keeps `volumential`
+composable with `pytential` and reduces duplicate abstractions.

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -32,7 +32,7 @@ import numpy as np
 
 import pyopencl as cl
 import pyopencl.array  # noqa: F401
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 
 try:
     from boxtree.timing import TimingRecorder
@@ -153,14 +153,14 @@ def _normalize_source_fields(
     else:
         fields = [values]
 
-    return make_obj_array([_cast_source_field_dtype(field, dtype) for field in fields])
+    return obj_array_1d([_cast_source_field_dtype(field, dtype) for field in fields])
 
 
 def _as_obj_array(potentials):
     if isinstance(potentials, np.ndarray) and potentials.dtype == object:
         return potentials
 
-    return make_obj_array([potentials])
+    return obj_array_1d([potentials])
 
 
 def _add_obj_arrays(lhs, rhs):
@@ -170,7 +170,7 @@ def _add_obj_arrays(lhs, rhs):
     if len(lhs_oa) != len(rhs_oa):
         raise ValueError("incompatible potential vector lengths")
 
-    return make_obj_array(
+    return obj_array_1d(
         [lhs_i + rhs_i for lhs_i, rhs_i in zip(lhs_oa, rhs_oa, strict=True)]
     )
 
@@ -324,9 +324,9 @@ def drive_volume_fmm(
         traversal = traversal.get(queue)
 
         if isinstance(src_weights[0], cl.array.Array):
-            src_weights = make_obj_array([sw.get(queue) for sw in src_weights])
+            src_weights = obj_array_1d([sw.get(queue) for sw in src_weights])
         if isinstance(src_func[0], cl.array.Array):
-            src_func = make_obj_array([sf.get(queue) for sf in src_func])
+            src_func = obj_array_1d([sf.get(queue) for sf in src_func])
 
     if reorder_sources:
         logger.debug("reorder source weights")
@@ -396,14 +396,14 @@ def drive_volume_fmm(
 
         logger.info("fmm complete with list 1 only")
         logger.info("fmm complete")
-        logger.warn("only list 1 results are returned")
+        logger.warning("only list 1 results are returned")
 
         return result
 
     # Do not include list 1
     if "exclude_list1" in kwargs and kwargs["exclude_list1"]:
         logger.info("Using zeros for list 1")
-        logger.warn("list 1 interactions are not included")
+        logger.warning("list 1 interactions are not included")
         potentials = wrangler.output_zeros()
 
     # these potentials are called alpha in [1]


### PR DESCRIPTION
## Summary
- Replace deprecated object-array helpers in `volumential/volume_fmm.py` with `pytools.obj_array.new_1d` and update `logger.warn` calls to `logger.warning`.
- Keep source-field normalization behavior unchanged while removing deprecation warnings from the exercised volume FMM paths.
- Shorten `AGENTS.md` and refresh its constraints section to match the current codebase state (internalized meshgen compatibility and reduced legacy API drift).

## Testing
- `rtk uv run pytest --noconftest test/test_volume_fmm.py -k "normalize_source_fields or volume_fmm_list1_multi_source_superposition or volume_fmm_rejects_multi_source_full_sumpy_path or volume_fmm_direct_eval_accepts_fmmlib_plain_arrays" test/test_version.py`