### PR TITLE
feat(kernels): add Yukawa table parameter binding

### DIFF
--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -158,6 +158,80 @@ Split order :math:`p` extracts
 into prebuilt split tables, while the online remainder keeps the constant,
 even powers, and higher odd powers.
 
+Design Principles (Why This Layer Exists)
+-----------------------------------------
+
+The split implementation is organized around a **kernel-agnostic basis cache**
+plus **runtime kernel coefficients**.
+
+- Split basis tables (Laplace + split terms such as ``power``/``power_log``)
+  depend on geometry/discretization, not on runtime wave number.
+- Helmholtz/Yukawa parameter values are applied online in split coefficients and
+  smooth remainders.
+- This enables broad reuse across wave numbers while preserving correctness.
+
+In contrast, direct (non-split) parameterized kernel tables remain
+parameter-specific and are validated against requested kernel parameters when
+loaded from cache.
+
+Automatic Regime Planner
+------------------------
+
+For wide ranges of :math:`k` and mesh sizes, one fixed split order is often
+suboptimal. Volumential now provides a lightweight automatic planner that
+chooses split order from the dimensionless local scale
+
+.. math::
+
+    \rho_{\max} = \max_{\ell\in\text{active levels}} |k| h_\ell,
+
+where :math:`h_\ell` is source-box extent at level :math:`\ell`.
+
+For Yukawa split mode, the planner uses the internal mapping
+:math:`k = i\,\lambda`, so :math:`|k|=|\lambda|` in the same formula.
+
+Default planner policy:
+
+- thresholds: ``(0.5, 1.5, 3.0)``
+- split orders: ``(1, 2, 3, 4)``
+
+meaning:
+
+- :math:`\rho_{\max} \le 0.5 \Rightarrow p=1`
+- :math:`0.5 < \rho_{\max} \le 1.5 \Rightarrow p=2`
+- :math:`1.5 < \rho_{\max} \le 3.0 \Rightarrow p=3`
+- :math:`\rho_{\max} > 3.0 \Rightarrow p=4`
+
+These defaults are intentionally conservative and can be tuned per workload.
+
+Runtime Configuration Knobs
+---------------------------
+
+You may enable auto selection by either:
+
+- passing ``helmholtz_split_order="auto"``, or
+- passing ``helmholtz_split_auto_config={"enabled": True, ...}``.
+
+Supported planner config keys:
+
+- ``rho_thresholds``: sequence of increasing boundaries
+- ``orders``: sequence of selected orders (length = ``len(rho_thresholds)+1``)
+- ``order_min`` / ``order_max``: optional clamps
+- ``smooth_quad_order_min``: floor for smooth quadrature order
+- ``smooth_quad_order_per_order``: increment per additional split order above 1
+
+When auto mode is active and ``helmholtz_split_smooth_quad_order`` is not set,
+the smooth quadrature order is chosen from these knobs instead of forcing
+``m=q``.
+
+Yukawa and Mixed-Complex Parameters
+-----------------------------------
+
+- Yukawa split reuse follows the same basis-table mechanism as Helmholtz.
+- Current Yukawa split path requires real ``lam``.
+- For mixed complex wave numbers (nonzero real+imag parts), use Helmholtz
+  kernels directly.
+
 Implementation Notes
 --------------------
 

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -486,13 +486,14 @@ Supported planner config keys:
 - ``rho_base_real`` / ``rho_base_imag``: base values for default geometric
   threshold ladders for :math:`|\Re(k)|h` and :math:`|\Im(k)|h`
 - ``rho_imag_split_max``: maximum :math:`|\Im(k)|h` for default split mode
-- ``disable_split_if_outside_coverage``: if true, auto mode falls back to
-  direct (non-split) near-field evaluation when :math:`|\Im(k)|h` exceeds
-  ``rho_imag_split_max``
+- ``disable_split_if_outside_coverage``: when :math:`|\Im(k)|h` exceeds
+  ``rho_imag_split_max``, Volumential currently emits warnings and keeps split
+  evaluation enabled (direct fallback is not performed because it would require
+  matching direct near-field tables)
 
-By default, ``disable_split_if_outside_coverage`` is ``False``. In that mode,
-auto selection keeps split enabled, clamps to the highest configured split
-order, and emits warnings when :math:`|\Im(k)|h` exceeds configured coverage.
+By default, ``disable_split_if_outside_coverage`` is ``False``. Auto selection
+keeps split enabled, clamps to the highest configured split order, and emits
+warnings when :math:`|\Im(k)|h` exceeds configured coverage.
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
   for easy/moderate attenuation regimes (default ``1``)

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -491,9 +491,10 @@ Supported planner config keys:
   evaluation enabled (direct fallback is not performed because it would require
   matching direct near-field tables)
 
-By default, ``disable_split_if_outside_coverage`` is ``False``. Auto selection
-keeps split enabled, clamps to the highest configured split order, and emits
-warnings when :math:`|\Im(k)|h` exceeds configured coverage.
+  By default, ``disable_split_if_outside_coverage`` is ``False``. Auto
+  selection keeps split enabled, clamps to the highest configured split order,
+  and emits warnings when :math:`|\Im(k)|h` exceeds configured coverage.
+
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
   for easy/moderate attenuation regimes (default ``1``)

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -217,6 +217,12 @@ Supported planner config keys:
 - ``order_min`` / ``order_max``: optional clamps
 - ``rho_base_real`` / ``rho_base_imag``: base values for default geometric
   threshold ladders for :math:`|\Re(k)|h` and :math:`|\Im(k)|h`
+- ``exp_tail_guardrail_enabled``: enable exponential-tail order guardrail
+- ``exp_tail_rel_tol``: relative tail tolerance for the exponential guardrail
+- ``rho_imag_split_max``: maximum :math:`|\Im(k)|h` for default split mode
+- ``disable_split_if_outside_coverage``: if true, auto mode falls back to
+  direct (non-split) near-field evaluation when :math:`|\Im(k)|h` exceeds
+  ``rho_imag_split_max``
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
 

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -33,6 +33,35 @@ Hence the neighbor potential contribution is
     + \mathcal{N}_{S_p,\mathrm{table}}[\rho]
     + \mathcal{N}_{R_p,\mathrm{p2p}}[\rho].
 
+Reusable Split-Term Notation
+----------------------------
+
+To avoid duplicating implementation logic, both 2D and 3D paths are written in
+the same abstract form:
+
+.. math::
+
+    G_k(r) - G_0(r)
+    = C_k + \sum_{n\ge 1} \beta_n(k)\,\phi_n(r) + \Psi_k(r),
+
+where:
+
+- :math:`\phi_n` are the non-smooth radial basis terms that get table support,
+- :math:`\beta_n(k)` are runtime coefficients,
+- :math:`\Psi_k` is the remaining smooth/higher-order part evaluated online.
+
+For split order :math:`p`, Volumential tables
+:math:`\{\phi_1,\ldots,\phi_{p-1}\}` and evaluates
+
+.. math::
+
+    R_p(r) = C_k + \sum_{n\ge p} \beta_n(k)\,\phi_n(r) + \Psi_k(r)
+
+in the online correction path.
+
+This is exactly the same cache/reuse pattern used for Helmholtz and Yukawa;
+Yukawa uses the mapping :math:`k=i\lambda` in the coefficient formulas.
+
 2D Expansion
 ------------
 
@@ -71,6 +100,27 @@ with
       \left[
         \frac{H_n - (\log(k/2)+\gamma)}{2\pi} + \frac{i}{4}
       \right].
+
+These coefficients come directly from the classical small-argument expansions:
+
+.. math::
+
+    J_0(z) = \sum_{n=0}^{\infty} \frac{(-1)^n}{(n!)^2}\left(\frac{z^2}{4}\right)^n,
+
+.. math::
+
+    Y_0(z) = \frac{2}{\pi}\left(\log(z/2)+\gamma\right)J_0(z)
+    - \frac{2}{\pi}\sum_{n=1}^{\infty} H_n
+      \frac{(-1)^n}{(n!)^2}\left(\frac{z^2}{4}\right)^n,
+
+with :math:`H_0^{(1)}(z)=J_0(z)+iY_0(z)` and :math:`z=kr`.
+
+Using the reusable notation above:
+
+- :math:`\phi_n(r)=r^{2n}\log r`,
+- :math:`\beta_n(k)=a_n(k)`,
+- :math:`\Psi_k(r)=\sum_{n\ge 1} b_n(k)r^{2n}`,
+- :math:`C_k=c_0(k)`.
 
 Split order :math:`p` means:
 
@@ -148,6 +198,13 @@ we have
     \qquad
     c_n(k)=\frac{(ik)^n}{4\pi\,n!}.
 
+Equivalently, from :math:`e^{ikr}=\sum_{n\ge 0}(ikr)^n/n!`:
+
+.. math::
+
+    \frac{e^{ikr}-1}{4\pi r}
+    = \sum_{n=1}^{\infty}\frac{(ik)^n}{4\pi\,n!}r^{n-1}.
+
 Terms :math:`r^{2j-1}` are the non-smooth radial powers at the origin.
 Split order :math:`p` extracts
 
@@ -157,6 +214,214 @@ Split order :math:`p` extracts
 
 into prebuilt split tables, while the online remainder keeps the constant,
 even powers, and higher odd powers.
+
+Using the reusable notation above:
+
+- :math:`\phi_j(r)=r^{2j-1}` (odd-power branch),
+- :math:`\beta_j(k)=(ik)^{2j}/(4\pi(2j)!)`,
+- :math:`\Psi_k` collects constant/even-power terms and odd powers
+  :math:`j\ge p`.
+
+High-Reference Wideband Convergence Snapshot
+--------------------------------------------
+
+Copy of the IPA table used in PR #79 for split-auto defaults
+(``helmholtz_split_order="auto"`` with auto smooth quadrature), reporting
+``rel_vs_direct_high``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 5 6 6 8 8 6 6 14
+
+   * - Kernel
+     - Dim
+     - Re(k)
+     - Im(k)
+     - rho_real
+     - rho_imag
+     - auto p
+     - auto m
+     - rel_vs_direct_high
+   * - Helmholtz
+     - 2
+     - 2.0
+     - 0
+     - 0.5
+     - 0
+     - 3
+     - 7
+     - 2.3436e-08
+   * - Helmholtz
+     - 2
+     - 8.0
+     - 0
+     - 2.0
+     - 0
+     - 5
+     - 9
+     - 7.9173e-08
+   * - Helmholtz
+     - 2
+     - 16.0
+     - 0
+     - 4.0
+     - 0
+     - 6
+     - 11
+     - 3.3398e-07
+   * - Helmholtz
+     - 2
+     - 32.0
+     - 0
+     - 8.0
+     - 0
+     - 7
+     - 14
+     - 2.6230e-06
+   * - Helmholtz
+     - 3
+     - 2.0
+     - 0
+     - 0.5
+     - 0
+     - 3
+     - 5
+     - 2.2215e-12
+   * - Helmholtz
+     - 3
+     - 4.0
+     - 0
+     - 1.0
+     - 0
+     - 4
+     - 6
+     - 1.3885e-13
+   * - Helmholtz
+     - 3
+     - 6.0
+     - 0
+     - 1.5
+     - 0
+     - 5
+     - 7
+     - 5.5698e-13
+   * - Helmholtz
+     - 3
+     - 8.0
+     - 0
+     - 2.0
+     - 0
+     - 5
+     - 7
+     - 3.4457e-12
+   * - Helmholtz
+     - 3
+     - 10.0
+     - 0
+     - 2.5
+     - 0
+     - 6
+     - 8
+     - 1.9042e-11
+   * - Helmholtz
+     - 3
+     - 12.0
+     - 0
+     - 3.0
+     - 0
+     - 6
+     - 8
+     - 1.9167e-10
+   * - Helmholtz
+     - 3
+     - 16.0
+     - 0
+     - 4.0
+     - 0
+     - 6
+     - 9
+     - 1.1670e-08
+   * - Yukawa
+     - 2
+     - 0
+     - 8
+     - 0
+     - 2.0
+     - 4
+     - 8
+     - 1.8611e-09
+   * - Yukawa
+     - 2
+     - 0
+     - 16
+     - 0
+     - 4.0
+     - 5
+     - 9
+     - 6.1665e-08
+   * - Yukawa
+     - 2
+     - 0
+     - 24
+     - 0
+     - 6.0
+     - 6
+     - 12
+     - 1.2716e-07
+   * - Yukawa
+     - 2
+     - 0
+     - 32
+     - 0
+     - 8.0
+     - 6
+     - 14
+     - 6.6297e-08
+   * - Yukawa
+     - 3
+     - 0
+     - 2
+     - 0
+     - 0.5
+     - 2
+     - 4
+     - 4.8224e-07
+   * - Yukawa
+     - 3
+     - 0
+     - 4
+     - 0
+     - 1.0
+     - 3
+     - 5
+     - 8.7211e-07
+   * - Yukawa
+     - 3
+     - 0
+     - 8
+     - 0
+     - 2.0
+     - 4
+     - 6
+     - 2.0533e-06
+   * - Yukawa
+     - 3
+     - 0
+     - 12
+     - 0
+     - 3.0
+     - 5
+     - 7
+     - 3.8141e-06
+   * - Yukawa
+     - 3
+     - 0
+     - 16
+     - 0
+     - 4.0
+     - 5
+     - 7
+     - 6.1529e-06
 
 Design Principles (Why This Layer Exists)
 -----------------------------------------

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -192,17 +192,13 @@ For Yukawa split mode, the planner uses the internal mapping
 
 Default planner policy:
 
-- thresholds: ``(0.5, 1.5, 3.0)``
-- split orders: ``(1, 2, 3, 4)``
+- ``order_min=1``
+- ``order_max=8``
+- geometric rho ladder with ``rho_base=0.5``
 
-meaning:
-
-- :math:`\rho_{\max} \le 0.5 \Rightarrow p=1`
-- :math:`0.5 < \rho_{\max} \le 1.5 \Rightarrow p=2`
-- :math:`1.5 < \rho_{\max} \le 3.0 \Rightarrow p=3`
-- :math:`\rho_{\max} > 3.0 \Rightarrow p=4`
-
-These defaults are intentionally conservative and can be tuned per workload.
+This yields thresholds like ``(0.5, 1, 2, 4, 8, 16, 32)`` and candidate
+orders ``1..8``. This default is meant to cover wider :math:`k h` regimes than
+a short fixed threshold list.
 
 Runtime Configuration Knobs
 ---------------------------
@@ -217,6 +213,7 @@ Supported planner config keys:
 - ``rho_thresholds``: sequence of increasing boundaries
 - ``orders``: sequence of selected orders (length = ``len(rho_thresholds)+1``)
 - ``order_min`` / ``order_max``: optional clamps
+- ``rho_base``: base value for the default geometric threshold ladder
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
 

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -192,13 +192,16 @@ For Yukawa split mode, the planner uses the internal mapping
 
 Default planner policy:
 
-- ``order_min=1``
+- ``order_min=2``
 - ``order_max=12``
-- geometric rho ladders with ``rho_base_real=0.75`` and ``rho_base_imag=0.5``
+- geometric rho ladders with ``rho_base_real=0.25`` and ``rho_base_imag=0.5``
+- hard-real smooth trigger ``smooth_quad_order_hard_rho_real=3.0``
 
-This yields thresholds like ``(0.5, 1, 2, 4, 8, 16, 32)`` and candidate
-orders ``1..8``. This default is meant to cover wider :math:`k h` regimes than
-a short fixed threshold list.
+This yields thresholds like ``(0.25, 0.5, 1, 2, 4, 8, 16)`` for
+:math:`|\Re(k)|h` and ``(0.5, 1, 2, 4, 8, 16, 32)`` for
+:math:`|\Im(k)|h`, with candidate orders ``2..12``. This default is tuned to
+be more accuracy-forward in easy regimes while keeping split-order selection
+purely ladder-based.
 
 Runtime Configuration Knobs
 ---------------------------
@@ -217,11 +220,6 @@ Supported planner config keys:
 - ``order_min`` / ``order_max``: optional clamps
 - ``rho_base_real`` / ``rho_base_imag``: base values for default geometric
   threshold ladders for :math:`|\Re(k)|h` and :math:`|\Im(k)|h`
-- ``exp_tail_guardrail_enabled``: enable exponential-tail order guardrail
-- ``exp_tail_rel_tol``: relative tail tolerance for the exponential guardrail
-  (default ``2e-1``)
-- ``rho_imag_hard_trigger``: when :math:`|\Im(k)|h` exceeds this value,
-  auto mode promotes split order to ``order_max``
 - ``rho_imag_split_max``: maximum :math:`|\Im(k)|h` for default split mode
 - ``disable_split_if_outside_coverage``: if true, auto mode falls back to
   direct (non-split) near-field evaluation when :math:`|\Im(k)|h` exceeds
@@ -232,10 +230,49 @@ auto selection keeps split enabled, clamps to the highest configured split
 order, and emits warnings when :math:`|\Im(k)|h` exceeds configured coverage.
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
+  for easy/moderate attenuation regimes (default ``1``)
+- ``smooth_quad_order_per_order_hard``: increment per additional split order above
+  1 for hard attenuation regimes (default ``1``)
+- ``smooth_quad_order_hard_rho_imag``: hard-regime trigger on
+  :math:`|\Im(k)|h` for switching from
+  ``smooth_quad_order_per_order`` to
+  ``smooth_quad_order_per_order_hard`` (default ``4.0``)
+- ``smooth_quad_order_hard_rho_real``: hard-regime trigger on
+  :math:`|\Re(k)|h` for switching from
+  ``smooth_quad_order_per_order`` to
+  ``smooth_quad_order_per_order_hard`` (default ``3.0``)
+- ``smooth_quad_order_rho_boost_start``: start of direct
+  :math:`|\Im(k)|h`-based smooth-order boost (default same as
+  ``smooth_quad_order_hard_rho_imag``)
+- ``smooth_quad_order_rho_boost_scale``: boost slope in
+  :math:`\Delta m \approx \lceil \mathrm{scale}\cdot(
+  \rho_{\mathrm{imag}}-\rho_0)\rceil`
+  (default ``1.0``)
+- ``smooth_quad_order_rho_boost_cap``: optional cap on direct rho-based boost
+- ``smooth_quad_order_real_boost_start``: start of direct
+  :math:`|\Re(k)|h`-based smooth-order boost (default same as
+  ``smooth_quad_order_hard_rho_real``)
+- ``smooth_quad_order_real_boost_scale``: boost slope in
+  :math:`\Delta m \approx \lceil \mathrm{scale}\cdot(
+  \rho_{\mathrm{real}}-\rho_0)\rceil`
+  (default ``0.5``)
+- ``smooth_quad_order_real_boost_cap``: optional cap on direct
+  :math:`|\Re(k)|h`-based smooth-order boost
+- ``smooth_quad_order_max``: optional cap on final auto-selected smooth order
+- ``power_log_single_table_beta_mode``: backend for the
+  :math:`(\log \alpha_\ell)r^{2n}` correction when 2D ``power_log`` terms use
+  one reference table. ``"p2p"`` (default) evaluates this correction online
+  with the active smooth-correction source layout (including oversampled
+  ``m>q`` sources). ``"table"`` evaluates it via split-power tables.
 
 When auto mode is active and ``helmholtz_split_smooth_quad_order`` is not set,
 the smooth quadrature order is chosen from these knobs instead of forcing
-``m=q``.
+``m=q``. The default policy is accuracy-forward in easy regimes
+(``smooth_quad_order_per_order=1``) while retaining stronger smooth-quadrature
+growth in hard attenuation regimes via
+``smooth_quad_order_per_order_hard=1`` and an additional direct
+:math:`|\Im(k)|h`-based boost, while also allowing extra smooth-order growth
+for high real-frequency regimes via :math:`|\Re(k)|h`-based triggers/boosts.
 
 Yukawa and Mixed-Complex Parameters
 -----------------------------------
@@ -248,7 +285,9 @@ Yukawa and Mixed-Complex Parameters
 Implementation Notes
 --------------------
 
-- ``helmholtz_split_smooth_quad_order`` defaults to ``m=q``.
+- ``helmholtz_split_smooth_quad_order`` defaults to ``m=q`` when auto mode is
+  inactive. In auto mode, the default smooth order follows the planner policy
+  described above.
 - split-order-1 now defaults to the analytic series-remainder kernel path,
   avoiding runtime Helmholtz-minus-Laplace singular subtraction.
 - the historical split-order-1 subtraction path is still available for
@@ -268,9 +307,15 @@ Implementation Notes
 
       (\log \alpha_\ell) r^{2n}
 
-  is added online by folding :math:`\log \alpha_\ell` into source strengths,
-  where :math:`\alpha_\ell = h_\ell / h_{\mathrm{ref}}` and :math:`h_\ell` is
-  the source-box extent.
+  is added online by folding :math:`\log \alpha_\ell` into source strengths
+  and evaluating the matching :math:`r^{2n}` correction kernel. By default this
+  uses an online P2P correction with the same source layout as the active
+  smooth-correction path (including oversampled ``m>q`` sources), which avoids
+  prebuilding extra split-power tables and typically improves list1 throughput
+  on GPU. The alternative table-based correction path can be selected with
+  ``helmholtz_split_auto_config={"power_log_single_table_beta_mode": "table"}``.
+  Here :math:`\alpha_\ell = h_\ell / h_{\mathrm{ref}}` and :math:`h_\ell` is the
+  source-box extent.
 - when self interactions are excluded in correction P2P, the finite
   :math:`r\to0` diagonal limit of :math:`G_k-G_0` is added back analytically.
 

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -194,7 +194,7 @@ Default planner policy:
 
 - ``order_min=1``
 - ``order_max=8``
-- geometric rho ladder with ``rho_base=0.5``
+- geometric rho ladders with ``rho_base_real=0.75`` and ``rho_base_imag=0.5``
 
 This yields thresholds like ``(0.5, 1, 2, 4, 8, 16, 32)`` and candidate
 orders ``1..8``. This default is meant to cover wider :math:`k h` regimes than
@@ -211,9 +211,12 @@ You may enable auto selection by either:
 Supported planner config keys:
 
 - ``rho_thresholds``: sequence of increasing boundaries
+- ``rho_thresholds_real`` / ``rho_thresholds_imag``: optional per-component
+  threshold ladders (override defaults)
 - ``orders``: sequence of selected orders (length = ``len(rho_thresholds)+1``)
 - ``order_min`` / ``order_max``: optional clamps
-- ``rho_base``: base value for the default geometric threshold ladder
+- ``rho_base_real`` / ``rho_base_imag``: base values for default geometric
+  threshold ladders for :math:`|\Re(k)|h` and :math:`|\Im(k)|h`
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
 

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -193,7 +193,7 @@ For Yukawa split mode, the planner uses the internal mapping
 Default planner policy:
 
 - ``order_min=1``
-- ``order_max=8``
+- ``order_max=12``
 - geometric rho ladders with ``rho_base_real=0.75`` and ``rho_base_imag=0.5``
 
 This yields thresholds like ``(0.5, 1, 2, 4, 8, 16, 32)`` and candidate
@@ -219,6 +219,9 @@ Supported planner config keys:
   threshold ladders for :math:`|\Re(k)|h` and :math:`|\Im(k)|h`
 - ``exp_tail_guardrail_enabled``: enable exponential-tail order guardrail
 - ``exp_tail_rel_tol``: relative tail tolerance for the exponential guardrail
+  (default ``2e-1``)
+- ``rho_imag_hard_trigger``: when :math:`|\Im(k)|h` exceeds this value,
+  auto mode promotes split order to ``order_max``
 - ``rho_imag_split_max``: maximum :math:`|\Im(k)|h` for default split mode
 - ``disable_split_if_outside_coverage``: if true, auto mode falls back to
   direct (non-split) near-field evaluation when :math:`|\Im(k)|h` exceeds

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -223,6 +223,10 @@ Supported planner config keys:
 - ``disable_split_if_outside_coverage``: if true, auto mode falls back to
   direct (non-split) near-field evaluation when :math:`|\Im(k)|h` exceeds
   ``rho_imag_split_max``
+
+By default, ``disable_split_if_outside_coverage`` is ``False``. In that mode,
+auto selection keeps split enabled, clamps to the highest configured split
+order, and emits warnings when :math:`|\Im(k)|h` exceeds configured coverage.
 - ``smooth_quad_order_min``: floor for smooth quadrature order
 - ``smooth_quad_order_per_order``: increment per additional split order above 1
 

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -50,7 +50,7 @@ where:
 - :math:`\beta_n(k)` are runtime coefficients,
 - :math:`\Psi_k` is the remaining smooth/higher-order part evaluated online.
 
-For split order :math:`p`, Volumential tables
+For split order :math:`p`, Volumential pretabulates
 :math:`\{\phi_1,\ldots,\phi_{p-1}\}` and evaluates
 
 .. math::

--- a/doc/source/helmholtz_split.rst
+++ b/doc/source/helmholtz_split.rst
@@ -444,16 +444,19 @@ Automatic Regime Planner
 
 For wide ranges of :math:`k` and mesh sizes, one fixed split order is often
 suboptimal. Volumential now provides a lightweight automatic planner that
-chooses split order from the dimensionless local scale
+chooses split order from the dimensionless local scales
 
 .. math::
 
-    \rho_{\max} = \max_{\ell\in\text{active levels}} |k| h_\ell,
+    \rho_{\mathrm{real}} &= \max_{\ell\in\text{active levels}} |\Re(k)| h_\ell, \\
+    \rho_{\mathrm{imag}} &= \max_{\ell\in\text{active levels}} |\Im(k)| h_\ell, \\
+    \rho_{\max} &= \max(\rho_{\mathrm{real}}, \rho_{\mathrm{imag}}),
 
 where :math:`h_\ell` is source-box extent at level :math:`\ell`.
 
 For Yukawa split mode, the planner uses the internal mapping
-:math:`k = i\,\lambda`, so :math:`|k|=|\lambda|` in the same formula.
+:math:`k = i\,\lambda`, so the same component-wise scales are formed from
+:math:`\Re(i\lambda)` and :math:`\Im(i\lambda)`.
 
 Default planner policy:
 

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -715,6 +715,7 @@ def test_duffy_radial_auto_tune_orders_routes_to_batched_builder(monkeypatch):
         sample_count=5,
         candidates=None,
         floor_factor=8.0,
+        kernel_kwargs=None,
     ):
         seen["auto_called"] = True
         seen["sample_count"] = sample_count
@@ -797,6 +798,7 @@ def test_duffy_radial_auto_keyword_orders_trigger_autotune(monkeypatch):
         sample_count=5,
         candidates=None,
         floor_factor=8.0,
+        kernel_kwargs=None,
     ):
         seen["auto_called"] = True
         return (
@@ -874,6 +876,7 @@ def test_duffy_radial_partial_auto_order_keeps_explicit_value(monkeypatch):
         sample_count=5,
         candidates=None,
         floor_factor=8.0,
+        kernel_kwargs=None,
     ):
         seen["auto_called"] = True
         return (

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -1288,6 +1288,72 @@ def test_duffy_radial_routes_queue_to_batched_builder_3d(monkeypatch):
     assert table.last_duffy_build_timings["normalizer_s"] == 0.0
 
 
+def test_duffy_radial_wrapped_kernel_does_not_fallback_to_scalar(monkeypatch):
+    class WrappedKernel:
+        def __init__(self):
+            self._base = object()
+
+        def get_base_kernel(self):
+            return self._base
+
+    table = npt.NearFieldInteractionTable(
+        quad_order=2,
+        build_method="DuffyRadial",
+        dim=2,
+        sumpy_kernel=WrappedKernel(),
+        derive_kernel_func=False,
+        progress_bar=False,
+    )
+
+    seen = {"scalar_called": False}
+
+    def fake_build_normalizer_table(self, pool=None, pb=None):
+        pass
+
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
+        raise RuntimeError("batched failed")
+
+    def fake_scalar(
+        self,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
+        seen["scalar_called"] = True
+        self.is_built = True
+
+    monkeypatch.setattr(
+        npt.NearFieldInteractionTable,
+        "build_normalizer_table",
+        fake_build_normalizer_table,
+    )
+    monkeypatch.setattr(
+        npt.NearFieldInteractionTable,
+        "build_table_via_duffy_radial_batched",
+        fake_batched,
+    )
+    monkeypatch.setattr(
+        npt.NearFieldInteractionTable,
+        "_build_table_via_duffy_radial_scalar",
+        fake_scalar,
+    )
+
+    with pytest.raises(RuntimeError, match="scalar fallback is disabled"):
+        table.build_table_via_duffy_radial(queue=object())
+
+    assert not seen["scalar_called"]
+
+
 def _get_cpu_queue_or_skip(ctx_factory):
     import pyopencl as cl
 

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -1354,6 +1354,60 @@ def test_duffy_radial_wrapped_kernel_does_not_fallback_to_scalar(monkeypatch):
     assert not seen["scalar_called"]
 
 
+def test_duffy_radial_adaptive_rejects_wrapped_kernel_scalar_path(monkeypatch):
+    class WrappedKernel:
+        def __init__(self):
+            self._base = object()
+
+        def get_base_kernel(self):
+            return self._base
+
+    table = npt.NearFieldInteractionTable(
+        quad_order=2,
+        build_method="DuffyRadial",
+        dim=2,
+        sumpy_kernel=WrappedKernel(),
+        derive_kernel_func=False,
+        progress_bar=False,
+    )
+
+    seen = {"scalar_called": False}
+
+    def fake_build_normalizer_table(self, pool=None, pb=None):
+        pass
+
+    def fake_scalar(
+        self,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
+        seen["scalar_called"] = True
+
+    monkeypatch.setattr(
+        npt.NearFieldInteractionTable,
+        "build_normalizer_table",
+        fake_build_normalizer_table,
+    )
+    monkeypatch.setattr(
+        npt.NearFieldInteractionTable,
+        "_build_table_via_duffy_radial_scalar",
+        fake_scalar,
+    )
+
+    with pytest.raises(RuntimeError, match="Adaptive DuffyRadial scalar build"):
+        table.build_table_via_duffy_radial(
+            radial_rule="adaptive",
+            regular_quad_order=8,
+            radial_quad_order=31,
+            mp_dps=50,
+        )
+
+    assert not seen["scalar_called"]
+
+
 def _get_cpu_queue_or_skip(ctx_factory):
     import pyopencl as cl
 

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -1408,6 +1408,36 @@ def test_duffy_radial_adaptive_rejects_wrapped_kernel_scalar_path(monkeypatch):
     assert not seen["scalar_called"]
 
 
+def test_duffy_runtime_kernel_kwargs_reject_none_or_nonnumeric():
+    class FakeLoopyArg:
+        def __init__(self, name):
+            self.name = name
+
+    class FakeKernelArg:
+        def __init__(self, name):
+            self.loopy_arg = FakeLoopyArg(name)
+
+    class FakeKernel:
+        def get_args(self):
+            return [FakeKernelArg("lam")]
+
+    table = npt.NearFieldInteractionTable(
+        quad_order=2,
+        build_method="DuffyRadial",
+        dim=2,
+        sumpy_kernel=object(),
+        derive_kernel_func=False,
+        progress_bar=False,
+    )
+    table.integral_knl = FakeKernel()
+
+    with pytest.raises(TypeError, match="lam=None"):
+        table._extract_integral_kernel_runtime_kwargs({"lam": None})
+
+    with pytest.raises(TypeError, match="expected numeric scalar"):
+        table._extract_integral_kernel_runtime_kwargs({"lam": "abc"})
+
+
 def _get_cpu_queue_or_skip(ctx_factory):
     import pyopencl as cl
 

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -415,7 +415,15 @@ def test_duffy_radial_routes_queue_to_batched_builder(monkeypatch):
     def fake_build_normalizer_table(self, pool=None, pb=None):
         self.mode_normalizers[:] = 1
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["queue"] = queue
         seen["called"] = True
         self.is_built = True
@@ -455,7 +463,15 @@ def test_build_table_uses_supplied_cl_ctx_when_queue_missing(monkeypatch):
     def fake_build_normalizer_table(self, pool=None, pb=None):
         pass
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["queue"] = queue
         self.is_built = True
 
@@ -505,7 +521,15 @@ def test_duffy_radial_keeps_legacy_deg_theta_alias(monkeypatch):
     def fake_build_normalizer_table(self, pool=None, pb=None):
         pass
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["called"] = True
         seen["regular_quad_order"] = deg_theta
 
@@ -544,7 +568,15 @@ def test_duffy_radial_accepts_build_config_dataclass(monkeypatch):
     def fake_build_normalizer_table(self, pool=None, pb=None):
         pass
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["called"] = True
         seen["radial_rule"] = radial_rule
         seen["regular_quad_order"] = deg_theta
@@ -596,7 +628,15 @@ def test_duffy_radial_adaptive_rule_uses_scalar_fallback(monkeypatch):
     def fake_build_normalizer_table(self, pool=None, pb=None):
         self.mode_normalizers[:] = 1
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["batched_called"] = True
         raise AssertionError("adaptive rule should not use batched builder")
 
@@ -689,7 +729,15 @@ def test_duffy_radial_auto_tune_orders_routes_to_batched_builder(monkeypatch):
             },
         )
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["called"] = True
         seen["regular_quad_order"] = deg_theta
         seen["radial_quad_order"] = radial_quad_order
@@ -761,7 +809,15 @@ def test_duffy_radial_auto_keyword_orders_trigger_autotune(monkeypatch):
             },
         )
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["called"] = True
         seen["regular_quad_order"] = deg_theta
         seen["radial_quad_order"] = radial_quad_order
@@ -830,7 +886,15 @@ def test_duffy_radial_partial_auto_order_keeps_explicit_value(monkeypatch):
             },
         )
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["called"] = True
         seen["regular_quad_order"] = deg_theta
         seen["radial_quad_order"] = radial_quad_order
@@ -968,7 +1032,15 @@ def test_duffy_radial_batched_initializes_normalizers(monkeypatch):
         self.mode_normalizers[:] = 2
         seen["normalizers"] = True
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         assert seen["normalizers"]
         self.is_built = True
 
@@ -1114,7 +1186,15 @@ def test_duffy_radial_routes_queue_to_batched_builder_1d(monkeypatch):
     def fail_build_normalizer_table(self, pool=None, pb=None):
         raise AssertionError("normalizer table should not be built in 1D")
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["queue"] = queue
         seen["dim"] = self.dim
         seen["called"] = True
@@ -1163,7 +1243,15 @@ def test_duffy_radial_routes_queue_to_batched_builder_3d(monkeypatch):
     def fail_build_normalizer_table(self, pool=None, pb=None):
         raise AssertionError("normalizer table should not be built in 3D")
 
-    def fake_batched(self, queue, radial_rule, deg_theta, radial_quad_order, mp_dps):
+    def fake_batched(
+        self,
+        queue,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
         seen["queue"] = queue
         seen["dim"] = self.dim
         seen["called"] = True

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -141,6 +141,26 @@ def test_sumpy_kernel_to_lambda_lambdifies_once(monkeypatch):
     assert call_count["n"] == 1
 
 
+def test_sumpy_kernel_to_lambda_applies_wrapper_postprocess():
+    class FakeKernel:
+        dim = 1
+
+        def get_expression(self, args):
+            return args[0]
+
+        def postprocess_at_source(self, expr, bvec):
+            return expr + 1
+
+        def postprocess_at_target(self, expr, bvec):
+            return 2 * expr
+
+        def get_global_scaling_const(self):
+            return 3
+
+    knl_func = npt.sumpy_kernel_to_lambda(FakeKernel())
+    assert knl_func(4.0) == 30.0
+
+
 def cheb_eval(dim, coefs, coords):
     if dim == 1:
         return chebval(coords[0], coefs)
@@ -1436,6 +1456,12 @@ def test_duffy_runtime_kernel_kwargs_reject_none_or_nonnumeric():
 
     with pytest.raises(TypeError, match="expected numeric scalar"):
         table._extract_integral_kernel_runtime_kwargs({"lam": "abc"})
+
+    with pytest.raises(TypeError, match="expected finite numeric scalar"):
+        table._extract_integral_kernel_runtime_kwargs({"lam": np.nan})
+
+    with pytest.raises(TypeError, match="expected finite numeric scalar"):
+        table._extract_integral_kernel_runtime_kwargs({"lam": np.inf})
 
 
 def _get_cpu_queue_or_skip(ctx_factory):

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -74,6 +74,42 @@ def test_get_table_2d_order1(table_2d_order1):
     assert table.dim == 2
 
 
+def test_get_table_yukawa_requires_lambda(ctx_factory, tmp_path):
+    cl_ctx = ctx_factory()
+    queue = cl.CommandQueue(cl_ctx)
+
+    cache_file = tmp_path / "nft-yukawa-requires-lam.sqlite"
+    with NFTable(str(cache_file), progress_bar=False) as table_manager:
+        with pytest.raises(TypeError, match="missing kernel parameter"):
+            table_manager.get_table(
+                2,
+                "Yukawa",
+                q_order=1,
+                force_recompute=True,
+                queue=queue,
+            )
+
+
+def test_get_table_yukawa_builds_with_lambda(ctx_factory, tmp_path):
+    cl_ctx = ctx_factory()
+    queue = cl.CommandQueue(cl_ctx)
+
+    cache_file = tmp_path / "nft-yukawa-with-lam.sqlite"
+    with NFTable(str(cache_file), progress_bar=False) as table_manager:
+        table, _ = table_manager.get_table(
+            2,
+            "Yukawa",
+            q_order=1,
+            lam=3.0,
+            force_recompute=True,
+            queue=queue,
+        )
+
+    assert table.is_built
+    values = np.array([table.get_entry_data(i) for i in range(len(table.data))])
+    assert np.all(np.isfinite(values))
+
+
 def laplace_const_source_same_box(table_2d_order1, queue, q_order, dim=2):
     if q_order == 1:
         nft = table_2d_order1

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -42,6 +42,7 @@ import pyopencl as cl
 
 import volumential as vm
 from volumential.table_manager import NearFieldInteractionTableManager as NFTable
+from volumential.table_manager import TableRequest
 
 
 def get_table(queue, q_order=1, dim=2):
@@ -108,6 +109,26 @@ def test_get_table_yukawa_builds_with_lambda(ctx_factory, tmp_path):
     assert table.is_built
     values = np.array([table.get_entry_data(i) for i in range(len(table.data))])
     assert np.all(np.isfinite(values))
+
+
+def test_load_saved_yukawa_table_rejects_lambda_mismatch(ctx_factory, tmp_path):
+    cl_ctx = ctx_factory()
+    queue = cl.CommandQueue(cl_ctx)
+
+    cache_file = tmp_path / "nft-yukawa-lam-mismatch.sqlite"
+    with NFTable(str(cache_file), progress_bar=False) as table_manager:
+        table_manager.get_table(
+            2,
+            "Yukawa",
+            q_order=1,
+            lam=3.0,
+            force_recompute=True,
+            queue=queue,
+        )
+
+        request = TableRequest.from_args(2, "Yukawa", 1, 0)
+        with pytest.raises(KeyError, match="kernel parameter 'lam' mismatch"):
+            table_manager._load_saved_table_for_request(request, lam=5.0)
 
 
 def laplace_const_source_same_box(table_2d_order1, queue, q_order, dim=2):

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -131,6 +131,27 @@ def test_load_saved_yukawa_table_rejects_lambda_mismatch(ctx_factory, tmp_path):
             table_manager._load_saved_table_for_request(request, lam=5.0)
 
 
+def test_load_saved_yukawa_table_accepts_float32_roundtrip(ctx_factory, tmp_path):
+    cl_ctx = ctx_factory()
+    queue = cl.CommandQueue(cl_ctx)
+
+    cache_file = tmp_path / "nft-yukawa-lam-float32-roundtrip.sqlite"
+    with NFTable(str(cache_file), progress_bar=False) as table_manager:
+        table_manager.get_table(
+            2,
+            "Yukawa",
+            q_order=1,
+            lam=np.float32(0.1),
+            force_recompute=True,
+            queue=queue,
+        )
+
+        request = TableRequest.from_args(2, "Yukawa", 1, 0)
+        table = table_manager._load_saved_table_for_request(request, lam=0.1)
+
+    assert table.is_built
+
+
 def laplace_const_source_same_box(table_2d_order1, queue, q_order, dim=2):
     if q_order == 1:
         nft = table_2d_order1

--- a/test/test_table_manager_sqlite_migration.py
+++ b/test/test_table_manager_sqlite_migration.py
@@ -205,7 +205,7 @@ def test_resolve_kernel_bundle_skips_python_kernel_lookup_for_sumpy(
         )
 
     assert bundle.sumpy_kernel is not None
-    assert bundle.kernel_func is None
+    assert callable(bundle.kernel_func)
 
 
 def test_load_saved_table_uses_payload_without_python_kernel_lookup(
@@ -296,7 +296,7 @@ def test_load_saved_table_uses_payload_without_python_kernel_lookup(
 
         loaded = table_manager.load_saved_table(3, "Laplace", q_order=1)
 
-    assert loaded.kernel_func is None
+    assert callable(loaded.kernel_func)
     assert np.allclose(loaded.q_points, payload_table.q_points)
     assert np.allclose(loaded.data, payload_table.data)
 
@@ -357,7 +357,7 @@ def test_get_table_recompute_skips_python_kernel_lookup_for_sumpy(
         table, is_recomputed = table_manager.get_table(3, "Laplace", q_order=1)
 
     assert is_recomputed
-    assert table.kernel_func is None
+    assert callable(table.kernel_func)
 
 
 def test_get_table_rejects_legacy_knl_func_kwarg(tmp_path):

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -977,6 +977,39 @@ def _get_laplace_2d_table(queue, table_path, q_order):
     return table
 
 
+def _get_yukawa_2d_tables(queue, table_path, q_order, lam, *, max_source_box_level):
+    from volumential.nearfield_potential_table import DuffyBuildConfig
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    regular_quad_order = max(8, 4 * q_order)
+    radial_quad_order = max(21, 10 * q_order)
+
+    build_config = DuffyBuildConfig(
+        radial_rule="tanh-sinh-fast",
+        regular_quad_order=regular_quad_order,
+        radial_quad_order=radial_quad_order,
+    )
+
+    tables = []
+    with NearFieldInteractionTableManager(
+        str(table_path), root_extent=2.0, queue=queue
+    ) as tm:
+        for source_box_level in range(max_source_box_level + 1):
+            table, _ = tm.get_table(
+                2,
+                "Yukawa",
+                q_order,
+                source_box_level=source_box_level,
+                force_recompute=False,
+                queue=queue,
+                build_config=build_config,
+                lam=lam,
+            )
+            tables.append(table)
+
+    return tables
+
+
 def _make_radial_power_kernel(dim, power):
     from pymbolic.primitives import make_sym_vector
     from sumpy.kernel import ExpressionKernel
@@ -1502,6 +1535,103 @@ def _run_2d_helmholtz_pde_case(
         )
 
     return result
+
+
+def _run_2d_yukawa_split_case(
+    ctx,
+    queue,
+    near_field_table,
+    *,
+    q_order,
+    nlevels,
+    fmm_order,
+    lam,
+    helmholtz_split=False,
+    helmholtz_split_order=1,
+):
+    from sumpy.expansion import DefaultExpansionFactory
+    from sumpy.kernel import YukawaKernel
+
+    from volumential.expansion_wrangler_fpnd import (
+        FPNDExpansionWrangler,
+        FPNDTreeIndependentDataForWrangler,
+    )
+    from volumential.volume_fmm import drive_volume_fmm
+
+    if np.imag(np.complex128(lam)) != 0.0:
+        raise NotImplementedError(
+            "Yukawa FMM path currently requires real lam; use HelmholtzKernel for mixed complex k"
+        )
+
+    dim = 2
+    mesh = mg.MeshGen2D(q_order, nlevels, -0.5, 0.5, queue=queue)
+    q_points, source_weights, tree, traversal = mg.build_geometry_info(
+        ctx,
+        queue,
+        dim,
+        q_order,
+        mesh,
+        bbox=np.array([[-0.5, 0.5]] * dim, dtype=np.float64),
+    )
+
+    source_coords_host = np.array([coords.get(queue) for coords in q_points])
+    x = source_coords_host[0]
+    y = source_coords_host[1]
+
+    source_vals_host = np.exp(-35.0 * ((x + 0.11) ** 2 + (y - 0.07) ** 2))
+    value_dtype = np.complex128 if helmholtz_split else np.float64
+    source_vals = cl.array.to_device(
+        queue,
+        np.ascontiguousarray(source_vals_host.astype(value_dtype)),
+    )
+
+    knl = YukawaKernel(dim)
+    expn_factory = DefaultExpansionFactory()
+    local_expn_class = expn_factory.get_local_expansion_class(knl)
+    mpole_expn_class = expn_factory.get_multipole_expansion_class(knl)
+
+    tree_indep = FPNDTreeIndependentDataForWrangler(
+        ctx,
+        partial(mpole_expn_class, knl),
+        partial(local_expn_class, knl),
+        [knl],
+        exclude_self=True,
+    )
+
+    self_extra_kwargs = {}
+    if tree.sources_are_targets:
+        self_extra_kwargs = {
+            "target_to_source": np.arange(tree.ntargets, dtype=np.int32)
+        }
+
+    wrangler = FPNDExpansionWrangler(
+        tree_indep=tree_indep,
+        queue=queue,
+        traversal=traversal,
+        near_field_table=near_field_table,
+        dtype=value_dtype,
+        fmm_level_to_order=lambda kernel, kernel_args, tree, lev: fmm_order,
+        quad_order=q_order,
+        kernel_extra_kwargs={knl.yukawa_lambda_name: lam},
+        self_extra_kwargs=self_extra_kwargs,
+        helmholtz_split=helmholtz_split,
+        helmholtz_split_order=helmholtz_split_order,
+    )
+
+    weighted_sources = source_vals * source_weights.astype(value_dtype)
+    (fmm_potentials,) = drive_volume_fmm(
+        traversal,
+        wrangler,
+        weighted_sources,
+        source_vals,
+        direct_evaluation=False,
+        list1_only=False,
+    )
+
+    return {
+        "potentials": fmm_potentials,
+        "n_points": int(source_vals_host.size),
+    }
 
 
 def _run_3d_gaussian_case(
@@ -2374,6 +2504,60 @@ def test_volume_fmm_2d_helmholtz_split_order2_runs(tmp_path):
 
     assert np.isfinite(result["rel_pde_residual"])
     assert result["rel_pde_residual"] < 1.0
+
+
+def test_volume_fmm_2d_yukawa_split_order2_runs(tmp_path):
+    ctx = _create_non_intel_opencl_context_or_skip()
+    queue = cl.CommandQueue(ctx)
+
+    q_order = 5
+    lam = 8.0
+    split_table = _get_laplace_2d_table(
+        queue,
+        tmp_path / "nft-yukawa2d-split-order2-q5.sqlite",
+        q_order,
+    )
+    split = _run_2d_yukawa_split_case(
+        ctx,
+        queue,
+        split_table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        lam=lam,
+        helmholtz_split=True,
+        helmholtz_split_order=2,
+    )
+
+    pot = split["potentials"].get(queue)
+    assert np.all(np.isfinite(pot))
+    assert split["n_points"] > 0
+
+
+def test_volume_fmm_2d_yukawa_complex_lambda_rejected(tmp_path):
+    ctx = _create_non_intel_opencl_context_or_skip()
+    queue = cl.CommandQueue(ctx)
+
+    q_order = 5
+    lam = 7.0 + 1.25j
+    split_table = _get_laplace_2d_table(
+        queue,
+        tmp_path / "nft-yukawa2d-split-complex-q5.sqlite",
+        q_order,
+    )
+
+    with pytest.raises(NotImplementedError, match="real lam"):
+        _run_2d_yukawa_split_case(
+            ctx,
+            queue,
+            split_table,
+            q_order=q_order,
+            nlevels=3,
+            fmm_order=16,
+            lam=lam,
+            helmholtz_split=True,
+            helmholtz_split_order=2,
+        )
 
 
 def test_volume_fmm_2d_helmholtz_split_order1_remainder_matches_legacy(tmp_path):

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -207,6 +207,48 @@ def test_validate_table_box_particle_layout_cached_separates_q_order(monkeypatch
     assert calls == [16, 25]
 
 
+def test_autobuild_split_source_levels_uses_base_table_levels():
+    import volumential.expansion_wrangler_fpnd as wrangler_mod
+
+    wrangler = wrangler_mod.FPNDExpansionWrangler.__new__(
+        wrangler_mod.FPNDExpansionWrangler
+    )
+    wrangler.queue = None
+    wrangler.table_starting_level = 0
+    fake_tree = SimpleNamespace(
+        box_source_counts_nonchild=_FakeDeviceArray(np.array([0, 0, 16, 16])),
+        box_levels=_FakeDeviceArray(np.array([0, 1, 2, 3])),
+        nlevels=4,
+    )
+    wrangler.traversal = SimpleNamespace(tree=fake_tree)
+
+    base_tables = [
+        SimpleNamespace(source_box_level=0),
+        SimpleNamespace(source_box_level=2),
+        SimpleNamespace(source_box_level=2),
+    ]
+
+    power_levels = wrangler._autobuild_helmholtz_split_source_box_levels(
+        base_tables,
+        [("power", 1)],
+    )
+    assert power_levels == [0, 2]
+
+    power_log_levels = wrangler._autobuild_helmholtz_split_source_box_levels(
+        base_tables,
+        [("power_log", 2)],
+    )
+    assert power_log_levels == [0, 2]
+
+    wrangler.table_starting_level = -1
+    inferred_tables = [SimpleNamespace(source_box_level=None)]
+    inferred_levels = wrangler._autobuild_helmholtz_split_source_box_levels(
+        inferred_tables,
+        [("power_log", 2)],
+    )
+    assert inferred_levels == [-1]
+
+
 def test_rebuild_tob_from_geometry_restores_unit_level_edges():
     from boxtree import make_tree_of_boxes_root, refine_and_coarsen_tree_of_boxes
 
@@ -1423,6 +1465,7 @@ def _run_2d_helmholtz_pde_case(
     helmholtz_split=False,
     helmholtz_split_order=1,
     helmholtz_split_smooth_quad_order=None,
+    helmholtz_split_auto_config=None,
     helmholtz_split_term_tables=None,
     helmholtz_split_order1_legacy_subtraction=False,
     compute_pde_residual=True,
@@ -1493,6 +1536,7 @@ def _run_2d_helmholtz_pde_case(
         helmholtz_split=helmholtz_split,
         helmholtz_split_order=helmholtz_split_order,
         helmholtz_split_smooth_quad_order=helmholtz_split_smooth_quad_order,
+        helmholtz_split_auto_config=helmholtz_split_auto_config,
         helmholtz_split_term_tables=helmholtz_split_term_tables,
         helmholtz_split_order1_legacy_subtraction=(
             helmholtz_split_order1_legacy_subtraction
@@ -1548,6 +1592,8 @@ def _run_2d_yukawa_split_case(
     lam,
     helmholtz_split=False,
     helmholtz_split_order=1,
+    helmholtz_split_auto_config=None,
+    return_state=False,
 ):
     from sumpy.expansion import DefaultExpansionFactory
     from sumpy.kernel import YukawaKernel
@@ -1616,6 +1662,7 @@ def _run_2d_yukawa_split_case(
         self_extra_kwargs=self_extra_kwargs,
         helmholtz_split=helmholtz_split,
         helmholtz_split_order=helmholtz_split_order,
+        helmholtz_split_auto_config=helmholtz_split_auto_config,
     )
 
     weighted_sources = source_vals * source_weights.astype(value_dtype)
@@ -1628,10 +1675,16 @@ def _run_2d_yukawa_split_case(
         list1_only=False,
     )
 
-    return {
+    result = {
         "potentials": fmm_potentials,
         "n_points": int(source_vals_host.size),
     }
+
+    if return_state:
+        result["wrangler"] = wrangler
+        result["traversal"] = traversal
+
+    return result
 
 
 def _run_3d_gaussian_case(
@@ -2588,9 +2641,113 @@ def test_volume_fmm_2d_yukawa_split_auto_high_rho_runs(tmp_path):
     assert np.all(np.isfinite(pot))
 
 
+def test_volume_fmm_2d_yukawa_split_auto_smooth_quad_policy(tmp_path):
+    ctx = _create_non_intel_opencl_context_or_skip()
+    queue = cl.CommandQueue(ctx)
+
+    q_order = 5
+    split_table = _get_laplace_2d_table(
+        queue,
+        tmp_path / "nft-yukawa2d-split-auto-smooth-policy-q5.sqlite",
+        q_order,
+    )
+
+    easy = _run_2d_yukawa_split_case(
+        ctx,
+        queue,
+        split_table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        lam=8.0,
+        helmholtz_split=True,
+        helmholtz_split_order="auto",
+        return_state=True,
+    )
+    easy_wrangler = easy["wrangler"]
+    easy_base_smooth = q_order + max(0, easy_wrangler.helmholtz_split_order - 1)
+    assert easy_wrangler.helmholtz_split_smooth_quad_order == easy_base_smooth
+    assert getattr(easy_wrangler, "_split_auto_rho_imag", np.inf) < 4.0
+
+    hard = _run_2d_yukawa_split_case(
+        ctx,
+        queue,
+        split_table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        lam=32.0,
+        helmholtz_split=True,
+        helmholtz_split_order="auto",
+        return_state=True,
+    )
+    hard_wrangler = hard["wrangler"]
+    assert getattr(hard_wrangler, "_split_auto_rho_imag", 0.0) >= 4.0
+    assert hard_wrangler.helmholtz_split_order > easy_wrangler.helmholtz_split_order
+    hard_base_smooth = q_order + max(0, hard_wrangler.helmholtz_split_order - 1)
+    assert hard_wrangler.helmholtz_split_smooth_quad_order >= hard_base_smooth
+    if getattr(hard_wrangler, "_split_auto_rho_imag", 0.0) > 4.0:
+        assert hard_wrangler.helmholtz_split_smooth_quad_order > hard_base_smooth
+
+
+def test_volume_fmm_2d_helmholtz_split_auto_real_smooth_quad_policy(tmp_path):
+    ctx = _create_non_intel_opencl_context_or_skip()
+    queue = cl.CommandQueue(ctx)
+
+    q_order = 5
+    table = _get_laplace_2d_table(
+        queue,
+        tmp_path / "nft-helmholtz2d-split-auto-real-smooth-policy-q5.sqlite",
+        q_order,
+    )
+
+    easy = _run_2d_helmholtz_pde_case(
+        ctx,
+        queue,
+        table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        wave_number=2.0,
+        helmholtz_split=True,
+        helmholtz_split_order="auto",
+        compute_pde_residual=False,
+        return_state=True,
+    )
+    easy_wrangler = easy["wrangler"]
+    assert getattr(easy_wrangler, "_split_auto_rho_real", np.inf) < 3.0
+    easy_base_smooth = q_order + max(0, easy_wrangler.helmholtz_split_order - 1)
+    assert easy_wrangler.helmholtz_split_smooth_quad_order == easy_base_smooth
+
+    hard = _run_2d_helmholtz_pde_case(
+        ctx,
+        queue,
+        table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        wave_number=30.0,
+        helmholtz_split=True,
+        helmholtz_split_order="auto",
+        helmholtz_split_auto_config={
+            "smooth_quad_order_hard_rho_real": 1.0,
+            "smooth_quad_order_real_boost_start": 1.0,
+            "smooth_quad_order_real_boost_scale": 1.0,
+            "smooth_quad_order_rho_boost_scale": 0.0,
+            "smooth_quad_order_hard_rho_imag": 1000.0,
+        },
+        compute_pde_residual=False,
+        return_state=True,
+    )
+    hard_wrangler = hard["wrangler"]
+    assert getattr(hard_wrangler, "_split_auto_rho_imag", np.inf) < 1000.0
+    assert getattr(hard_wrangler, "_split_auto_rho_real", 0.0) > 1.0
+    hard_base_smooth = q_order + max(0, hard_wrangler.helmholtz_split_order - 1)
+    assert hard_wrangler.helmholtz_split_smooth_quad_order > hard_base_smooth
+
+
 def test_select_split_order_from_rho_default_boundaries():
     from volumential.expansion_wrangler_fpnd import (
-        _select_split_order_from_exp_tail,
         _select_split_order_from_rho,
         _select_split_order_from_rho_components,
     )
@@ -2613,18 +2770,6 @@ def test_select_split_order_from_rho_default_boundaries():
         orders=(1, 2, 3, 4),
     )
     assert order == 2
-
-    # Exponential-tail guardrail is monotone in rho_imag.
-    p1 = _select_split_order_from_exp_tail(
-        1.0, rel_tol=1.0e-2, order_min=1, order_max=12
-    )
-    p2 = _select_split_order_from_exp_tail(
-        4.0, rel_tol=1.0e-2, order_min=1, order_max=12
-    )
-    p3 = _select_split_order_from_exp_tail(
-        8.0, rel_tol=1.0e-2, order_min=1, order_max=12
-    )
-    assert p1 <= p2 <= p3
 
 
 def test_volume_fmm_2d_helmholtz_split_order1_remainder_matches_legacy(tmp_path):

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -2561,7 +2561,10 @@ def test_volume_fmm_2d_yukawa_complex_lambda_rejected(tmp_path):
 
 
 def test_select_split_order_from_rho_default_boundaries():
-    from volumential.expansion_wrangler_fpnd import _select_split_order_from_rho
+    from volumential.expansion_wrangler_fpnd import (
+        _select_split_order_from_rho,
+        _select_split_order_from_rho_components,
+    )
 
     thresholds = (0.5, 1.5, 3.0)
     orders = (1, 2, 3, 4)
@@ -2571,6 +2574,16 @@ def test_select_split_order_from_rho_default_boundaries():
     assert _select_split_order_from_rho(0.7, thresholds, orders) == 2
     assert _select_split_order_from_rho(2.0, thresholds, orders) == 3
     assert _select_split_order_from_rho(9.0, thresholds, orders) == 4
+
+    # Imaginary-part ladder can be stricter than real-part ladder.
+    order = _select_split_order_from_rho_components(
+        rho_real=0.6,
+        rho_imag=0.6,
+        thresholds_real=(1.0, 2.0, 4.0),
+        thresholds_imag=(0.5, 1.0, 2.0),
+        orders=(1, 2, 3, 4),
+    )
+    assert order == 2
 
 
 def test_volume_fmm_2d_helmholtz_split_order1_remainder_matches_legacy(tmp_path):

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -2560,8 +2560,37 @@ def test_volume_fmm_2d_yukawa_complex_lambda_rejected(tmp_path):
         )
 
 
+def test_volume_fmm_2d_yukawa_split_auto_high_rho_runs(tmp_path):
+    ctx = _create_non_intel_opencl_context_or_skip()
+    queue = cl.CommandQueue(ctx)
+
+    q_order = 5
+    lam = 32.0
+    split_table = _get_laplace_2d_table(
+        queue,
+        tmp_path / "nft-yukawa2d-split-auto-highrho-q5.sqlite",
+        q_order,
+    )
+
+    out = _run_2d_yukawa_split_case(
+        ctx,
+        queue,
+        split_table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        lam=lam,
+        helmholtz_split=True,
+        helmholtz_split_order="auto",
+    )
+
+    pot = out["potentials"].get(queue)
+    assert np.all(np.isfinite(pot))
+
+
 def test_select_split_order_from_rho_default_boundaries():
     from volumential.expansion_wrangler_fpnd import (
+        _select_split_order_from_exp_tail,
         _select_split_order_from_rho,
         _select_split_order_from_rho_components,
     )
@@ -2584,6 +2613,18 @@ def test_select_split_order_from_rho_default_boundaries():
         orders=(1, 2, 3, 4),
     )
     assert order == 2
+
+    # Exponential-tail guardrail is monotone in rho_imag.
+    p1 = _select_split_order_from_exp_tail(
+        1.0, rel_tol=1.0e-2, order_min=1, order_max=12
+    )
+    p2 = _select_split_order_from_exp_tail(
+        4.0, rel_tol=1.0e-2, order_min=1, order_max=12
+    )
+    p3 = _select_split_order_from_exp_tail(
+        8.0, rel_tol=1.0e-2, order_min=1, order_max=12
+    )
+    assert p1 <= p2 <= p3
 
 
 def test_volume_fmm_2d_helmholtz_split_order1_remainder_matches_legacy(tmp_path):

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -2581,29 +2581,39 @@ def test_volume_fmm_2d_yukawa_split_order2_runs(tmp_path):
         helmholtz_split=True,
         helmholtz_split_order=2,
     )
+    split_half_lam = _run_2d_yukawa_split_case(
+        ctx,
+        queue,
+        split_table,
+        q_order=q_order,
+        nlevels=3,
+        fmm_order=16,
+        lam=0.5 * lam,
+        helmholtz_split=True,
+        helmholtz_split_order=2,
+    )
 
     pot = split["potentials"].get(queue)
+    pot_half_lam = split_half_lam["potentials"].get(queue)
     assert np.all(np.isfinite(pot))
+    assert np.all(np.isfinite(pot_half_lam))
+    assert not np.allclose(pot, pot_half_lam, rtol=1.0e-8, atol=1.0e-10)
     assert split["n_points"] > 0
+    assert split_half_lam["n_points"] > 0
 
 
-def test_volume_fmm_2d_yukawa_complex_lambda_rejected(tmp_path):
+def test_volume_fmm_2d_yukawa_complex_lambda_rejected():
     ctx = _create_non_intel_opencl_context_or_skip()
     queue = cl.CommandQueue(ctx)
 
     q_order = 5
     lam = 7.0 + 1.25j
-    split_table = _get_laplace_2d_table(
-        queue,
-        tmp_path / "nft-yukawa2d-split-complex-q5.sqlite",
-        q_order,
-    )
 
     with pytest.raises(NotImplementedError, match="real lam"):
         _run_2d_yukawa_split_case(
             ctx,
             queue,
-            split_table,
+            object(),
             q_order=q_order,
             nlevels=3,
             fmm_order=16,

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -2560,6 +2560,19 @@ def test_volume_fmm_2d_yukawa_complex_lambda_rejected(tmp_path):
         )
 
 
+def test_select_split_order_from_rho_default_boundaries():
+    from volumential.expansion_wrangler_fpnd import _select_split_order_from_rho
+
+    thresholds = (0.5, 1.5, 3.0)
+    orders = (1, 2, 3, 4)
+
+    assert _select_split_order_from_rho(0.1, thresholds, orders) == 1
+    assert _select_split_order_from_rho(0.5, thresholds, orders) == 1
+    assert _select_split_order_from_rho(0.7, thresholds, orders) == 2
+    assert _select_split_order_from_rho(2.0, thresholds, orders) == 3
+    assert _select_split_order_from_rho(9.0, thresholds, orders) == 4
+
+
 def test_volume_fmm_2d_helmholtz_split_order1_remainder_matches_legacy(tmp_path):
     ctx = _create_non_intel_opencl_context_or_skip()
     queue = cl.CommandQueue(ctx)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -42,6 +42,7 @@ from sumpy.kernel import (
     ExpressionKernel,
     HelmholtzKernel,
     LaplaceKernel,
+    YukawaKernel,
 )
 
 from volumential.expansion_wrangler_interface import (
@@ -1121,7 +1122,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 raise ValueError("helmholtz_split_smooth_quad_order must be >= 1")
 
         if self.helmholtz_split:
-            from sumpy.kernel import HelmholtzKernel, LaplaceKernel
+            from sumpy.kernel import HelmholtzKernel, LaplaceKernel, YukawaKernel
 
             from volumential.table_manager import ConstantKernel
 
@@ -1132,9 +1133,11 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
             out_knl = self.tree_indep.target_kernels[0]
             base_knl = out_knl.get_base_kernel()
-            if out_knl is not base_knl or not isinstance(base_knl, HelmholtzKernel):
+            if out_knl is not base_knl or not isinstance(
+                base_knl, (HelmholtzKernel, YukawaKernel)
+            ):
                 raise NotImplementedError(
-                    "helmholtz_split currently supports only base Helmholtz kernels"
+                    "helmholtz_split currently supports only base Helmholtz/Yukawa kernels"
                 )
 
             if base_knl.dim not in (2, 3):
@@ -1224,6 +1227,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         queue,
         table0,
         near_field_tables,
+        eval_dtype,
     ):
         payload = self._nearfield_device_payload_cache.get(cache_key)
         if payload is not None:
@@ -1252,14 +1256,14 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             table_entry_scales,
         ) = _prepare_table_data_and_entry_map(near_field_tables)
 
-        if table_data_combined.dtype != self.dtype:
-            table_data_combined = table_data_combined.astype(self.dtype)
-        if mode_nmlz_combined.dtype != self.dtype:
-            mode_nmlz_combined = mode_nmlz_combined.astype(self.dtype)
-        if exterior_mode_nmlz_combined.dtype != self.dtype:
-            exterior_mode_nmlz_combined = exterior_mode_nmlz_combined.astype(self.dtype)
-        if table_entry_scales.dtype != self.dtype:
-            table_entry_scales = table_entry_scales.astype(self.dtype)
+        if table_data_combined.dtype != eval_dtype:
+            table_data_combined = table_data_combined.astype(eval_dtype)
+        if mode_nmlz_combined.dtype != eval_dtype:
+            mode_nmlz_combined = mode_nmlz_combined.astype(eval_dtype)
+        if exterior_mode_nmlz_combined.dtype != eval_dtype:
+            exterior_mode_nmlz_combined = exterior_mode_nmlz_combined.astype(eval_dtype)
+        if table_entry_scales.dtype != eval_dtype:
+            table_entry_scales = table_entry_scales.astype(eval_dtype)
 
         table_data_shapes = {
             "n_tables": len(near_field_tables),
@@ -1414,12 +1418,14 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         for table in near_field_tables:
             table.symmetry_source_direction = symmetry_source_direction
 
+        eval_dtype = np.complex128 if out_kernel.is_complex_valued else np.float64
+
         cache_key = (
             kname,
             tuple(int(np.asarray(tbl.data).ctypes.data) for tbl in near_field_tables),
             tuple(int(np.asarray(tbl.data).size) for tbl in near_field_tables),
             tuple(_table_data_fingerprint(tbl.data) for tbl in near_field_tables),
-            np.dtype(self.dtype).str,
+            np.dtype(eval_dtype).str,
             None
             if symmetry_source_direction is None
             else tuple(np.asarray(symmetry_source_direction, dtype=float).tolist()),
@@ -1429,6 +1435,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             queue,
             table0,
             near_field_tables,
+            eval_dtype,
         )
 
         base = payload["base"]
@@ -1845,6 +1852,29 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
         return cache[kname]
 
+    def _split_wave_number_parameter_name(self, base_knl):
+        if isinstance(base_knl, HelmholtzKernel):
+            return getattr(base_knl, "helmholtz_k_name", None)
+        if isinstance(base_knl, YukawaKernel):
+            return getattr(base_knl, "yukawa_lambda_name", None)
+        return None
+
+    def _split_wave_number(self, base_knl, *, what):
+        param_name = self._split_wave_number_parameter_name(base_knl)
+        if (
+            not isinstance(param_name, str)
+            or param_name not in self.kernel_extra_kwargs
+        ):
+            raise RuntimeError(f"missing kernel parameter for {what}")
+
+        param = np.complex128(self.kernel_extra_kwargs[param_name])
+        if isinstance(base_knl, HelmholtzKernel):
+            return np.complex128(param)
+        if isinstance(base_knl, YukawaKernel):
+            return np.complex128(1j * param)
+
+        raise RuntimeError("split mode supports only Helmholtz/Yukawa kernels")
+
     def _helmholtz_split_max_neighbor_distance(self):
         box_source_counts = self.tree.box_source_counts_nonchild.get(self.queue)
         box_levels = self.tree.box_levels.get(self.queue)
@@ -1864,11 +1894,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         if split_order < 1:
             raise ValueError("split_order must be >= 1")
 
-        k_name = helm_knl.helmholtz_k_name
-        if k_name not in self.kernel_extra_kwargs:
-            raise RuntimeError("missing Helmholtz wave number for split terms")
-
-        k = np.complex128(self.kernel_extra_kwargs[k_name])
+        k = self._split_wave_number(helm_knl, what="split terms")
         abs_k = float(np.abs(k))
         r_max = self._helmholtz_split_max_neighbor_distance()
         z_max = abs_k * r_max
@@ -1919,11 +1945,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         helm_knl, _ = self._helmholtz_split_kernels
         dim = int(helm_knl.dim)
         split_order = int(self.helmholtz_split_order)
-        k_name = helm_knl.helmholtz_k_name
-        if k_name not in self.kernel_extra_kwargs:
-            raise RuntimeError("missing Helmholtz wave number for split remainder")
-
-        k = np.complex128(self.kernel_extra_kwargs[k_name])
+        k = self._split_wave_number(helm_knl, what="split remainder")
         series_nmax = self._helmholtz_split_series_nmax(split_order)
 
         cache_key = (
@@ -2420,11 +2442,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
         helm_knl, _ = self._helmholtz_split_kernels
         dim = helm_knl.dim
-        k_name = helm_knl.helmholtz_k_name
-        if k_name not in self.kernel_extra_kwargs:
-            raise RuntimeError("missing Helmholtz wave number for split terms")
-
-        k = np.complex128(self.kernel_extra_kwargs[k_name])
+        k = self._split_wave_number(helm_knl, what="split terms")
 
         terms = []
 
@@ -2655,11 +2673,10 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             return None
 
         helm_knl, _ = self._helmholtz_split_kernels
-        k_name = helm_knl.helmholtz_k_name
-        if k_name not in self.kernel_extra_kwargs:
+        try:
+            k = self._split_wave_number(helm_knl, what="self diagonal limit")
+        except RuntimeError:
             return None
-
-        k = np.complex128(self.kernel_extra_kwargs[k_name])
         if helm_knl.dim == 3:
             return np.complex128(1j * k / (4.0 * np.pi))
 
@@ -3299,12 +3316,13 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
 
         near_field_tables = self.near_field_table[kname]
         table0 = near_field_tables[0]
+        eval_dtype = np.complex128 if out_kernel.is_complex_valued else np.float64
         cache_key = (
             kname,
             tuple(int(np.asarray(tbl.data).ctypes.data) for tbl in near_field_tables),
             tuple(int(np.asarray(tbl.data).size) for tbl in near_field_tables),
             tuple(_table_data_fingerprint(tbl.data) for tbl in near_field_tables),
-            np.dtype(self.dtype).str,
+            np.dtype(eval_dtype).str,
             None
             if symmetry_source_direction is None
             else tuple(np.asarray(symmetry_source_direction, dtype=float).tolist()),
@@ -3314,6 +3332,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             self.queue,
             table0,
             near_field_tables,
+            eval_dtype,
         )
 
         base = payload["base"]
@@ -3415,6 +3434,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         queue,
         table0,
         near_field_tables,
+        eval_dtype,
     ):
         payload = self._nearfield_device_payload_cache.get(cache_key)
         if payload is not None:
@@ -3443,14 +3463,14 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             table_entry_scales,
         ) = _prepare_table_data_and_entry_map(near_field_tables)
 
-        if table_data_combined.dtype != self.dtype:
-            table_data_combined = table_data_combined.astype(self.dtype)
-        if mode_nmlz_combined.dtype != self.dtype:
-            mode_nmlz_combined = mode_nmlz_combined.astype(self.dtype)
-        if exterior_mode_nmlz_combined.dtype != self.dtype:
-            exterior_mode_nmlz_combined = exterior_mode_nmlz_combined.astype(self.dtype)
-        if table_entry_scales.dtype != self.dtype:
-            table_entry_scales = table_entry_scales.astype(self.dtype)
+        if table_data_combined.dtype != eval_dtype:
+            table_data_combined = table_data_combined.astype(eval_dtype)
+        if mode_nmlz_combined.dtype != eval_dtype:
+            mode_nmlz_combined = mode_nmlz_combined.astype(eval_dtype)
+        if exterior_mode_nmlz_combined.dtype != eval_dtype:
+            exterior_mode_nmlz_combined = exterior_mode_nmlz_combined.astype(eval_dtype)
+        if table_entry_scales.dtype != eval_dtype:
+            table_entry_scales = table_entry_scales.astype(eval_dtype)
 
         table_data_shapes = {
             "n_tables": len(near_field_tables),

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -343,6 +343,17 @@ def _format_helmholtz_split_term_key(term_key):
     return f"power_log:{power}"
 
 
+def _select_split_order_from_rho(rho_max, thresholds, orders):
+    if len(orders) != len(thresholds) + 1:
+        raise ValueError("orders must have one more element than thresholds")
+
+    rho = float(rho_max)
+    for idx, threshold in enumerate(thresholds):
+        if rho <= float(threshold):
+            return int(orders[idx])
+    return int(orders[-1])
+
+
 def _compute_box_local_ids(queue, tree, n_q_points):
     if not getattr(tree, "sources_are_targets", False):
         raise ValueError(
@@ -828,6 +839,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         helmholtz_split=False,
         helmholtz_split_order=1,
         helmholtz_split_smooth_quad_order=None,
+        helmholtz_split_auto_config=None,
         helmholtz_split_term_tables=None,
         helmholtz_split_order1_legacy_subtraction=False,
         translation_classes_data=None,
@@ -1032,7 +1044,20 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             list1_extra_kwargs = {}
 
         self.helmholtz_split = bool(helmholtz_split)
-        self.helmholtz_split_order = int(helmholtz_split_order)
+        auto_cfg = dict(helmholtz_split_auto_config or {})
+        auto_enabled = bool(auto_cfg.get("enabled", False))
+        auto_mode = auto_enabled or (
+            isinstance(helmholtz_split_order, str)
+            and helmholtz_split_order.strip().lower() == "auto"
+        )
+
+        if auto_mode and self.helmholtz_split:
+            self.helmholtz_split_order = self._choose_auto_helmholtz_split_order(
+                auto_cfg
+            )
+        else:
+            self.helmholtz_split_order = int(helmholtz_split_order)
+
         if self.helmholtz_split_order < 1:
             raise ValueError("helmholtz_split_order must be >= 1")
 
@@ -1110,7 +1135,16 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             self.helmholtz_split_term_tables[normalized_term_key] = tables
 
         if helmholtz_split_smooth_quad_order is None and self.helmholtz_split:
-            helmholtz_split_smooth_quad_order = self.quad_order
+            if auto_mode:
+                min_smooth = int(auto_cfg.get("smooth_quad_order_min", self.quad_order))
+                add_per_order = int(auto_cfg.get("smooth_quad_order_per_order", 1))
+                helmholtz_split_smooth_quad_order = max(
+                    min_smooth,
+                    self.quad_order
+                    + max(0, self.helmholtz_split_order - 1) * add_per_order,
+                )
+            else:
+                helmholtz_split_smooth_quad_order = self.quad_order
 
         if helmholtz_split_smooth_quad_order is None:
             self.helmholtz_split_smooth_quad_order = None
@@ -1886,6 +1920,41 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             return np.complex128(1j * param)
 
         raise RuntimeError("split mode supports only Helmholtz/Yukawa kernels")
+
+    def _compute_split_rho_max(self):
+        if len(self.tree_indep.target_kernels) != 1:
+            raise RuntimeError("split rho estimation expects one target kernel")
+
+        out_knl = self.tree_indep.target_kernels[0]
+        base_knl = out_knl.get_base_kernel()
+        k = self._split_wave_number(base_knl, what="split auto planning")
+        k_abs = float(abs(k))
+
+        box_source_counts = self.tree.box_source_counts_nonchild.get(self.queue)
+        box_levels = self.tree.box_levels.get(self.queue)
+        active = np.where(box_source_counts > 0)[0]
+        if active.size == 0:
+            return 0.0
+
+        min_level = int(np.min(box_levels[active]))
+        h_max = float(self.tree.root_extent) * (0.5**min_level)
+        return k_abs * h_max
+
+    def _choose_auto_helmholtz_split_order(self, auto_cfg):
+        thresholds = auto_cfg.get("rho_thresholds", (0.5, 1.5, 3.0))
+        orders = auto_cfg.get("orders", (1, 2, 3, 4))
+        rho_max = self._compute_split_rho_max()
+        selected = _select_split_order_from_rho(rho_max, thresholds, orders)
+
+        order_min = int(auto_cfg.get("order_min", 1))
+        order_max = int(auto_cfg.get("order_max", selected))
+        selected = max(order_min, min(order_max, selected))
+        logger.info(
+            "Auto-selected helmholtz_split_order=%d (rho_max=%.3g)",
+            selected,
+            rho_max,
+        )
+        return selected
 
     def _helmholtz_split_max_neighbor_distance(self):
         box_source_counts = self.tree.box_source_counts_nonchild.get(self.queue)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -354,6 +354,18 @@ def _select_split_order_from_rho(rho_max, thresholds, orders):
     return int(orders[-1])
 
 
+def _select_split_order_from_rho_components(
+    rho_real,
+    rho_imag,
+    thresholds_real,
+    thresholds_imag,
+    orders,
+):
+    order_real = _select_split_order_from_rho(rho_real, thresholds_real, orders)
+    order_imag = _select_split_order_from_rho(rho_imag, thresholds_imag, orders)
+    return max(order_real, order_imag)
+
+
 def _compute_box_local_ids(queue, tree, n_q_points):
     if not getattr(tree, "sources_are_targets", False):
         raise ValueError(
@@ -1940,6 +1952,26 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         h_max = float(self.tree.root_extent) * (0.5**min_level)
         return k_abs * h_max
 
+    def _compute_split_rho_components(self):
+        if len(self.tree_indep.target_kernels) != 1:
+            raise RuntimeError("split rho estimation expects one target kernel")
+
+        out_knl = self.tree_indep.target_kernels[0]
+        base_knl = out_knl.get_base_kernel()
+        k = self._split_wave_number(base_knl, what="split auto planning")
+
+        box_source_counts = self.tree.box_source_counts_nonchild.get(self.queue)
+        box_levels = self.tree.box_levels.get(self.queue)
+        active = np.where(box_source_counts > 0)[0]
+        if active.size == 0:
+            return 0.0, 0.0
+
+        min_level = int(np.min(box_levels[active]))
+        h_max = float(self.tree.root_extent) * (0.5**min_level)
+        rho_real = abs(float(np.real(k))) * h_max
+        rho_imag = abs(float(np.imag(k))) * h_max
+        return rho_real, rho_imag
+
     def _choose_auto_helmholtz_split_order(self, auto_cfg):
         order_min = int(auto_cfg.get("order_min", 1))
         order_max = int(auto_cfg.get("order_max", 8))
@@ -1947,35 +1979,54 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             raise ValueError("order_max must be >= order_min")
 
         if "rho_thresholds" in auto_cfg or "orders" in auto_cfg:
-            thresholds = auto_cfg.get("rho_thresholds", (0.5, 1.5, 3.0))
+            thresholds_real = auto_cfg.get("rho_thresholds", (0.5, 1.5, 3.0))
+            thresholds_imag = thresholds_real
             orders = auto_cfg.get("orders", (1, 2, 3, 4))
         else:
-            # Default to a geometric ladder in rho to cover wide k*h ranges.
-            # Example with order_max=8: thresholds = (0.5, 1, 2, 4, 8, 16, 32).
-            rho0 = float(auto_cfg.get("rho_base", 0.5))
-            if rho0 <= 0.0:
-                raise ValueError("rho_base must be positive")
+            # Default to geometric ladders for real/imag parts separately.
+            rho0_real = float(auto_cfg.get("rho_base_real", 0.75))
+            rho0_imag = float(auto_cfg.get("rho_base_imag", 0.5))
+            if rho0_real <= 0.0 or rho0_imag <= 0.0:
+                raise ValueError("rho_base_real and rho_base_imag must be positive")
             count = max(0, order_max - order_min)
-            thresholds = tuple(rho0 * (2.0**j) for j in range(count))
+            thresholds_real = tuple(rho0_real * (2.0**j) for j in range(count))
+            thresholds_imag = tuple(rho0_imag * (2.0**j) for j in range(count))
             orders = tuple(range(order_min, order_max + 1))
 
-        rho_max = self._compute_split_rho_max()
-        selected = _select_split_order_from_rho(rho_max, thresholds, orders)
+        if "rho_thresholds_real" in auto_cfg:
+            thresholds_real = tuple(auto_cfg["rho_thresholds_real"])
+        if "rho_thresholds_imag" in auto_cfg:
+            thresholds_imag = tuple(auto_cfg["rho_thresholds_imag"])
+
+        rho_real, rho_imag = self._compute_split_rho_components()
+        rho_max = max(rho_real, rho_imag)
+        selected = _select_split_order_from_rho_components(
+            rho_real,
+            rho_imag,
+            thresholds_real,
+            thresholds_imag,
+            orders,
+        )
         selected = max(order_min, min(order_max, selected))
 
-        if len(thresholds) > 0 and rho_max > float(thresholds[-1]):
+        coverage_max = max(
+            float(thresholds_real[-1]) if len(thresholds_real) else 0.0,
+            float(thresholds_imag[-1]) if len(thresholds_imag) else 0.0,
+        )
+        if coverage_max > 0.0 and rho_max > coverage_max:
             logger.warning(
                 "rho_max=%.3g exceeds planner threshold coverage (max %.3g); "
                 "clamping split order to %d",
                 rho_max,
-                float(thresholds[-1]),
+                coverage_max,
                 selected,
             )
 
         logger.info(
-            "Auto-selected helmholtz_split_order=%d (rho_max=%.3g)",
+            "Auto-selected helmholtz_split_order=%d (rho_real=%.3g, rho_imag=%.3g)",
             selected,
-            rho_max,
+            rho_real,
+            rho_imag,
         )
         return selected
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -2023,7 +2023,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
     def _choose_auto_helmholtz_split_order(self, auto_cfg):
         order_min = int(auto_cfg.get("order_min", 1))
-        order_max = int(auto_cfg.get("order_max", 8))
+        order_max = int(auto_cfg.get("order_max", 12))
         if order_max < order_min:
             raise ValueError("order_max must be >= order_min")
 
@@ -2060,7 +2060,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         )
 
         if bool(auto_cfg.get("exp_tail_guardrail_enabled", True)):
-            exp_tail_rel_tol = float(auto_cfg.get("exp_tail_rel_tol", 1.0e-2))
+            exp_tail_rel_tol = float(auto_cfg.get("exp_tail_rel_tol", 2.0e-1))
             p_exp = _select_split_order_from_exp_tail(
                 rho_imag,
                 rel_tol=exp_tail_rel_tol,
@@ -2068,6 +2068,10 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 order_max=order_max,
             )
             selected = max(selected, p_exp)
+
+        hard_rho_imag = float(auto_cfg.get("rho_imag_hard_trigger", 4.0))
+        if rho_imag >= hard_rho_imag:
+            selected = order_max
 
         selected = max(order_min, min(order_max, selected))
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 import json
 import logging
 import hashlib
+import math
 from collections import OrderedDict
 
 import numpy as np
@@ -364,6 +365,30 @@ def _select_split_order_from_rho_components(
     order_real = _select_split_order_from_rho(rho_real, thresholds_real, orders)
     order_imag = _select_split_order_from_rho(rho_imag, thresholds_imag, orders)
     return max(order_real, order_imag)
+
+
+def _select_split_order_from_exp_tail(
+    rho_imag,
+    *,
+    rel_tol,
+    order_min,
+    order_max,
+):
+    """Choose p so truncated-series proxy x^p/p! <= rel_tol."""
+    x = float(max(0.0, rho_imag))
+    tol = float(rel_tol)
+    if tol <= 0.0:
+        raise ValueError("rel_tol must be positive")
+
+    for p in range(int(order_min), int(order_max) + 1):
+        if x == 0.0:
+            return p
+
+        log_term = p * math.log(x) - math.lgamma(p + 1.0)
+        if log_term <= math.log(tol):
+            return p
+
+    return int(order_max)
 
 
 def _compute_box_local_ids(queue, tree, n_q_points):
@@ -1072,6 +1097,23 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
         if self.helmholtz_split_order < 1:
             raise ValueError("helmholtz_split_order must be >= 1")
+
+        if auto_mode and self.helmholtz_split:
+            max_rho_imag = float(auto_cfg.get("rho_imag_split_max", 8.0))
+            disable_outside = bool(
+                auto_cfg.get("disable_split_if_outside_coverage", True)
+            )
+            if (
+                disable_outside
+                and getattr(self, "_split_auto_rho_imag", 0.0) > max_rho_imag
+            ):
+                logger.warning(
+                    "Disabling split mode for high imaginary rho (%.3g > %.3g); "
+                    "falling back to direct kernel near-field evaluation",
+                    self._split_auto_rho_imag,
+                    max_rho_imag,
+                )
+                self.helmholtz_split = False
 
         self.helmholtz_split_order1_legacy_subtraction = bool(
             helmholtz_split_order1_legacy_subtraction
@@ -1999,6 +2041,8 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             thresholds_imag = tuple(auto_cfg["rho_thresholds_imag"])
 
         rho_real, rho_imag = self._compute_split_rho_components()
+        self._split_auto_rho_real = float(rho_real)
+        self._split_auto_rho_imag = float(rho_imag)
         rho_max = max(rho_real, rho_imag)
         selected = _select_split_order_from_rho_components(
             rho_real,
@@ -2007,6 +2051,17 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             thresholds_imag,
             orders,
         )
+
+        if bool(auto_cfg.get("exp_tail_guardrail_enabled", True)):
+            exp_tail_rel_tol = float(auto_cfg.get("exp_tail_rel_tol", 1.0e-2))
+            p_exp = _select_split_order_from_exp_tail(
+                rho_imag,
+                rel_tol=exp_tail_rel_tol,
+                order_min=order_min,
+                order_max=order_max,
+            )
+            selected = max(selected, p_exp)
+
         selected = max(order_min, min(order_max, selected))
 
         coverage_max = max(

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1061,18 +1061,23 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         self.helmholtz_split = bool(helmholtz_split)
         auto_cfg = dict(helmholtz_split_auto_config or {})
         self._helmholtz_split_auto_config = dict(auto_cfg)
-        auto_enabled = bool(auto_cfg.get("enabled", False))
-        auto_mode = auto_enabled or (
-            isinstance(helmholtz_split_order, str)
-            and helmholtz_split_order.strip().lower() == "auto"
-        )
-
-        if auto_mode and self.helmholtz_split:
-            self.helmholtz_split_order = self._choose_auto_helmholtz_split_order(
-                auto_cfg
+        auto_mode = False
+        if self.helmholtz_split:
+            auto_enabled = bool(auto_cfg.get("enabled", False))
+            auto_mode = auto_enabled or (
+                isinstance(helmholtz_split_order, str)
+                and helmholtz_split_order.strip().lower() == "auto"
             )
+
+            if auto_mode:
+                self.helmholtz_split_order = self._choose_auto_helmholtz_split_order(
+                    auto_cfg
+                )
+            else:
+                self.helmholtz_split_order = int(helmholtz_split_order)
         else:
-            self.helmholtz_split_order = int(helmholtz_split_order)
+            # Split order is irrelevant when split mode is disabled.
+            self.helmholtz_split_order = 1
 
         if self.helmholtz_split_order < 1:
             raise ValueError("helmholtz_split_order must be >= 1")
@@ -1087,12 +1092,12 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 and getattr(self, "_split_auto_rho_imag", 0.0) > max_rho_imag
             ):
                 logger.warning(
-                    "Disabling split mode for high imaginary rho (%.3g > %.3g); "
-                    "falling back to direct kernel near-field evaluation",
+                    "Imaginary rho %.3g exceeds configured split coverage %.3g. "
+                    "Keeping split mode enabled because direct fallback requires "
+                    "matching direct near-field tables.",
                     self._split_auto_rho_imag,
                     max_rho_imag,
                 )
-                self.helmholtz_split = False
             elif getattr(self, "_split_auto_rho_imag", 0.0) > max_rho_imag:
                 logger.warning(
                     "Imaginary rho %.3g exceeds configured split coverage %.3g; "
@@ -1572,7 +1577,21 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         for table in near_field_tables:
             table.symmetry_source_direction = symmetry_source_direction
 
-        eval_dtype = np.complex128 if out_kernel.is_complex_valued else np.float64
+        configured_dtype = np.dtype(self.dtype)
+        if out_kernel.is_complex_valued:
+            if configured_dtype.kind == "c":
+                eval_dtype = configured_dtype
+            else:
+                eval_dtype = (
+                    np.complex64 if configured_dtype == np.float32 else np.complex128
+                )
+        else:
+            if configured_dtype.kind == "f":
+                eval_dtype = configured_dtype
+            else:
+                eval_dtype = (
+                    np.float32 if configured_dtype == np.complex64 else np.float64
+                )
 
         cache_key = (
             kname,
@@ -2083,17 +2102,27 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
     def _split_wave_number(self, base_knl, *, what):
         param_name = self._split_wave_number_parameter_name(base_knl)
-        if (
-            not isinstance(param_name, str)
-            or param_name not in self.kernel_extra_kwargs
-        ):
-            raise RuntimeError(f"missing kernel parameter for {what}")
+        if not isinstance(param_name, str) or not param_name:
+            raise RuntimeError(
+                f"{base_knl.__class__.__name__} does not expose a split parameter "
+                f"name while evaluating {what}"
+            )
+        if param_name not in self.kernel_extra_kwargs:
+            raise TypeError(
+                f"missing kernel parameter {param_name!r} for "
+                f"{base_knl.__class__.__name__} while evaluating {what}"
+            )
 
         param = np.complex128(self.kernel_extra_kwargs[param_name])
         if isinstance(base_knl, HelmholtzKernel):
             return np.complex128(param)
         if isinstance(base_knl, YukawaKernel):
-            return np.complex128(1j * param)
+            if not np.isclose(np.imag(param), 0.0):
+                raise NotImplementedError(
+                    "Yukawa split mode requires real lam; use HelmholtzKernel "
+                    "for complex wave numbers"
+                )
+            return np.complex128(1j * np.real(param))
 
         raise RuntimeError("split mode supports only Helmholtz/Yukawa kernels")
 
@@ -2145,7 +2174,10 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         if "rho_thresholds" in auto_cfg or "orders" in auto_cfg:
             thresholds_real = auto_cfg.get("rho_thresholds", (0.5, 1.5, 3.0))
             thresholds_imag = thresholds_real
-            orders = auto_cfg.get("orders", (1, 2, 3, 4))
+            if "orders" in auto_cfg:
+                orders = auto_cfg["orders"]
+            else:
+                orders = tuple(range(order_min, order_min + len(thresholds_real) + 1))
         else:
             # Default to geometric ladders for real/imag parts separately.
             rho0_real = float(auto_cfg.get("rho_base_real", 0.25))
@@ -3707,7 +3739,21 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
 
         near_field_tables = self.near_field_table[kname]
         table0 = near_field_tables[0]
-        eval_dtype = np.complex128 if out_kernel.is_complex_valued else np.float64
+        configured_dtype = np.dtype(self.dtype)
+        if out_kernel.is_complex_valued:
+            if configured_dtype.kind == "c":
+                eval_dtype = configured_dtype
+            else:
+                eval_dtype = (
+                    np.complex64 if configured_dtype == np.float32 else np.complex128
+                )
+        else:
+            if configured_dtype.kind == "f":
+                eval_dtype = configured_dtype
+            else:
+                eval_dtype = (
+                    np.float32 if configured_dtype == np.complex64 else np.float64
+                )
         cache_key = (
             kname,
             tuple(int(np.asarray(tbl.data).ctypes.data) for tbl in near_field_tables),

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -367,30 +367,6 @@ def _select_split_order_from_rho_components(
     return max(order_real, order_imag)
 
 
-def _select_split_order_from_exp_tail(
-    rho_imag,
-    *,
-    rel_tol,
-    order_min,
-    order_max,
-):
-    """Choose p so truncated-series proxy x^p/p! <= rel_tol."""
-    x = float(max(0.0, rho_imag))
-    tol = float(rel_tol)
-    if tol <= 0.0:
-        raise ValueError("rel_tol must be positive")
-
-    for p in range(int(order_min), int(order_max) + 1):
-        if x == 0.0:
-            return p
-
-        log_term = p * math.log(x) - math.lgamma(p + 1.0)
-        if log_term <= math.log(tol):
-            return p
-
-    return int(order_max)
-
-
 def _compute_box_local_ids(queue, tree, n_q_points):
     if not getattr(tree, "sources_are_targets", False):
         raise ValueError(
@@ -904,7 +880,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         smooth correction.
         For 2D ``power_log`` terms, single-table scaling is supported with a
         level-dependent :math:`\\log(\\alpha_\\ell)` correction folded into online
-        source strengths.
+        source strengths. The correction backend is controlled by
+        ``helmholtz_split_auto_config["power_log_single_table_beta_mode"]``:
+        ``"p2p"`` (default) or ``"table"``.
 
         ``helmholtz_split_smooth_quad_order`` controls the online tensor-product
         quadrature order used for the smooth split correction integral. For
@@ -1082,6 +1060,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
         self.helmholtz_split = bool(helmholtz_split)
         auto_cfg = dict(helmholtz_split_auto_config or {})
+        self._helmholtz_split_auto_config = dict(auto_cfg)
         auto_enabled = bool(auto_cfg.get("enabled", False))
         auto_mode = auto_enabled or (
             isinstance(helmholtz_split_order, str)
@@ -1199,11 +1178,91 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             if auto_mode:
                 min_smooth = int(auto_cfg.get("smooth_quad_order_min", self.quad_order))
                 add_per_order = int(auto_cfg.get("smooth_quad_order_per_order", 1))
+                add_per_order_hard = int(
+                    auto_cfg.get("smooth_quad_order_per_order_hard", 1)
+                )
+                if add_per_order < 0 or add_per_order_hard < 0:
+                    raise ValueError(
+                        "smooth quadrature per-order increments must be non-negative"
+                    )
+
+                hard_rho_imag = float(
+                    auto_cfg.get(
+                        "smooth_quad_order_hard_rho_imag",
+                        4.0,
+                    )
+                )
+                hard_rho_real = float(
+                    auto_cfg.get("smooth_quad_order_hard_rho_real", 3.0)
+                )
+                if hard_rho_real <= 0.0:
+                    raise ValueError("smooth_quad_order_hard_rho_real must be > 0")
+
+                rho_real = float(getattr(self, "_split_auto_rho_real", 0.0))
+                rho_imag = float(getattr(self, "_split_auto_rho_imag", 0.0))
+                active_add_per_order = (
+                    add_per_order_hard
+                    if (rho_imag >= hard_rho_imag or rho_real >= hard_rho_real)
+                    else add_per_order
+                )
+
+                rho_boost_start = float(
+                    auto_cfg.get("smooth_quad_order_rho_boost_start", hard_rho_imag)
+                )
+                rho_boost_scale = float(
+                    auto_cfg.get("smooth_quad_order_rho_boost_scale", 1.0)
+                )
+                if rho_boost_scale < 0.0:
+                    raise ValueError("smooth_quad_order_rho_boost_scale must be >= 0")
+
+                rho_boost = int(
+                    math.ceil(max(0.0, rho_imag - rho_boost_start) * rho_boost_scale)
+                )
+
+                rho_boost_cap = auto_cfg.get("smooth_quad_order_rho_boost_cap", None)
+                if rho_boost_cap is not None:
+                    rho_boost = min(rho_boost, int(rho_boost_cap))
+
+                rho_real_boost_start = float(
+                    auto_cfg.get(
+                        "smooth_quad_order_real_boost_start",
+                        hard_rho_real,
+                    )
+                )
+                rho_real_boost_scale = float(
+                    auto_cfg.get("smooth_quad_order_real_boost_scale", 0.5)
+                )
+                if rho_real_boost_scale < 0.0:
+                    raise ValueError("smooth_quad_order_real_boost_scale must be >= 0")
+
+                rho_real_boost = int(
+                    math.ceil(
+                        max(0.0, rho_real - rho_real_boost_start) * rho_real_boost_scale
+                    )
+                )
+                rho_real_boost_cap = auto_cfg.get(
+                    "smooth_quad_order_real_boost_cap", None
+                )
+                if rho_real_boost_cap is not None:
+                    rho_real_boost = min(rho_real_boost, int(rho_real_boost_cap))
+
+                rho_boost += rho_real_boost
+
+                base_smooth_order = (
+                    self.quad_order
+                    + max(0, self.helmholtz_split_order - 1) * active_add_per_order
+                )
                 helmholtz_split_smooth_quad_order = max(
                     min_smooth,
-                    self.quad_order
-                    + max(0, self.helmholtz_split_order - 1) * add_per_order,
+                    base_smooth_order + rho_boost,
                 )
+
+                smooth_quad_order_max = auto_cfg.get("smooth_quad_order_max", None)
+                if smooth_quad_order_max is not None:
+                    helmholtz_split_smooth_quad_order = min(
+                        helmholtz_split_smooth_quad_order,
+                        int(smooth_quad_order_max),
+                    )
             else:
                 helmholtz_split_smooth_quad_order = self.quad_order
 
@@ -1824,30 +1883,86 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                     and term_kind == "power_log"
                     and len(term_tables) == 1
                 ):
-                    beta_weighted_strength = (
-                        self._fold_helmholtz_split_log_alpha_into_strength(
-                            src_weights,
-                            float(term_tables[0].source_box_extent),
-                        )
-                    )
-
-                    beta_strength = obj_array_1d([beta_weighted_strength])
                     power_kernel = self._get_helmholtz_split_power_kernel(term_power)
-                    p2p_power = self._get_helmholtz_split_term_p2p(
-                        power_kernel,
-                        exclude_self=exclude_self,
+                    beta_mode = (
+                        str(
+                            self._helmholtz_split_auto_config.get(
+                                "power_log_single_table_beta_mode",
+                                "p2p",
+                            )
+                        )
+                        .strip()
+                        .lower()
                     )
 
-                    beta_kwargs = dict(shared_kwargs)
-                    if not exclude_self:
-                        beta_kwargs.pop("target_to_source", None)
+                    if beta_mode == "p2p":
+                        beta_kwargs = dict(split_shared_kwargs)
+                        if not exclude_self:
+                            beta_kwargs.pop("target_to_source", None)
 
-                    beta_power_term = _run_p2p_from_csr(
-                        p2p_power,
-                        beta_kwargs,
-                        strength_arg=beta_strength,
-                        max_nsources_in_one_box_arg=self.max_nsources_in_one_box,
-                    )
+                        if use_interp_smooth_quad:
+                            beta_strength_scalar = (
+                                self._fold_helmholtz_split_log_alpha_into_strength(
+                                    smooth_data["strength"],
+                                    float(term_tables[0].source_box_extent),
+                                    box_source_starts=smooth_data["source_kwargs"][
+                                        "box_source_starts"
+                                    ],
+                                    box_source_counts=smooth_data["source_kwargs"][
+                                        "box_source_counts_nonchild"
+                                    ],
+                                )
+                            )
+                        else:
+                            beta_strength_scalar = (
+                                self._fold_helmholtz_split_log_alpha_into_strength(
+                                    src_weights,
+                                    float(term_tables[0].source_box_extent),
+                                )
+                            )
+
+                        beta_strength = obj_array_1d([beta_strength_scalar])
+                        p2p_power = self._get_helmholtz_split_term_p2p(
+                            power_kernel,
+                            exclude_self=exclude_self,
+                        )
+                        beta_power_term = _run_p2p_from_csr(
+                            p2p_power,
+                            beta_kwargs,
+                            strength_arg=beta_strength,
+                            max_nsources_in_one_box_arg=max_nsources_in_one_box,
+                        )
+                    elif beta_mode == "table":
+                        beta_mode_coefs = (
+                            self._fold_helmholtz_split_log_alpha_into_strength(
+                                src_func,
+                                float(term_tables[0].source_box_extent),
+                            )
+                        )
+
+                        power_term_key = _normalize_helmholtz_split_term_key(
+                            ("power", term_power)
+                        )
+                        power_term_tables = (
+                            self._get_or_autobuild_helmholtz_split_term_tables(
+                                power_term_key
+                            )
+                        )
+
+                        beta_power_term = self._eval_direct_helmholtz_split_term_table(
+                            target_boxes,
+                            neighbor_source_boxes_starts,
+                            neighbor_source_boxes_lists,
+                            beta_mode_coefs,
+                            power_kernel,
+                            power_term_tables,
+                            term_key=power_term_key,
+                        )
+                    else:
+                        raise ValueError(
+                            "power_log_single_table_beta_mode must be 'table' or 'p2p'"
+                        )
+
                     beta_term = beta_power_term[0]
                     if isinstance(term_contribution, cl.array.Array) and not isinstance(
                         beta_term, cl.array.Array
@@ -2022,7 +2137,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         return rho_real, rho_imag
 
     def _choose_auto_helmholtz_split_order(self, auto_cfg):
-        order_min = int(auto_cfg.get("order_min", 1))
+        order_min = int(auto_cfg.get("order_min", 2))
         order_max = int(auto_cfg.get("order_max", 12))
         if order_max < order_min:
             raise ValueError("order_max must be >= order_min")
@@ -2033,7 +2148,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             orders = auto_cfg.get("orders", (1, 2, 3, 4))
         else:
             # Default to geometric ladders for real/imag parts separately.
-            rho0_real = float(auto_cfg.get("rho_base_real", 0.75))
+            rho0_real = float(auto_cfg.get("rho_base_real", 0.25))
             rho0_imag = float(auto_cfg.get("rho_base_imag", 0.5))
             if rho0_real <= 0.0 or rho0_imag <= 0.0:
                 raise ValueError("rho_base_real and rho_base_imag must be positive")
@@ -2058,20 +2173,6 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             thresholds_imag,
             orders,
         )
-
-        if bool(auto_cfg.get("exp_tail_guardrail_enabled", True)):
-            exp_tail_rel_tol = float(auto_cfg.get("exp_tail_rel_tol", 2.0e-1))
-            p_exp = _select_split_order_from_exp_tail(
-                rho_imag,
-                rel_tol=exp_tail_rel_tol,
-                order_min=order_min,
-                order_max=order_max,
-            )
-            selected = max(selected, p_exp)
-
-        hard_rho_imag = float(auto_cfg.get("rho_imag_hard_trigger", 4.0))
-        if rho_imag >= hard_rho_imag:
-            selected = order_max
 
         selected = max(order_min, min(order_max, selected))
 
@@ -2233,6 +2334,20 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             )
 
         return self.helmholtz_split_term_tables[normalized_term_key]
+
+    def _get_or_autobuild_helmholtz_split_term_tables(self, term_key):
+        normalized_term_key = _normalize_helmholtz_split_term_key(term_key)
+        if normalized_term_key in self.helmholtz_split_term_tables:
+            return self.helmholtz_split_term_tables[normalized_term_key]
+
+        if len(self.tree_indep.target_kernels) != 1:
+            raise RuntimeError(
+                "helmholtz split term table auto-build expects one target kernel"
+            )
+
+        out_knl = self.tree_indep.target_kernels[0]
+        self._autobuild_helmholtz_split_term_tables(out_knl, [normalized_term_key])
+        return self._get_helmholtz_split_term_tables(normalized_term_key)
 
     def _initialize_helmholtz_split_table_umbrella(self, out_knl):
         kname = repr(out_knl)
@@ -2565,53 +2680,108 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         imag_scale = np.array(1j, dtype=self.dtype)
         return obj_array_1d([out_real + out_imag * imag_scale])
 
-    def _get_helmholtz_split_log_alpha_per_source(self, table_root_extent):
+    def _get_helmholtz_split_log_alpha_per_source(
+        self,
+        table_root_extent,
+        *,
+        box_source_starts=None,
+        box_source_counts=None,
+    ):
         table_root_extent = float(table_root_extent)
         if table_root_extent <= 0.0:
             raise ValueError("table_root_extent must be positive")
 
-        cache_key = table_root_extent
-        if cache_key in self._helmholtz_split_log_alpha_per_source_cache:
-            return self._helmholtz_split_log_alpha_per_source_cache[cache_key]
+        if box_source_starts is None and box_source_counts is None:
+            cache_key = table_root_extent
+            if cache_key in self._helmholtz_split_log_alpha_per_source_cache:
+                return self._helmholtz_split_log_alpha_per_source_cache[cache_key]
 
-        box_source_starts = self.tree.box_source_starts.get(self.queue)
-        box_source_counts = self.tree.box_source_counts_nonchild.get(self.queue)
+            box_source_starts_h = self.tree.box_source_starts.get(self.queue)
+            box_source_counts_h = self.tree.box_source_counts_nonchild.get(self.queue)
+            use_cache = True
+        else:
+            if box_source_starts is None or box_source_counts is None:
+                raise ValueError(
+                    "box_source_starts and box_source_counts must be provided together"
+                )
+
+            if isinstance(box_source_starts, cl.array.Array):
+                box_source_starts_h = box_source_starts.get(self.queue)
+            else:
+                box_source_starts_h = np.asarray(box_source_starts)
+
+            if isinstance(box_source_counts, cl.array.Array):
+                box_source_counts_h = box_source_counts.get(self.queue)
+            else:
+                box_source_counts_h = np.asarray(box_source_counts)
+
+            use_cache = False
+
         box_levels = self.tree.box_levels.get(self.queue)
 
-        nsources = int(self.tree.nsources)
+        if len(box_source_starts_h) != len(box_levels):
+            raise ValueError("box_source_starts length must match number of boxes")
+        if len(box_source_counts_h) != len(box_levels):
+            raise ValueError("box_source_counts length must match number of boxes")
+
+        if box_source_starts_h.size == 0:
+            nsources = 0
+        else:
+            nsources = int(np.max(box_source_starts_h + box_source_counts_h))
         beta_host = np.zeros(nsources, dtype=np.float64)
         root_extent = float(self.tree.root_extent)
 
-        for ibox in range(len(box_source_starts)):
-            count = int(box_source_counts[ibox])
+        for ibox in range(len(box_source_starts_h)):
+            count = int(box_source_counts_h[ibox])
             if count <= 0:
                 continue
 
-            start = int(box_source_starts[ibox])
+            start = int(box_source_starts_h[ibox])
             stop = start + count
             box_extent = root_extent * (0.5 ** int(box_levels[ibox]))
             beta_value = np.log(box_extent / table_root_extent)
             beta_host[start:stop] = beta_value
 
         beta_host = np.ascontiguousarray(beta_host)
-        self._helmholtz_split_log_alpha_per_source_cache[cache_key] = beta_host
+        if use_cache:
+            self._helmholtz_split_log_alpha_per_source_cache[cache_key] = beta_host
         return beta_host
 
     def _fold_helmholtz_split_log_alpha_into_strength(
-        self, src_weights, table_root_extent
+        self,
+        src_weights,
+        table_root_extent,
+        *,
+        box_source_starts=None,
+        box_source_counts=None,
     ):
-        beta_host = self._get_helmholtz_split_log_alpha_per_source(table_root_extent)
+        beta_host = self._get_helmholtz_split_log_alpha_per_source(
+            table_root_extent,
+            box_source_starts=box_source_starts,
+            box_source_counts=box_source_counts,
+        )
 
         if isinstance(src_weights, cl.array.Array):
             dtype = np.dtype(src_weights.dtype)
-            dev_key = (float(table_root_extent), dtype.str)
-            beta_dev = self._helmholtz_split_log_alpha_per_source_dev_cache.get(dev_key)
-            if beta_dev is None:
+            use_cache = box_source_starts is None and box_source_counts is None
+            if use_cache:
+                dev_key = (float(table_root_extent), dtype.str)
+                beta_dev = self._helmholtz_split_log_alpha_per_source_dev_cache.get(
+                    dev_key
+                )
+                if beta_dev is None:
+                    beta_dev = cl.array.to_device(
+                        self.queue,
+                        beta_host.astype(dtype, copy=False),
+                    )
+                    self._helmholtz_split_log_alpha_per_source_dev_cache[dev_key] = (
+                        beta_dev
+                    )
+            else:
                 beta_dev = cl.array.to_device(
                     self.queue,
                     beta_host.astype(dtype, copy=False),
                 )
-                self._helmholtz_split_log_alpha_per_source_dev_cache[dev_key] = beta_dev
 
             return src_weights * beta_dev
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -2214,7 +2214,8 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             orders,
         )
 
-        selected = max(order_min, min(order_max, selected))
+        if "orders" not in auto_cfg:
+            selected = max(order_min, min(order_max, selected))
 
         coverage_max = max(
             float(thresholds_real[-1]) if len(thresholds_real) else 0.0,

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1753,8 +1753,20 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                         strength_arg=beta_strength,
                         max_nsources_in_one_box_arg=self.max_nsources_in_one_box,
                     )
+                    beta_term = beta_power_term[0]
+                    if isinstance(term_contribution, cl.array.Array) and not isinstance(
+                        beta_term, cl.array.Array
+                    ):
+                        beta_term = cl.array.to_device(
+                            self.queue,
+                            np.ascontiguousarray(np.asarray(beta_term)),
+                        )
+                    elif isinstance(beta_term, cl.array.Array) and not isinstance(
+                        term_contribution, cl.array.Array
+                    ):
+                        beta_term = beta_term.get(self.queue)
 
-                    term_contribution = term_contribution + beta_power_term[0]
+                    term_contribution = term_contribution + beta_term
 
                 term_scale = correction[0].dtype.type(term_coeff)
                 correction = obj_array_1d(

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -2194,6 +2194,14 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         if "rho_thresholds_imag" in auto_cfg:
             thresholds_imag = tuple(auto_cfg["rho_thresholds_imag"])
 
+        if "orders" not in auto_cfg:
+            if len(thresholds_real) != len(thresholds_imag):
+                raise ValueError(
+                    "rho_thresholds_real and rho_thresholds_imag must have the "
+                    "same length when orders are not provided"
+                )
+            orders = tuple(range(order_min, order_min + len(thresholds_real) + 1))
+
         rho_real, rho_imag = self._compute_split_rho_components()
         self._split_auto_rho_real = float(rho_real)
         self._split_auto_rho_imag = float(rho_imag)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1941,14 +1941,37 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         return k_abs * h_max
 
     def _choose_auto_helmholtz_split_order(self, auto_cfg):
-        thresholds = auto_cfg.get("rho_thresholds", (0.5, 1.5, 3.0))
-        orders = auto_cfg.get("orders", (1, 2, 3, 4))
+        order_min = int(auto_cfg.get("order_min", 1))
+        order_max = int(auto_cfg.get("order_max", 8))
+        if order_max < order_min:
+            raise ValueError("order_max must be >= order_min")
+
+        if "rho_thresholds" in auto_cfg or "orders" in auto_cfg:
+            thresholds = auto_cfg.get("rho_thresholds", (0.5, 1.5, 3.0))
+            orders = auto_cfg.get("orders", (1, 2, 3, 4))
+        else:
+            # Default to a geometric ladder in rho to cover wide k*h ranges.
+            # Example with order_max=8: thresholds = (0.5, 1, 2, 4, 8, 16, 32).
+            rho0 = float(auto_cfg.get("rho_base", 0.5))
+            if rho0 <= 0.0:
+                raise ValueError("rho_base must be positive")
+            count = max(0, order_max - order_min)
+            thresholds = tuple(rho0 * (2.0**j) for j in range(count))
+            orders = tuple(range(order_min, order_max + 1))
+
         rho_max = self._compute_split_rho_max()
         selected = _select_split_order_from_rho(rho_max, thresholds, orders)
-
-        order_min = int(auto_cfg.get("order_min", 1))
-        order_max = int(auto_cfg.get("order_max", selected))
         selected = max(order_min, min(order_max, selected))
+
+        if len(thresholds) > 0 and rho_max > float(thresholds[-1]):
+            logger.warning(
+                "rho_max=%.3g exceeds planner threshold coverage (max %.3g); "
+                "clamping split order to %d",
+                rho_max,
+                float(thresholds[-1]),
+                selected,
+            )
+
         logger.info(
             "Auto-selected helmholtz_split_order=%d (rho_max=%.3g)",
             selected,

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1101,7 +1101,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         if auto_mode and self.helmholtz_split:
             max_rho_imag = float(auto_cfg.get("rho_imag_split_max", 8.0))
             disable_outside = bool(
-                auto_cfg.get("disable_split_if_outside_coverage", True)
+                auto_cfg.get("disable_split_if_outside_coverage", False)
             )
             if (
                 disable_outside
@@ -1114,6 +1114,13 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                     max_rho_imag,
                 )
                 self.helmholtz_split = False
+            elif getattr(self, "_split_auto_rho_imag", 0.0) > max_rho_imag:
+                logger.warning(
+                    "Imaginary rho %.3g exceeds configured split coverage %.3g; "
+                    "continuing with split at configured max order",
+                    self._split_auto_rho_imag,
+                    max_rho_imag,
+                )
 
         self.helmholtz_split_order1_legacy_subtraction = bool(
             helmholtz_split_order1_legacy_subtraction

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1338,7 +1338,53 @@ class NearFieldInteractionTable:
             except Exception:
                 pass
 
-        return kernel.__class__.__name__ != "YukawaKernel"
+        # Yukawa was historically routed to scalar Duffy builds. Batched Yukawa
+        # is now supported for 3D and should be preferred for production runtime.
+        if kernel.__class__.__name__ == "YukawaKernel":
+            return self.dim == 3
+
+        return True
+
+    def _prepare_loopy_kernel_for_integral_kernel(self, loopy_knl):
+        """Apply kernel-specific loopy callable registrations if needed."""
+        if self.integral_knl is None:
+            return loopy_knl
+
+        prepare = getattr(self.integral_knl, "prepare_loopy_kernel", None)
+        if prepare is None:
+            return loopy_knl
+
+        return prepare(loopy_knl)
+
+    def _extract_integral_kernel_runtime_kwargs(self, kwargs):
+        if self.integral_knl is None:
+            return {}
+
+        get_args = getattr(self.integral_knl, "get_args", None)
+        if get_args is None:
+            return {}
+
+        kernel_kwargs = {}
+        missing = []
+        for kernel_arg in get_args():
+            loopy_arg = getattr(kernel_arg, "loopy_arg", None)
+            name = getattr(loopy_arg, "name", None)
+            if not name:
+                continue
+
+            if name in kwargs:
+                kernel_kwargs[name] = kwargs[name]
+            else:
+                missing.append(name)
+
+        if missing:
+            missing_list = ", ".join(sorted(missing))
+            raise ValueError(
+                "Missing required kernel parameter value(s) for DuffyRadial "
+                f"table build: {missing_list}"
+            )
+
+        return kernel_kwargs
 
     @memoize_method
     def _get_fused_invariant_duffy_table_tunit(self):
@@ -1385,6 +1431,15 @@ class NearFieldInteractionTable:
             temp_var_type=lp.Optional(),
             within_inames=frozenset(["ientry", "inode"]),
         )
+
+        kernel_arg_types = []
+        if self.integral_knl is not None:
+            get_args = getattr(self.integral_knl, "get_args", None)
+            if get_args is not None:
+                for kernel_arg in get_args():
+                    loopy_arg = getattr(kernel_arg, "loopy_arg", None)
+                    if loopy_arg is not None:
+                        kernel_arg_types.append(loopy_arg)
 
         setup_lines = ["<> active = 1"]
         len_terms = []
@@ -1472,6 +1527,9 @@ class NearFieldInteractionTable:
                 lp.GlobalArg("interp_nodes", geom_dtype, "q_order"),
                 lp.GlobalArg("bary_w", geom_dtype, "q_order"),
                 lp.GlobalArg("mode_i", np.int32, "dim,n_entries"),
+            ]
+            + kernel_arg_types
+            + [
                 lp.GlobalArg("result", self.dtype, "n_entries", is_output=True),
                 lp.TemporaryVariable("knl_scaling", self.dtype),
             ],
@@ -1479,6 +1537,7 @@ class NearFieldInteractionTable:
             lang_version=(2018, 2),
         )
         tunit = lp.fix_parameters(tunit, dim=self.dim)
+        tunit = self._prepare_loopy_kernel_for_integral_kernel(tunit)
         tunit = lp.set_options(tunit, return_dict=True, no_numpy=True)
         tunit = lp.split_iname(tunit, "ientry", 64, outer_tag="g.0", inner_tag="l.0")
         tunit = lp.tag_inames(
@@ -1612,6 +1671,7 @@ class NearFieldInteractionTable:
         regular_quad_order,
         radial_quad_order,
         mp_dps,
+        kernel_kwargs=None,
     ):
         local_entry_indices = np.asarray(local_entry_indices, dtype=np.int64)
         n_entries = int(local_entry_indices.size)
@@ -1705,6 +1765,8 @@ class NearFieldInteractionTable:
             bary_w=bw_arg,
             mode_i=mode_i_arg,
         )
+        if kernel_kwargs:
+            common_kwargs.update(kernel_kwargs)
 
         if queue_is_cl:
             _, res = prg_exec(queue, **common_kwargs)
@@ -1860,6 +1922,7 @@ class NearFieldInteractionTable:
         deg_theta=20,
         radial_quad_order=61,
         mp_dps=50,
+        kernel_kwargs=None,
     ):
         t_total_start = time.perf_counter()
 
@@ -1906,6 +1969,7 @@ class NearFieldInteractionTable:
             deg_theta,
             radial_quad_order,
             mp_dps,
+            kernel_kwargs=kernel_kwargs,
         )
         t_quadrature_end = time.perf_counter()
         self._progress_step()
@@ -1943,6 +2007,7 @@ class NearFieldInteractionTable:
         deg_theta=20,
         radial_quad_order=61,
         mp_dps=50,
+        kernel_kwargs=None,
     ):
         if self.dim != 2:
             raise ValueError("build_table_via_duffy_radial_batched_2d requires dim=2")
@@ -1952,6 +2017,7 @@ class NearFieldInteractionTable:
             deg_theta=deg_theta,
             radial_quad_order=radial_quad_order,
             mp_dps=mp_dps,
+            kernel_kwargs=kernel_kwargs,
         )
 
     def compute_nmlz(self, mode_id):
@@ -2254,6 +2320,8 @@ class NearFieldInteractionTable:
                 "DuffyRadial loopy builder requires sumpy_kernel (integral_knl)"
             )
 
+        kernel_kwargs = self._extract_integral_kernel_runtime_kwargs(kwargs)
+
         if build_config.radial_rule not in {"tanh-sinh-fast", "tanh-sinh"}:
             raise ValueError(
                 "DuffyRadial loopy builder supports only tanh-sinh and "
@@ -2264,13 +2332,28 @@ class NearFieldInteractionTable:
             logger.warning(
                 "Using batched GPU-backed %dD DuffyRadial table builder", self.dim
             )
-            return_value = self.build_table_via_duffy_radial_batched(
-                queue,
-                radial_rule=build_config.radial_rule,
-                deg_theta=int(build_config.regular_quad_order),
-                radial_quad_order=int(build_config.radial_quad_order),
-                mp_dps=build_config.mp_dps,
-            )
+            try:
+                return_value = self.build_table_via_duffy_radial_batched(
+                    queue,
+                    radial_rule=build_config.radial_rule,
+                    deg_theta=int(build_config.regular_quad_order),
+                    radial_quad_order=int(build_config.radial_quad_order),
+                    mp_dps=build_config.mp_dps,
+                    kernel_kwargs=kernel_kwargs,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Batched DuffyRadial build failed for %s (%s); falling back "
+                    "to scalar builder",
+                    self.integral_knl.__class__.__name__,
+                    type(exc).__name__,
+                )
+                return_value = self._build_table_via_duffy_radial_scalar(
+                    build_config.radial_rule,
+                    int(build_config.regular_quad_order),
+                    int(build_config.radial_quad_order),
+                    build_config.mp_dps,
+                )
         else:
             logger.info(
                 "Falling back to scalar DuffyRadial table builder for %s",
@@ -2570,6 +2653,7 @@ class NearFieldInteractionTable:
         )
 
         lpknl = lp.fix_parameters(lpknl, dim=self.dim)
+        lpknl = self._prepare_loopy_kernel_for_integral_kernel(lpknl)
         lpknl = lp.set_options(lpknl, write_cl=False)
         lpknl = lp.set_options(lpknl, return_dict=True)
         lpknl_exec = lpknl.executor(queue.context)

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -2304,17 +2304,6 @@ class NearFieldInteractionTable:
                 self.pb.finished()
             return return_value
 
-        if queue is None:
-            if cl_ctx is not None:
-                queue = cl.CommandQueue(cl_ctx)
-            else:
-                raise ValueError(
-                    "queue (or cl_ctx) is required for DuffyRadial table builds; "
-                    "implicit OpenCL context auto-selection is not supported"
-                )
-        elif cl_ctx is not None and queue.context != cl_ctx:
-            raise ValueError("queue context does not match cl_ctx")
-
         if self.integral_knl is None:
             raise ValueError(
                 "DuffyRadial loopy builder requires sumpy_kernel (integral_knl)"
@@ -2328,7 +2317,20 @@ class NearFieldInteractionTable:
                 "tanh-sinh-fast radial rules"
             )
 
-        if self._supports_batched_duffy_builder():
+        use_batched_builder = self._supports_batched_duffy_builder()
+
+        if use_batched_builder:
+            if queue is None:
+                if cl_ctx is not None:
+                    queue = cl.CommandQueue(cl_ctx)
+                else:
+                    raise ValueError(
+                        "queue (or cl_ctx) is required for batched DuffyRadial "
+                        "table builds"
+                    )
+            elif cl_ctx is not None and queue.context != cl_ctx:
+                raise ValueError("queue context does not match cl_ctx")
+
             logger.warning(
                 "Using batched GPU-backed %dD DuffyRadial table builder", self.dim
             )

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1847,36 +1847,53 @@ class NearFieldInteractionTable:
             )
 
         candidate_values = []
-        for regular_quad_order, radial_quad_order in candidates:
-            if use_batched_eval:
-                values = self._batched_duffy_values_for_local_indices(
-                    queue,
-                    invariant_info,
-                    sample_local_indices,
-                    radial_rule,
-                    regular_quad_order,
-                    radial_quad_order,
-                    mp_dps,
-                    kernel_kwargs=kernel_kwargs,
-                )
-            else:
-                values = []
-                for entry_id in sample_entry_ids:
-                    _, value = self.compute_table_entry_duffy_radial(
-                        entry_id,
-                        radial_rule=radial_rule,
-                        deg_theta=regular_quad_order,
-                        radial_quad_order=radial_quad_order,
-                        mp_dps=mp_dps,
-                    )
-                    values.append(value)
-                values = np.asarray(values)
+        reset_kernel_func = (
+            not use_batched_eval
+            and bool(kernel_kwargs)
+            and self.integral_knl is not None
+        )
+        previous_kernel_func = self.kernel_func
+        if reset_kernel_func:
+            self.kernel_func = sumpy_kernel_to_lambda(
+                self.integral_knl,
+                fallback_dim=self.dim,
+                parameter_values=kernel_kwargs,
+            )
 
-            if np.iscomplexobj(values):
-                values = values.astype(np.complex128)
-            else:
-                values = values.astype(np.float64)
-            candidate_values.append(values)
+        try:
+            for regular_quad_order, radial_quad_order in candidates:
+                if use_batched_eval:
+                    values = self._batched_duffy_values_for_local_indices(
+                        queue,
+                        invariant_info,
+                        sample_local_indices,
+                        radial_rule,
+                        regular_quad_order,
+                        radial_quad_order,
+                        mp_dps,
+                        kernel_kwargs=kernel_kwargs,
+                    )
+                else:
+                    values = []
+                    for entry_id in sample_entry_ids:
+                        _, value = self.compute_table_entry_duffy_radial(
+                            entry_id,
+                            radial_rule=radial_rule,
+                            deg_theta=regular_quad_order,
+                            radial_quad_order=radial_quad_order,
+                            mp_dps=mp_dps,
+                        )
+                        values.append(value)
+                    values = np.asarray(values)
+
+                if np.iscomplexobj(values):
+                    values = values.astype(np.complex128)
+                else:
+                    values = values.astype(np.float64)
+                candidate_values.append(values)
+        finally:
+            if reset_kernel_func:
+                self.kernel_func = previous_kernel_func
 
         reference_values = candidate_values[-1]
         rel_errors = []

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1340,6 +1340,21 @@ class NearFieldInteractionTable:
 
         return True
 
+    def _scalar_duffy_fallback_is_safe(self):
+        if self.integral_knl is None:
+            return True
+
+        get_base = getattr(self.integral_knl, "get_base_kernel", None)
+        if get_base is None:
+            return True
+
+        try:
+            base_kernel = get_base()
+        except Exception:
+            return False
+
+        return base_kernel is self.integral_knl
+
     def _prepare_loopy_kernel_for_integral_kernel(self, loopy_knl):
         """Apply kernel-specific loopy callable registrations if needed."""
         if self.integral_knl is None:
@@ -2379,6 +2394,13 @@ class NearFieldInteractionTable:
                     kernel_kwargs=kernel_kwargs,
                 )
             except Exception as exc:
+                if not self._scalar_duffy_fallback_is_safe():
+                    raise RuntimeError(
+                        "Batched DuffyRadial build failed for wrapped kernel "
+                        f"{self.integral_knl.__class__.__name__}; scalar fallback "
+                        "is disabled because it may drop wrapper postprocessing"
+                    ) from exc
+
                 logger.warning(
                     "Batched DuffyRadial build failed for %s (%s); falling back "
                     "to scalar builder",

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -319,9 +319,12 @@ def sumpy_kernel_to_lambda(sknl, fallback_dim=None, parameter_values=None):
 
     expr = sknl.get_expression(args) * sknl.get_global_scaling_const()
     if parameter_values:
-        expr = expr.subs(
-            {Symbol(str(name)): value for name, value in parameter_values.items()}
-        )
+        subs_map = {}
+        for name, value in parameter_values.items():
+            name_str = str(name)
+            subs_map[Symbol(name_str)] = value
+            subs_map[Symbol(f"_spatial_constant_{name_str}")] = value
+        expr = expr.subs(subs_map)
 
     lmd = lambdify(
         arg_names,
@@ -1324,6 +1327,19 @@ class NearFieldInteractionTable:
                 if child is not None:
                     stack.append(child)
 
+    def _supports_batched_duffy_builder(self):
+        if self.integral_knl is None:
+            return False
+
+        kernel = self.integral_knl
+        if hasattr(kernel, "get_base_kernel"):
+            try:
+                kernel = kernel.get_base_kernel()
+            except Exception:
+                pass
+
+        return kernel.__class__.__name__ != "YukawaKernel"
+
     @memoize_method
     def _get_fused_invariant_duffy_table_tunit(self):
         from sumpy.assignment_collection import SymbolicAssignmentCollection
@@ -1741,6 +1757,7 @@ class NearFieldInteractionTable:
             and self.dim in (1, 2, 3)
             and self.integral_knl is not None
             and radial_rule in {"tanh-sinh-fast", "tanh-sinh"}
+            and self._supports_batched_duffy_builder()
         )
 
         invariant_info = None
@@ -2243,16 +2260,28 @@ class NearFieldInteractionTable:
                 "tanh-sinh-fast radial rules"
             )
 
-        logger.warning(
-            "Using batched GPU-backed %dD DuffyRadial table builder", self.dim
-        )
-        return_value = self.build_table_via_duffy_radial_batched(
-            queue,
-            radial_rule=build_config.radial_rule,
-            deg_theta=int(build_config.regular_quad_order),
-            radial_quad_order=int(build_config.radial_quad_order),
-            mp_dps=build_config.mp_dps,
-        )
+        if self._supports_batched_duffy_builder():
+            logger.warning(
+                "Using batched GPU-backed %dD DuffyRadial table builder", self.dim
+            )
+            return_value = self.build_table_via_duffy_radial_batched(
+                queue,
+                radial_rule=build_config.radial_rule,
+                deg_theta=int(build_config.regular_quad_order),
+                radial_quad_order=int(build_config.radial_quad_order),
+                mp_dps=build_config.mp_dps,
+            )
+        else:
+            logger.info(
+                "Falling back to scalar DuffyRadial table builder for %s",
+                self.integral_knl.__class__.__name__,
+            )
+            return_value = self._build_table_via_duffy_radial_scalar(
+                build_config.radial_rule,
+                int(build_config.regular_quad_order),
+                int(build_config.radial_quad_order),
+                build_config.mp_dps,
+            )
         if self.last_duffy_build_timings is not None:
             self.last_duffy_build_timings["normalizer_s"] = normalizer_s
             self.last_duffy_build_timings["total_with_normalizer_s"] = (

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -2225,50 +2225,52 @@ class NearFieldInteractionTable:
                 parameter_values=kernel_kwargs,
             )
 
-        t_total_start = time.perf_counter()
+        try:
+            t_total_start = time.perf_counter()
 
-        t_invariant_start = time.perf_counter()
-        invariant_entry_ids = [
-            int(entry_id) for entry_id in self._get_invariant_entry_info()["entry_ids"]
-        ]
-        t_invariant_end = time.perf_counter()
-        self._progress_step()
+            t_invariant_start = time.perf_counter()
+            invariant_entry_ids = [
+                int(entry_id)
+                for entry_id in self._get_invariant_entry_info()["entry_ids"]
+            ]
+            t_invariant_end = time.perf_counter()
+            self._progress_step()
 
-        t_quadrature_start = time.perf_counter()
-        for entry_id in invariant_entry_ids:
-            _, entry_val = self.compute_table_entry_duffy_radial(
-                entry_id,
-                radial_rule=radial_rule,
-                deg_theta=deg_theta,
-                radial_quad_order=radial_quad_order,
-                mp_dps=mp_dps,
-            )
-            self.data[entry_id] = entry_val
-        t_quadrature_end = time.perf_counter()
-        self._progress_step()
+            t_quadrature_start = time.perf_counter()
+            for entry_id in invariant_entry_ids:
+                _, entry_val = self.compute_table_entry_duffy_radial(
+                    entry_id,
+                    radial_rule=radial_rule,
+                    deg_theta=deg_theta,
+                    radial_quad_order=radial_quad_order,
+                    mp_dps=mp_dps,
+                )
+                self.data[entry_id] = entry_val
+            t_quadrature_end = time.perf_counter()
+            self._progress_step()
 
-        # Keep table data symmetry-reduced to minimize cache/storage size.
-        # Call progress step for the legacy "symmetry fill" stage even though
-        # propagation is intentionally disabled.
-        t_symmetry_fill_start = time.perf_counter()
-        t_symmetry_fill_end = t_symmetry_fill_start
-        self._progress_step()
+            # Keep table data symmetry-reduced to minimize cache/storage size.
+            # Call progress step for the legacy "symmetry fill" stage even though
+            # propagation is intentionally disabled.
+            t_symmetry_fill_start = time.perf_counter()
+            t_symmetry_fill_end = t_symmetry_fill_start
+            self._progress_step()
 
-        self.table_data_is_symmetry_reduced = bool(np.isnan(self.data).any())
-        self.is_built = True
+            self.table_data_is_symmetry_reduced = bool(np.isnan(self.data).any())
+            self.is_built = True
 
-        t_total_end = time.perf_counter()
-        self.last_duffy_build_timings = {
-            "invariant_info_s": t_invariant_end - t_invariant_start,
-            "quadrature_s": t_quadrature_end - t_quadrature_start,
-            "scatter_s": 0.0,
-            "symmetry_fill_s": t_symmetry_fill_end - t_symmetry_fill_start,
-            "total_s": t_total_end - t_total_start,
-            "n_entries": int(len(invariant_entry_ids)),
-        }
-
-        if reset_kernel_func:
-            self.kernel_func = previous_kernel_func
+            t_total_end = time.perf_counter()
+            self.last_duffy_build_timings = {
+                "invariant_info_s": t_invariant_end - t_invariant_start,
+                "quadrature_s": t_quadrature_end - t_quadrature_start,
+                "scatter_s": 0.0,
+                "symmetry_fill_s": t_symmetry_fill_end - t_symmetry_fill_start,
+                "total_s": t_total_end - t_total_start,
+                "n_entries": int(len(invariant_entry_ids)),
+            }
+        finally:
+            if reset_kernel_func:
+                self.kernel_func = previous_kernel_func
 
     def build_table_via_duffy_radial(
         self,

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -21,6 +21,7 @@ THE SOFTWARE.
 """
 
 import logging
+import numbers
 import time
 from dataclasses import dataclass
 from functools import partial
@@ -1383,7 +1384,19 @@ class NearFieldInteractionTable:
                 continue
 
             if name in kwargs:
-                kernel_kwargs[name] = kwargs[name]
+                value = kwargs[name]
+                if value is None:
+                    raise TypeError(
+                        "Invalid kernel parameter value for DuffyRadial table "
+                        f"build: {name}=None"
+                    )
+                if not isinstance(value, numbers.Number):
+                    raise TypeError(
+                        "Invalid kernel parameter value for DuffyRadial table "
+                        f"build: {name}={value!r} (expected numeric scalar)"
+                    )
+
+                kernel_kwargs[name] = value
             else:
                 missing.append(name)
 

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -318,7 +318,13 @@ def sumpy_kernel_to_lambda(sknl, fallback_dim=None, parameter_values=None):
     arg_names = symbols(var_names)
     args = [Symbol(var_name_prefix + str(i)) for i in range(dim)]
 
-    expr = sknl.get_expression(args) * sknl.get_global_scaling_const()
+    expr = (
+        sknl.postprocess_at_target(
+            sknl.postprocess_at_source(sknl.get_expression(args), args),
+            args,
+        )
+        * sknl.get_global_scaling_const()
+    )
     if parameter_values:
         subs_map = {}
         for name, value in parameter_values.items():
@@ -1394,6 +1400,11 @@ class NearFieldInteractionTable:
                     raise TypeError(
                         "Invalid kernel parameter value for DuffyRadial table "
                         f"build: {name}={value!r} (expected numeric scalar)"
+                    )
+                if not np.isfinite(value):
+                    raise TypeError(
+                        "Invalid kernel parameter value for DuffyRadial table "
+                        f"build: {name}={value!r} (expected finite numeric scalar)"
                     )
 
                 kernel_kwargs[name] = value

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1332,11 +1332,6 @@ class NearFieldInteractionTable:
             return False
 
         kernel = self.integral_knl
-        if hasattr(kernel, "get_base_kernel"):
-            try:
-                kernel = kernel.get_base_kernel()
-            except Exception:
-                pass
 
         # Yukawa was historically routed to scalar Duffy builds. Batched Yukawa
         # is now supported for 3D and should be preferred for production runtime.
@@ -2187,7 +2182,17 @@ class NearFieldInteractionTable:
         deg_theta,
         radial_quad_order,
         mp_dps,
+        kernel_kwargs=None,
     ):
+        reset_kernel_func = bool(kernel_kwargs) and self.integral_knl is not None
+        previous_kernel_func = self.kernel_func
+        if reset_kernel_func:
+            self.kernel_func = sumpy_kernel_to_lambda(
+                self.integral_knl,
+                fallback_dim=self.dim,
+                parameter_values=kernel_kwargs,
+            )
+
         t_total_start = time.perf_counter()
 
         t_invariant_start = time.perf_counter()
@@ -2229,6 +2234,9 @@ class NearFieldInteractionTable:
             "total_s": t_total_end - t_total_start,
             "n_entries": int(len(invariant_entry_ids)),
         }
+
+        if reset_kernel_func:
+            self.kernel_func = previous_kernel_func
 
     def build_table_via_duffy_radial(
         self,
@@ -2272,6 +2280,17 @@ class NearFieldInteractionTable:
                     auto_tune_candidates=build_config.auto_tune_candidates,
                     kwargs=kwargs,
                 )
+
+        if queue is not None and cl_ctx is not None and queue.context != cl_ctx:
+            raise ValueError("queue context does not match cl_ctx")
+
+        if (
+            queue is None
+            and cl_ctx is not None
+            and self._supports_batched_duffy_builder()
+        ):
+            queue = cl.CommandQueue(cl_ctx)
+
         kernel_kwargs = self._extract_integral_kernel_runtime_kwargs(kwargs)
         build_config = self._resolve_duffy_build_config(
             build_config,
@@ -2302,6 +2321,7 @@ class NearFieldInteractionTable:
                 deg_theta=int(build_config.regular_quad_order),
                 radial_quad_order=int(build_config.radial_quad_order),
                 mp_dps=build_config.mp_dps,
+                kernel_kwargs=kernel_kwargs,
             )
             if self.last_duffy_build_timings is not None:
                 self.last_duffy_build_timings["normalizer_s"] = normalizer_s
@@ -2361,6 +2381,7 @@ class NearFieldInteractionTable:
                     int(build_config.regular_quad_order),
                     int(build_config.radial_quad_order),
                     build_config.mp_dps,
+                    kernel_kwargs=kernel_kwargs,
                 )
         else:
             logger.info(
@@ -2372,6 +2393,7 @@ class NearFieldInteractionTable:
                 int(build_config.regular_quad_order),
                 int(build_config.radial_quad_order),
                 build_config.mp_dps,
+                kernel_kwargs=kernel_kwargs,
             )
         if self.last_duffy_build_timings is not None:
             self.last_duffy_build_timings["normalizer_s"] = normalizer_s

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -294,7 +294,7 @@ def _sumpy_kernel_dim(sknl, fallback_dim=None):
     )
 
 
-def sumpy_kernel_to_lambda(sknl, fallback_dim=None):
+def sumpy_kernel_to_lambda(sknl, fallback_dim=None, parameter_values=None):
     if not _is_sumpy_kernel_like(sknl):
         raise TypeError(
             "sumpy_kernel_to_lambda requires a sumpy-like kernel object with "
@@ -317,9 +317,15 @@ def sumpy_kernel_to_lambda(sknl, fallback_dim=None):
     arg_names = symbols(var_names)
     args = [Symbol(var_name_prefix + str(i)) for i in range(dim)]
 
+    expr = sknl.get_expression(args) * sknl.get_global_scaling_const()
+    if parameter_values:
+        expr = expr.subs(
+            {Symbol(str(name)): value for name, value in parameter_values.items()}
+        )
+
     lmd = lambdify(
         arg_names,
-        sknl.get_expression(args) * sknl.get_global_scaling_const(),
+        expr,
         modules=[
             {
                 "hankel_1": _hankel1,

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1786,6 +1786,7 @@ class NearFieldInteractionTable:
         sample_count=5,
         candidates=None,
         floor_factor=8.0,
+        kernel_kwargs=None,
     ):
         if radial_rule == "adaptive":
             raise ValueError(
@@ -1846,6 +1847,7 @@ class NearFieldInteractionTable:
                     regular_quad_order,
                     radial_quad_order,
                     mp_dps,
+                    kernel_kwargs=kernel_kwargs,
                 )
             else:
                 values = []
@@ -2131,7 +2133,7 @@ class NearFieldInteractionTable:
             auto_tune_candidates=auto_tune_candidates,
         )
 
-    def _resolve_duffy_build_config(self, build_config, queue):
+    def _resolve_duffy_build_config(self, build_config, queue, kernel_kwargs=None):
         regular_quad_order = build_config.regular_quad_order
         radial_quad_order = build_config.radial_quad_order
 
@@ -2148,6 +2150,7 @@ class NearFieldInteractionTable:
                 sample_count=build_config.auto_tune_samples,
                 candidates=build_config.auto_tune_candidates,
                 floor_factor=build_config.auto_tune_floor_factor,
+                kernel_kwargs=kernel_kwargs,
             )
             if build_config.auto_tune_orders or _is_auto_quad_order(regular_quad_order):
                 regular_quad_order = tuned_regular
@@ -2269,7 +2272,12 @@ class NearFieldInteractionTable:
                     auto_tune_candidates=build_config.auto_tune_candidates,
                     kwargs=kwargs,
                 )
-        build_config = self._resolve_duffy_build_config(build_config, queue=queue)
+        kernel_kwargs = self._extract_integral_kernel_runtime_kwargs(kwargs)
+        build_config = self._resolve_duffy_build_config(
+            build_config,
+            queue=queue,
+            kernel_kwargs=kernel_kwargs,
+        )
 
         if self.pb is not None:
             self.pb.draw()
@@ -2308,8 +2316,6 @@ class NearFieldInteractionTable:
             raise ValueError(
                 "DuffyRadial loopy builder requires sumpy_kernel (integral_knl)"
             )
-
-        kernel_kwargs = self._extract_integral_kernel_runtime_kwargs(kwargs)
 
         if build_config.radial_rule not in {"tanh-sinh-fast", "tanh-sinh"}:
             raise ValueError(

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -2281,7 +2281,12 @@ class NearFieldInteractionTable:
                     kwargs=kwargs,
                 )
 
-        if queue is not None and cl_ctx is not None and queue.context != cl_ctx:
+        if (
+            queue is not None
+            and cl_ctx is not None
+            and hasattr(queue, "context")
+            and queue.context != cl_ctx
+        ):
             raise ValueError("queue context does not match cl_ctx")
 
         if (
@@ -2354,7 +2359,11 @@ class NearFieldInteractionTable:
                         "queue (or cl_ctx) is required for batched DuffyRadial "
                         "table builds"
                     )
-            elif cl_ctx is not None and queue.context != cl_ctx:
+            elif (
+                cl_ctx is not None
+                and hasattr(queue, "context")
+                and queue.context != cl_ctx
+            ):
                 raise ValueError("queue context does not match cl_ctx")
 
             logger.warning(

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -2350,6 +2350,14 @@ class NearFieldInteractionTable:
             self.has_normalizers = False
 
         if build_config.radial_rule == "adaptive":
+            if not self._scalar_duffy_fallback_is_safe():
+                raise RuntimeError(
+                    "Adaptive DuffyRadial scalar build is not supported for "
+                    f"wrapped kernel {self.integral_knl.__class__.__name__}; "
+                    "use a fixed tanh-sinh radial rule so the batched path can "
+                    "preserve wrapper postprocessing"
+                )
+
             logger.warning(
                 "Using scalar CPU-backed %dD DuffyRadial table builder "
                 "with adaptive radial rule",
@@ -2434,6 +2442,14 @@ class NearFieldInteractionTable:
                     kernel_kwargs=kernel_kwargs,
                 )
         else:
+            if not self._scalar_duffy_fallback_is_safe():
+                raise RuntimeError(
+                    "Scalar DuffyRadial build is not supported for wrapped "
+                    f"kernel {self.integral_knl.__class__.__name__}; use a "
+                    "batched-capable configuration to preserve wrapper "
+                    "postprocessing"
+                )
+
             logger.info(
                 "Falling back to scalar DuffyRadial table builder for %s",
                 self.integral_knl.__class__.__name__,

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1633,6 +1633,18 @@ class NearFieldInteractionTableManager:
             if loaded_build_config_fingerprint != requested_build_config_fingerprint:
                 raise KeyError("cached build_config mismatch")
 
+        requested_kernel_params = self._extract_kernel_parameter_values(
+            kernel_bundle.sumpy_kernel,
+            kwargs,
+        )
+        for pname, pvalue in requested_kernel_params.items():
+            loaded_value = loaded_kwargs.get(pname)
+            if loaded_value is None:
+                raise KeyError(f"cached kernel parameter '{pname}' is missing")
+
+            if complex(loaded_value) != complex(pvalue):
+                raise KeyError(f"cached kernel parameter '{pname}' mismatch")
+
         for atkey, atval in loaded_kwargs.items():
             setattr(table, atkey, atval)
         t_kwargs_load_end = time.perf_counter()

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1212,11 +1212,41 @@ class NearFieldInteractionTableManager:
                 "for loopy table build."
             )
 
+        kernel_func = None
+        if sumpy_knl is not None:
+            from volumential.nearfield_potential_table import sumpy_kernel_to_lambda
+
+            parameter_values = self._extract_kernel_parameter_values(sumpy_knl, kwargs)
+            kernel_func = sumpy_kernel_to_lambda(
+                sumpy_knl,
+                fallback_dim=table_request.dim,
+                parameter_values=parameter_values,
+            )
+
         return TableKernelBundle(
-            kernel_func=None,
+            kernel_func=kernel_func,
             kernel_scale_type=kernel_scale_type,
             sumpy_kernel=sumpy_knl,
         )
+
+    def _extract_kernel_parameter_values(self, sumpy_knl, kwargs):
+        parameter_values = {}
+        for attr_name in ("helmholtz_k_name", "yukawa_lambda_name"):
+            param_name = getattr(sumpy_knl, attr_name, None)
+            if not isinstance(param_name, str) or not param_name:
+                continue
+
+            if param_name not in kwargs:
+                raise TypeError(
+                    "missing kernel parameter "
+                    + repr(param_name)
+                    + " for "
+                    + sumpy_knl.__class__.__name__
+                )
+
+            parameter_values[param_name] = kwargs[param_name]
+
+        return parameter_values
 
     def _warn_on_loaded_kwarg_mismatch(self, table, kwargs):
         for kkey, kval in kwargs.items():

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1230,9 +1230,17 @@ class NearFieldInteractionTableManager:
         )
 
     def _extract_kernel_parameter_values(self, sumpy_knl, kwargs):
+        base_knl = sumpy_knl
+        get_base_kernel = getattr(sumpy_knl, "get_base_kernel", None)
+        if callable(get_base_kernel):
+            try:
+                base_knl = get_base_kernel()
+            except Exception:
+                base_knl = sumpy_knl
+
         parameter_values = {}
         for attr_name in ("helmholtz_k_name", "yukawa_lambda_name"):
-            param_name = getattr(sumpy_knl, attr_name, None)
+            param_name = getattr(base_knl, attr_name, None)
             if not isinstance(param_name, str) or not param_name:
                 continue
 
@@ -1244,7 +1252,26 @@ class NearFieldInteractionTableManager:
                     + sumpy_knl.__class__.__name__
                 )
 
-            parameter_values[param_name] = kwargs[param_name]
+            param_value = kwargs[param_name]
+            if param_value is None:
+                raise TypeError(
+                    "missing kernel parameter "
+                    + repr(param_name)
+                    + " for "
+                    + sumpy_knl.__class__.__name__
+                )
+
+            try:
+                complex(param_value)
+            except Exception as exc:
+                raise TypeError(
+                    "kernel parameter "
+                    + repr(param_name)
+                    + " must be numeric for "
+                    + sumpy_knl.__class__.__name__
+                ) from exc
+
+            parameter_values[param_name] = param_value
 
         return parameter_values
 
@@ -1642,7 +1669,12 @@ class NearFieldInteractionTableManager:
             if loaded_value is None:
                 raise KeyError(f"cached kernel parameter '{pname}' is missing")
 
-            if complex(loaded_value) != complex(pvalue):
+            if not np.isclose(
+                complex(loaded_value),
+                complex(pvalue),
+                rtol=1.0e-12,
+                atol=1.0e-15,
+            ):
                 raise KeyError(f"cached kernel parameter '{pname}' mismatch")
 
         for atkey, atval in loaded_kwargs.items():

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -1275,6 +1275,26 @@ class NearFieldInteractionTableManager:
 
         return parameter_values
 
+    @staticmethod
+    def _kernel_parameter_values_match(loaded_value, requested_value):
+        loaded_c = complex(loaded_value)
+        requested_c = complex(requested_value)
+
+        if np.isclose(loaded_c, requested_c, rtol=1.0e-12, atol=1.0e-15):
+            return True
+
+        loaded_c64 = np.complex64(loaded_c)
+        requested_c64 = np.complex64(requested_c)
+        c64_eps = np.finfo(np.float32).eps
+        return bool(
+            np.isclose(
+                loaded_c64,
+                requested_c64,
+                rtol=64.0 * c64_eps,
+                atol=64.0 * c64_eps,
+            )
+        )
+
     def _warn_on_loaded_kwarg_mismatch(self, table, kwargs):
         for kkey, kval in kwargs.items():
             if kval is not None:
@@ -1669,12 +1689,7 @@ class NearFieldInteractionTableManager:
             if loaded_value is None:
                 raise KeyError(f"cached kernel parameter '{pname}' is missing")
 
-            if not np.isclose(
-                complex(loaded_value),
-                complex(pvalue),
-                rtol=1.0e-12,
-                atol=1.0e-15,
-            ):
+            if not self._kernel_parameter_values_match(loaded_value, pvalue):
                 raise KeyError(f"cached kernel parameter '{pname}' mismatch")
 
         for atkey, atval in loaded_kwargs.items():


### PR DESCRIPTION
## Summary
- add parameter substitution support to `sumpy_kernel_to_lambda` so parameterized kernels can build concrete near-field kernel callables
- make `NearFieldInteractionTableManager` derive concrete kernel callables from sumpy kernels and enforce required parameter kwargs (e.g. `lam` for Yukawa)
- add Yukawa table-manager tests for missing-parameter failure and finite table build with `lam`
- fix 2D Helmholtz batched Duffy table builds by applying `prepare_loopy_kernel` callable registration and plumbing runtime kernel args (e.g. `k`) into fused kernels
- enable batched Duffy builder for Yukawa 3D direct-table builds in production, with automatic scalar fallback if batched build fails

## Why
Issue #63 calls out first-milestone scalar kernel support including Modified Helmholtz/Yukawa. Existing paths exposed Yukawa kernels but did not enforce/provide parameter binding in table builds, leaving support brittle and under-tested.

For high-reference 2D Helmholtz direct tables, batched GPU Duffy generation was blocked by missing Hankel callable registration (`hank1_01`) and missing runtime kernel parameter wiring in the generated fused kernel. This PR now aligns Volumential table generation with Sumpy's callable-registration flow.

For Yukawa 3D, direct-table generation was unexpectedly slow because production logic forced Yukawa onto the scalar Duffy path. Enabling batched Yukawa 3D restores expected runtime characteristics and allows full IPA coverage sweeps.

## High-Reference Wideband Snapshot (auto `p,m` defaults)
Measured on IPA (`NVIDIA H200 NVL`) with split auto defaults (`helmholtz_split_order="auto"`, auto smooth quadrature), reporting `rel_vs_direct_high`.

### Column Guide
- `Re(k)`, `Im(k)`: real/imaginary parts of Helmholtz/Yukawa split parameter (`k=i*lam` for Yukawa)
- `rho_real`, `rho_imag`: planner-normalized magnitudes (`|Re(k)|h`, `|Im(k)|h`) at runtime
- `auto p`: auto-selected split expansion truncation order
- `auto m`: auto-selected smooth quadrature order
- `rel_vs_direct_high`: relative error against the strongest available direct-table reference for that row

### Problem Setup (all rows)
- Domain/mesh: uniform box `[-0.5, 0.5]^d`, `nlevels=3`, same source/target points for split and direct in each row
- Helmholtz 2D + Yukawa 2D: `q_order=5`, `fmm_order=16`
- Helmholtz 3D + Yukawa 3D: `q_order=3`, `fmm_order=14`
- Direct-high table builds:
  - 2D rows: `regular_quad_order=36`, `radial_quad_order=120`
  - 3D rows: `regular_quad_order=10`, `radial_quad_order=41`
- Source profiles:
  - Helmholtz rows: complex helper profiles from test helpers (`_helmholtz_complex_source_profile_2d/_3d`)
  - Yukawa 2D: `exp(-35*((x+0.11)^2 + (y-0.07)^2))`
  - Yukawa 3D: `exp(-14*((x+0.1)^2 + (y-0.08)^2 + (z+0.06)^2))`

### Rows With Stable High-Reference Coverage
| Kernel | Dim | Re(k) | Im(k) | rho_real | rho_imag | auto p | auto m | rel_vs_direct_high |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Helmholtz | 2D | 2.0 | 0 | 0.5 | 0 | 3 | 7 | 2.3436e-08 |
| Helmholtz | 2D | 8.0 | 0 | 2.0 | 0 | 5 | 9 | 7.9173e-08 |
| Helmholtz | 2D | 16.0 | 0 | 4.0 | 0 | 6 | 11 | 3.3398e-07 |
| Helmholtz | 2D | 32.0 | 0 | 8.0 | 0 | 7 | 14 | 2.6230e-06 |
| Helmholtz | 3D | 2.0 | 0 | 0.5 | 0 | 3 | 5 | 2.2215e-12 |
| Helmholtz | 3D | 4.0 | 0 | 1.0 | 0 | 4 | 6 | 1.3885e-13 |
| Helmholtz | 3D | 6.0 | 0 | 1.5 | 0 | 5 | 7 | 5.5698e-13 |
| Helmholtz | 3D | 8.0 | 0 | 2.0 | 0 | 5 | 7 | 3.4457e-12 |
| Helmholtz | 3D | 10.0 | 0 | 2.5 | 0 | 6 | 8 | 1.9042e-11 |
| Helmholtz | 3D | 12.0 | 0 | 3.0 | 0 | 6 | 8 | 1.9167e-10 |
| Helmholtz | 3D | 16.0 | 0 | 4.0 | 0 | 6 | 9 | 1.1670e-08 |
| Yukawa | 2D | 0 | 8 | 0 | 2.0 | 4 | 8 | 1.8611e-09 |
| Yukawa | 2D | 0 | 16 | 0 | 4.0 | 5 | 9 | 6.1665e-08 |
| Yukawa | 2D | 0 | 24 | 0 | 6.0 | 6 | 12 | 1.2716e-07 |
| Yukawa | 2D | 0 | 32 | 0 | 8.0 | 6 | 14 | 6.6297e-08 |
| Yukawa | 3D | 0 | 2 | 0 | 0.5 | 2 | 4 | 4.8224e-07 |
| Yukawa | 3D | 0 | 4 | 0 | 1.0 | 3 | 5 | 8.7211e-07 |
| Yukawa | 3D | 0 | 8 | 0 | 2.0 | 4 | 6 | 2.0533e-06 |
| Yukawa | 3D | 0 | 12 | 0 | 3.0 | 5 | 7 | 3.8141e-06 |
| Yukawa | 3D | 0 | 16 | 0 | 4.0 | 5 | 7 | 6.1529e-06 |

## Accuracy-Floor Findings (IPA)
### Helmholtz 2D
- Reference-strength probe (`k=16,32`) with direct builds `r28/z90 -> r36/z120 -> r48/z160` shows the direct reference is already converged at `r36/z120`:
  - `rel(direct r36/z120, direct r48/z160)` = `3.70e-14` (`k=16`), `2.89e-13` (`k=32`)
  - `rel(split, direct)` changes only in the `1e-13` range when strengthening reference from `r36/z120` to `r48/z160`
- Tightening split controls (`p,m` above auto and higher `fmm_order`) does not materially lower error for the tested setup, indicating a numerical floor.
- Cancellation diagnostics show strong subtractive cancellation growth with `k`:
  - `(||list1_base||+||list1_corr||)/||near||`: `1.87` (`k=2`) -> `5.29` (`k=8`) -> `15.76` (`k=16`) -> `93.21` (`k=32`)
  - `(||near||+||far||)/||total||`: `1.16` -> `1.53` -> `1.83` -> `2.30`
- Two mitigation attempts were tested and then reverted (no benefit on IPA):
  1) compensated summation in split correction accumulation and list1 combine,
  2) regrouping split series terms (small-to-large by coefficient scale).

### Yukawa 2D
- Earlier apparent plateaus at `lam=8/16/24` were largely reference-limited with weaker direct caches.
- Against stronger direct references, the errors tighten substantially and stabilize (examples):
  - `lam=8`: ~`8.47e-06` -> ~`1.86e-09`
  - `lam=16`: ~`2.56e-05` -> ~`6.17e-08`
  - `lam=24`: ~`5.26e-05` -> ~`1.27e-07`
- At `lam=32`, behavior remains sensitive/non-monotone with very high `p`; mid-range auto `p,m` remains near-optimal in this campaign.

### Yukawa 3D Runtime/Reference Notes
- Root cause of earlier long runtimes: `_supports_batched_duffy_builder` previously hard-disabled batched mode for `YukawaKernel`, forcing scalar Duffy direct-table builds.
- Production change in this PR enables batched Yukawa for 3D and adds safe fallback to scalar on batched-build exceptions.
- IPA timings after production enable (typical): direct-table build ~`6.9s` per lambda (warm cache), direct unsplit eval ~`22-25s`, split eval ~`28-45s`.