### PR TITLE
Sweep logger.warning and object-array helper migrations

### DIFF
--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -27,7 +27,7 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.array
 from boxtree.pyfmmlib_integration import FMMLibExpansionWrangler
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 from sumpy.array_context import PyOpenCLArrayContext
 from sumpy.fmm import (
     SumpyExpansionWrangler,
@@ -1425,7 +1425,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
     ):
         pot = self.output_zeros()
         if pot.dtype != object:
-            pot = make_obj_array(
+            pot = obj_array_1d(
                 [
                     pot,
                 ]

--- a/volumential/function_extension.py
+++ b/volumential/function_extension.py
@@ -47,7 +47,7 @@ from pytential.array_context import PyOpenCLArrayContext
 from pytential.linalg.gmres import gmres
 from pytential.target import PointsTarget
 from pytential.symbolic.stokes import StokesletWrapper, StressletWrapper
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 from sumpy.kernel import AxisTargetDerivative, ExpressionKernel
 
 
@@ -112,7 +112,7 @@ def get_normal_vectors(queue, density_discr, loc_sign=-1):
 def get_tangent_vectors(queue, density_discr, loc_sign):
     # the domain is on the left.
     normal = get_normal_vectors(queue, density_discr, loc_sign)
-    return make_obj_array([-1 * normal[1], normal[0]])
+    return obj_array_1d([-1 * normal[1], normal[0]])
 
 
 def get_path_length(queue, density_discr):
@@ -567,7 +567,7 @@ def compute_biharmonic_extension(
 
     grad_v2 = [
         bind(qbx, GD2[iaxis])(
-            queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])
+            queue, mu=mu, arclength_parametrization_derivatives=obj_array_1d([xp, yp])
         ).real
         for iaxis in range(dim)
     ]
@@ -638,7 +638,7 @@ def compute_biharmonic_extension(
             (qbx_stick_out, target_discr), sym.grad(dim, GS2)
         )(queue, mu=mu).real
     )
-    grad_omega_S3 = (int_rho * make_obj_array([1.0, -1.0])).real  # noqa: N806
+    grad_omega_S3 = (int_rho * obj_array_1d([1.0, -1.0])).real  # noqa: N806
     grad_omega_S = -(grad_omega_S1 + grad_omega_S2 + grad_omega_S3)  # noqa: N806
 
     omega_S1_bdry = bind(qbx, GS1_bdry)(queue, mu=mu).real  # noqa: N806
@@ -648,17 +648,17 @@ def compute_biharmonic_extension(
 
     omega_D1 = bind(  # noqa: N806
         (qbx_stick_out, target_discr), GD1
-    )(queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
+    )(queue, mu=mu, arclength_parametrization_derivatives=obj_array_1d([xp, yp])).real
     omega_D = omega_D1 + v1  # noqa: N806
 
     grad_omega_D1 = bind(  # noqa: N806
         (qbx_stick_out, target_discr), sym.grad(dim, GD1)
-    )(queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
+    )(queue, mu=mu, arclength_parametrization_derivatives=obj_array_1d([xp, yp])).real
     grad_omega_D = grad_omega_D1 + grad_v1  # noqa: N806
 
     omega_D1_bdry = bind(  # noqa: N806
         qbx, GD1_bdry
-    )(queue, mu=mu, arclength_parametrization_derivatives=make_obj_array([xp, yp])).real
+    )(queue, mu=mu, arclength_parametrization_derivatives=obj_array_1d([xp, yp])).real
     omega_D_bdry = omega_D1_bdry + v1_bdry  # noqa: N806
 
     int_bdry_mu = bind(qbx, sym.integral(dim, dim - 1, sym.make_sym_vector("mu", dim)))(
@@ -668,7 +668,7 @@ def compute_biharmonic_extension(
         int_bdry_mu[0] * target_discr.nodes()[1]
         - int_bdry_mu[1] * target_discr.nodes()[0]
     )
-    grad_omega_W = make_obj_array(  # noqa: N806
+    grad_omega_W = obj_array_1d(  # noqa: N806
         [-int_bdry_mu[1], int_bdry_mu[0]]
     )
     omega_W_bdry = (  # noqa: N806

--- a/volumential/geometry.py
+++ b/volumential/geometry.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import pyopencl as cl
 from boxtree.pyfmmlib_integration import FMMLibRotationData
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 
 
 # {{{ bounding box factory
@@ -226,7 +226,7 @@ class BoxFMMGeometryFactory:
         if queue is None:
             return q_points
         else:
-            return make_obj_array(
+            return obj_array_1d(
                 [cl.array.to_device(queue, q_points[i]) for i in range(self.dim)]
             )
 
@@ -244,7 +244,7 @@ class BoxFMMGeometryFactory:
         if queue is None:
             return cell_centers
         else:
-            return make_obj_array(
+            return obj_array_1d(
                 [cl.array.to_device(queue, cell_centers[i]) for i in range(self.dim)]
             )
 

--- a/volumential/interpolation.py
+++ b/volumential/interpolation.py
@@ -35,7 +35,7 @@ from boxtree.tools import DeviceDataRecord
 from meshmode.array_context import PyOpenCLArrayContext as MeshmodePyOpenCLArrayContext
 from meshmode.dof_array import DOFArray
 from pytools import ProcessLogger, memoize_method
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 
 logger = logging.getLogger(__name__)
 
@@ -757,7 +757,7 @@ class ElementsToSourcesLookupBuilder:
             / 2
         )
 
-        ball_centers = make_obj_array(
+        ball_centers = obj_array_1d(
             [
                 cl.array.to_device(actx.queue, center_coord_comp)
                 for center_coord_comp in ball_centers_host
@@ -806,7 +806,7 @@ class ElementsToSourcesLookupBuilder:
 
         element_lookup_kernel = self.get_simplex_lookup_kernel()
 
-        vertices_dev = make_obj_array(
+        vertices_dev = obj_array_1d(
             [
                 cl.array.to_device(actx.queue, verts)
                 for verts in self.discr.mesh.vertices
@@ -926,7 +926,7 @@ class LeavesToNodesLookupBuilder:
                 raise ValueError
 
         nodes = flatten(actx.thaw(self.discr.nodes()), actx, leaf_class=DOFArray)
-        nodes = make_obj_array([coord.with_queue(actx.queue) for coord in nodes])
+        nodes = obj_array_1d([coord.with_queue(actx.queue) for coord in nodes])
         lookup_tol = _compute_leaves_to_nodes_lookup_tol(self.trav.tree, tol)
         radii = _make_constant_array(actx.queue, nodes[0], lookup_tol)
 
@@ -1118,7 +1118,7 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup, order="
         actx.queue, sources_in_element_lists
     )
 
-    mesh_vertices_dev = make_obj_array(
+    mesh_vertices_dev = obj_array_1d(
         [
             cl.array.to_device(
                 actx.queue,
@@ -1128,7 +1128,7 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup, order="
         ]
     )
     n_source_slots = len(sources_in_element_lists)
-    barycentric_dev = make_obj_array(
+    barycentric_dev = obj_array_1d(
         [
             cl.array.empty(actx.queue, n_source_slots, dtype=coord_dtype)
             for _ in range(dim + 1)
@@ -1159,7 +1159,7 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup, order="
             map_kwargs[f"barycentric_{iaxis}"] = barycentric_dev[iaxis]
 
         evt, map_res = map_executor(actx.queue, **map_kwargs)
-        barycentric_dev = make_obj_array(
+        barycentric_dev = obj_array_1d(
             [map_res[f"barycentric_{iaxis}"] for iaxis in range(dim + 1)]
         )
         for iaxis in range(dim + 1):
@@ -1197,7 +1197,7 @@ def interpolate_from_meshmode(actx, dof_vec, elements_to_sources_lookup, order="
             bernstein_coeffs_real, dtype=value_dtype
         )
 
-        bernstein_alpha_dev = make_obj_array(
+        bernstein_alpha_dev = obj_array_1d(
             [
                 cl.array.to_device(
                     actx.queue,

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -217,7 +217,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         (table_root_extent * table_root_extent * table_root_extent)"
 
             else:
-                logger.warn(
+                logger.warning(
                     "Kernel not scalable and not using multiple tables, "
                     "to get correct results, please make sure that your "
                     "tree is uniform and only needs one table."
@@ -267,7 +267,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 logger.info("no displacement for CstKnl3D")
                 code = "0.0"
             else:
-                logger.warn(
+                logger.warning(
                     "Kernel not scalable and not using multiple tables, "
                     "to get correct results, please make sure that either "
                     "no displacement is needed, or the box "
@@ -303,7 +303,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 logger.info("scaling from table[0] for " + self.kname)
                 code = "0.0"
             else:
-                logger.warn(
+                logger.warning(
                     "Kernel not scalable and not using multiple tables, "
                     "to get correct results, please make sure that your "
                     "tree is uniform and only needs one table."

--- a/volumential/meshgen.py
+++ b/volumential/meshgen.py
@@ -35,7 +35,7 @@ import logging
 
 import numpy as np
 import pyopencl as cl
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 
 from volumential.tree_interactive_build import BoxTree, QuadratureOnBoxTree
 
@@ -397,7 +397,7 @@ def build_geometry_info(ctx, queue, dim, q_order, mesh, bbox=None, a=None, b=Non
     q_points_org = q_points  # noqa: F841
     q_points = np.ascontiguousarray(np.transpose(q_points))
 
-    q_points = make_obj_array(
+    q_points = obj_array_1d(
         [cl.array.to_device(queue, q_points[i]) for i in range(dim)]
     )
     q_weights = cl.array.to_device(queue, q_weights)

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1934,7 +1934,7 @@ class NearFieldInteractionTable:
 
         where :math:`B` is the source box :math:`[0, source_box_extent]^dim`.
         """
-        logger.warn("this method is currently under construction.")
+        logger.warning("this method is currently under construction.")
 
         if ncpus is None:
             import multiprocessing
@@ -2058,7 +2058,7 @@ class NearFieldInteractionTable:
                     - bind(discr, sym.integral(self.dim, self.dim, 1))(queue)
                 ) / (np.pi * r**2 - (2 * hs) ** 2)
                 if arerr > 1e-12:
-                    log_to = logger.warn
+                    log_to = logger.warning
                 else:
                     log_to = logger.debug
                 log_to(
@@ -2072,10 +2072,10 @@ class NearFieldInteractionTable:
                     - bind(discr, sym.integral(self.dim, self.dim, 1))(queue)
                 ) / (4 / 3 * np.pi * r**3 - (2 * hs) ** 3)
                 if arerr > 1e-12:
-                    log_to = logger.warn
+                    log_to = logger.warning
                 else:
                     log_to = logger.debug
-                logger.warn(
+                logger.warning(
                     "The numerical error when computing the measure of a "
                     "unit ball is %e" % arerr
                 )
@@ -2225,7 +2225,7 @@ class NearFieldInteractionTable:
                     val - radius ** (-2 * s) * 2 * np.pi * (1 / (2 * s)) * scaling
                 ) / (radius ** (-2 * s) * 2 * np.pi * (1 / (2 * s)) * scaling)
                 if test_err > 1e-12:
-                    logger.warn("Error evaluating at origin = %f" % test_err)
+                    logger.warning("Error evaluating at origin = %f" % test_err)
 
             for tid, target in enumerate(self.q_points):
                 # The formula assumes that the source box is centered at origin

--- a/volumential/tools.py
+++ b/volumential/tools.py
@@ -556,7 +556,7 @@ class DiscreteLegendreTransform(BoxSpecificMap):
             self.V.T * np.matmul(self.W, self.V) - np.diag(self.I)
         )
         if ortho_resid > 1e-13:
-            logger.warn(
+            logger.warning(
                 "Legendre polynomials' orthogonality residual = %f" % ortho_resid
             )
 

--- a/volumential/tree_interactive_build.py
+++ b/volumential/tree_interactive_build.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import pyopencl as cl
 import pyopencl.array
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import new_1d as obj_array_1d
 
 from boxtree import (
     Tree,
@@ -213,7 +213,7 @@ class BoxTree:
         for ilevel in range(nlevels):
             ids = np.where(box_levels == ilevel)[0].astype(self.box_id_dtype)
             level_boxes.append(cl.array.to_device(self.queue, ids))
-        self.level_boxes = make_obj_array(level_boxes)
+        self.level_boxes = obj_array_1d(level_boxes)
 
     @property
     def dimensions(self):
@@ -286,7 +286,7 @@ class QuadratureOnBoxTree:
             + 0.5 * side_lengths[:, None, None] * ref_points[None, :, :]
         )
         q_points = q_points.reshape(-1, dim).T
-        return make_obj_array(
+        return obj_array_1d(
             [cl.array.to_device(queue, np.ascontiguousarray(comp)) for comp in q_points]
         )
 
@@ -303,7 +303,7 @@ class QuadratureOnBoxTree:
 
     def get_cell_centers(self, queue):
         centers = self._leaf_centers()
-        return make_obj_array(
+        return obj_array_1d(
             [cl.array.to_device(queue, np.ascontiguousarray(comp)) for comp in centers]
         )
 
@@ -475,7 +475,7 @@ def build_particle_tree_from_box_tree(actx, box_tree, q_points_host):
     reordered_points = q_points_host[particle_perm]
     particle_id_dtype = np.int32
 
-    sources = make_obj_array(
+    sources = obj_array_1d(
         [
             actx.from_numpy(np.ascontiguousarray(reordered_points[:, iaxis]))
             for iaxis in range(dim)
@@ -514,7 +514,7 @@ def build_particle_tree_from_box_tree(actx, box_tree, q_points_host):
         box_flags_enum.HAS_SOURCE_CHILD_BOXES | box_flags_enum.HAS_TARGET_CHILD_BOXES
     )
 
-    zeros_bbox = make_obj_array(
+    zeros_bbox = obj_array_1d(
         [
             actx.from_numpy(np.zeros(aligned_nboxes, dtype=box_tree.coord_dtype))
             for _ in range(dim)


### PR DESCRIPTION
## Summary
- Replace remaining `logger.warn(...)` callsites in `tools.py`, `list1.py`, and `nearfield_potential_table.py` with `logger.warning(...)`.
- Migrate remaining `pytools.obj_array.make_obj_array(...)` usage in core modules to `pytools.obj_array.new_1d(...)` for compatibility with newer pytools APIs.
- Keep behavior unchanged while removing deprecation noise and standardizing helper usage across meshgen/interpolation/geometry/tree/wrangler/function-extension paths.

## Testing
- `rtk uv run python -m compileall volumential/tools.py volumential/nearfield_potential_table.py volumential/list1.py volumential/meshgen.py volumential/function_extension.py volumential/expansion_wrangler_fpnd.py volumential/interpolation.py volumential/geometry.py volumential/tree_interactive_build.py`
- `rtk uv run pytest --noconftest test/test_volume_fmm.py -k "volume_fmm_list1_multi_source_superposition or volume_fmm_rejects_multi_source_full_sumpy_path or volume_fmm_direct_eval_accepts_fmmlib_plain_arrays"`