### PR TITLE
Expose List 1 scaling policy metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,19 +55,19 @@ include = ["volumential*"]
 default-groups = []
 
 [tool.uv.sources]
-arraycontext = { git = "https://gitlab.tiker.net/inducer/arraycontext.git" }
-boxtree = { git = "https://gitlab.tiker.net/inducer/boxtree.git" }
-cgen = { git = "https://gitlab.tiker.net/inducer/cgen.git" }
-genpy = { git = "https://gitlab.tiker.net/inducer/genpy.git" }
-gmsh_interop = { git = "https://gitlab.tiker.net/inducer/gmsh_interop.git" }
-loopy = { git = "https://gitlab.tiker.net/inducer/loopy.git" }
-meshmode = { git = "https://gitlab.tiker.net/inducer/meshmode.git" }
-modepy = { git = "https://gitlab.tiker.net/inducer/modepy.git" }
-pymbolic = { git = "https://gitlab.tiker.net/inducer/pymbolic.git" }
-pytential = { git = "https://gitlab.tiker.net/inducer/pytential.git" }
-pytools = { git = "https://gitlab.tiker.net/inducer/pytools.git" }
-pyvisfile = { git = "https://gitlab.tiker.net/inducer/pyvisfile.git" }
-sumpy = { git = "https://gitlab.tiker.net/inducer/sumpy.git" }
+arraycontext = { git = "https://github.com/inducer/arraycontext.git" }
+boxtree = { git = "https://github.com/inducer/boxtree.git" }
+cgen = { git = "https://github.com/inducer/cgen.git" }
+genpy = { git = "https://github.com/inducer/genpy.git" }
+gmsh_interop = { git = "https://github.com/inducer/gmsh_interop.git" }
+loopy = { git = "https://github.com/inducer/loopy.git" }
+meshmode = { git = "https://github.com/inducer/meshmode.git" }
+modepy = { git = "https://github.com/inducer/modepy.git" }
+pymbolic = { git = "https://github.com/inducer/pymbolic.git" }
+pytential = { git = "https://github.com/inducer/pytential.git" }
+pytools = { git = "https://github.com/inducer/pytools.git" }
+pyvisfile = { git = "https://github.com/inducer/pyvisfile.git" }
+sumpy = { git = "https://github.com/inducer/sumpy.git" }
 
 [tool.pytest.ini_options]
 testpaths = ["test"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,18 +6,18 @@
 
 filelock
 
--e git+https://gitlab.tiker.net/inducer/gmsh_interop.git#egg=gmsh_interop
--e git+https://gitlab.tiker.net/inducer/pytential.git#egg=pytential
--e git+https://gitlab.tiker.net/inducer/pytools.git#egg=pytools
--e git+https://gitlab.tiker.net/inducer/cgen.git#egg=cgen
--e git+https://gitlab.tiker.net/inducer/loopy.git#egg=loopy
--e git+https://gitlab.tiker.net/inducer/pymbolic.git#egg=pymbolic
--e git+https://gitlab.tiker.net/inducer/boxtree.git#egg=boxtree
--e git+https://gitlab.tiker.net/inducer/arraycontext.git#egg=arraycontext
--e git+https://gitlab.tiker.net/inducer/meshmode.git#egg=meshmode
--e git+https://gitlab.tiker.net/inducer/genpy.git#egg=genpy
--e git+https://gitlab.tiker.net/inducer/pyvisfile.git#egg=pyvisfile
--e git+https://gitlab.tiker.net/inducer/sumpy.git#egg=sumpy
--e git+https://gitlab.tiker.net/inducer/modepy.git#egg=modepy
+-e git+https://github.com/inducer/gmsh_interop.git#egg=gmsh_interop
+-e git+https://github.com/inducer/pytential.git#egg=pytential
+-e git+https://github.com/inducer/pytools.git#egg=pytools
+-e git+https://github.com/inducer/cgen.git#egg=cgen
+-e git+https://github.com/inducer/loopy.git#egg=loopy
+-e git+https://github.com/inducer/pymbolic.git#egg=pymbolic
+-e git+https://github.com/inducer/boxtree.git#egg=boxtree
+-e git+https://github.com/inducer/arraycontext.git#egg=arraycontext
+-e git+https://github.com/inducer/meshmode.git#egg=meshmode
+-e git+https://github.com/inducer/genpy.git#egg=genpy
+-e git+https://github.com/inducer/pyvisfile.git#egg=pyvisfile
+-e git+https://github.com/inducer/sumpy.git#egg=sumpy
+-e git+https://github.com/inducer/modepy.git#egg=modepy
 
 -e .[test,doc]

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -3501,6 +3501,36 @@ def test_list1_scaling_policy_documents_per_level_tables_for_helmholtz():
     assert policy.table_level_code == near_field.codegen_get_table_level()
 
 
+def test_list1_scaling_policy_documents_fixed_single_table_for_helmholtz():
+    from sumpy.kernel import HelmholtzKernel
+
+    from volumential.list1 import NearFieldFromCSR
+
+    near_field = NearFieldFromCSR(
+        HelmholtzKernel(3),
+        {
+            "n_tables": 1,
+            "n_q_points": 1,
+            "n_cases": 1,
+            "n_table_entries": 1,
+        },
+        potential_kind=1,
+    )
+
+    policy = near_field.get_kernel_scaling_policy()
+    assert policy.mode == "fixed_single_table"
+    assert not policy.infer_kernel_scaling
+    assert not policy.single_table_scaling_supported
+    assert policy.reference_table_level == 0
+    assert policy.scaling_code == "1.0"
+    assert policy.displacement_code == "0.0"
+    assert policy.table_level_code == "0.0"
+    assert "runtime checks reject mixed source levels" in policy.notes
+    assert policy.scaling_code == near_field.codegen_compute_scaling()
+    assert policy.displacement_code == near_field.codegen_compute_displacement()
+    assert policy.table_level_code == near_field.codegen_get_table_level()
+
+
 def test_list1_laplace_derivative_infer_scaling_is_first_order():
     from sumpy.kernel import AxisSourceDerivative, AxisTargetDerivative, LaplaceKernel
 

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -3472,6 +3472,35 @@ def test_list1_helmholtz_infer_scaling_rejected():
         )
 
 
+def test_list1_scaling_policy_documents_per_level_tables_for_helmholtz():
+    from sumpy.kernel import HelmholtzKernel
+
+    from volumential.list1 import NearFieldFromCSR
+
+    near_field = NearFieldFromCSR(
+        HelmholtzKernel(3),
+        {
+            "n_tables": 3,
+            "n_q_points": 1,
+            "n_cases": 1,
+            "n_table_entries": 1,
+        },
+        potential_kind=1,
+    )
+
+    policy = near_field.get_kernel_scaling_policy()
+    assert policy.mode == "per_level_tables"
+    assert not policy.infer_kernel_scaling
+    assert not policy.single_table_scaling_supported
+    assert policy.reference_table_level is None
+    assert policy.scaling_code == "1.0"
+    assert policy.displacement_code == "0.0"
+    assert "sbox_level" in policy.table_level_code
+    assert policy.scaling_code == near_field.codegen_compute_scaling()
+    assert policy.displacement_code == near_field.codegen_compute_displacement()
+    assert policy.table_level_code == near_field.codegen_get_table_level()
+
+
 def test_list1_laplace_derivative_infer_scaling_is_first_order():
     from sumpy.kernel import AxisSourceDerivative, AxisTargetDerivative, LaplaceKernel
 
@@ -3491,6 +3520,66 @@ def test_list1_laplace_derivative_infer_scaling_is_first_order():
         near_field = NearFieldFromCSR(out_knl, table_shapes, potential_kind=1)
         scaling = "".join(near_field.codegen_compute_scaling().split())
         assert scaling == "sbox_extent/table_root_extent"
+
+
+def test_list1_laplace_scaling_policy_documents_canonical_table():
+    from sumpy.kernel import LaplaceKernel
+
+    from volumential.list1 import NearFieldFromCSR
+
+    near_field = NearFieldFromCSR(
+        LaplaceKernel(2),
+        {
+            "n_tables": 1,
+            "n_q_points": 1,
+            "n_cases": 1,
+            "n_table_entries": 1,
+        },
+        potential_kind=1,
+    )
+
+    policy = near_field.get_kernel_scaling_policy()
+    assert policy.mode == "canonical_single_table"
+    assert policy.infer_kernel_scaling
+    assert policy.single_table_scaling_supported
+    assert policy.reference_table_level == 0
+    assert "sbox_extent" in policy.scaling_code
+    assert "log(sbox_extent / table_root_extent)" in policy.displacement_code
+    assert policy.table_level_code == "0.0"
+    assert policy.scaling_code == near_field.codegen_compute_scaling()
+    assert policy.displacement_code == near_field.codegen_compute_displacement()
+    assert policy.table_level_code == near_field.codegen_get_table_level()
+
+
+def test_list1_custom_scaling_policy_documents_user_code():
+    from sumpy.kernel import HelmholtzKernel
+
+    from volumential.list1 import NearFieldFromCSR
+
+    near_field = NearFieldFromCSR(
+        HelmholtzKernel(3),
+        {
+            "n_tables": 1,
+            "n_q_points": 1,
+            "n_cases": 1,
+            "n_table_entries": 1,
+        },
+        potential_kind=1,
+        kernel_scaling_code="2 * BOX_extent",
+        kernel_displacement_code="BOX_level",
+    )
+
+    policy = near_field.get_kernel_scaling_policy()
+    assert policy.mode == "custom_single_table"
+    assert not policy.infer_kernel_scaling
+    assert policy.single_table_scaling_supported
+    assert policy.reference_table_level == 0
+    assert policy.scaling_code == "2 * sbox_extent"
+    assert policy.displacement_code == "sbox_level"
+    assert policy.table_level_code == "0.0"
+    assert policy.scaling_code == near_field.codegen_compute_scaling()
+    assert policy.displacement_code == near_field.codegen_compute_displacement()
+    assert policy.table_level_code == near_field.codegen_get_table_level()
 
 
 def test_list1_laplace_2d_derivative_infer_scaling_has_no_log_displacement():

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 [[package]]
 name = "arraycontext"
 version = "2024.0"
-source = { git = "https://gitlab.tiker.net/inducer/arraycontext.git#5ed2868f1ee0f4f45dcd07cf96ae71e57939fd16" }
+source = { git = "https://github.com/inducer/arraycontext.git#4ed685da024473266b2a635b350615e36c3ce176" }
 dependencies = [
     { name = "constantdict" },
     { name = "numpy" },
@@ -38,7 +38,7 @@ wheels = [
 [[package]]
 name = "boxtree"
 version = "2024.10"
-source = { git = "https://gitlab.tiker.net/inducer/boxtree.git#3c220d5065cff40243fb7d0cf32dd08014c05fb4" }
+source = { git = "https://github.com/inducer/boxtree.git#bfee6b8ffee7e187a1020984305a7107cecca638" }
 dependencies = [
     { name = "arraycontext" },
     { name = "cgen" },
@@ -221,7 +221,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/04/03/1578d2a701e5596f9
 [[package]]
 name = "gmsh-interop"
 version = "2025.1"
-source = { git = "https://gitlab.tiker.net/inducer/gmsh_interop.git#0250c1eff69bf17b2d1e9b296163f2aef5cdbda5" }
+source = { git = "https://github.com/inducer/gmsh_interop.git#0250c1eff69bf17b2d1e9b296163f2aef5cdbda5" }
 dependencies = [
     { name = "numpy" },
     { name = "packaging" },
@@ -302,7 +302,7 @@ wheels = [
 [[package]]
 name = "loopy"
 version = "2025.2"
-source = { git = "https://gitlab.tiker.net/inducer/loopy.git#fe8bdedf32202492b96acbfb394a81abfd4bf195" }
+source = { git = "https://github.com/inducer/loopy.git#682ad32b859ac562937beff905f74dff35534ab0" }
 dependencies = [
     { name = "cgen" },
     { name = "codepy" },
@@ -407,7 +407,7 @@ wheels = [
 [[package]]
 name = "meshmode"
 version = "2024.0"
-source = { git = "https://gitlab.tiker.net/inducer/meshmode.git#9c3142724fc5f57469855bd7d06ecc974b0262bd" }
+source = { git = "https://github.com/inducer/meshmode.git#fa2d5450a42468ef31b9b8f420e2514465ba7a5c" }
 dependencies = [
     { name = "arraycontext" },
     { name = "gmsh-interop" },
@@ -423,7 +423,7 @@ dependencies = [
 [[package]]
 name = "modepy"
 version = "2026.1"
-source = { git = "https://gitlab.tiker.net/inducer/modepy.git#cd824fbf761beb287275041b4968a730077837ec" }
+source = { git = "https://github.com/inducer/modepy.git#a0f44097f4f470c9107c60ef322512ecabda1174" }
 dependencies = [
     { name = "numpy" },
     { name = "optype" },
@@ -571,7 +571,7 @@ wheels = [
 [[package]]
 name = "pymbolic"
 version = "2025.1"
-source = { git = "https://gitlab.tiker.net/inducer/pymbolic.git#ae07a0f041094de88e1d7d89162e03171d2520e7" }
+source = { git = "https://github.com/inducer/pymbolic.git#3963dd2d0be04e3f06ce7b5d1151dff3955ff5aa" }
 dependencies = [
     { name = "constantdict" },
     { name = "pytools" },
@@ -628,7 +628,7 @@ wheels = [
 [[package]]
 name = "pytential"
 version = "2024.0"
-source = { git = "https://gitlab.tiker.net/inducer/pytential.git#fc413f1128fc0f310cd3af717d4a38da9e32c3c1" }
+source = { git = "https://github.com/inducer/pytential.git#09a0316b88ddb3fd75670089dc64411186740606" }
 dependencies = [
     { name = "arraycontext" },
     { name = "boxtree" },
@@ -641,6 +641,7 @@ dependencies = [
     { name = "pytools" },
     { name = "scipy" },
     { name = "sumpy" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]
@@ -661,8 +662,8 @@ wheels = [
 
 [[package]]
 name = "pytools"
-version = "2025.2.5"
-source = { git = "https://gitlab.tiker.net/inducer/pytools.git#f6395afe859f5dab7523b077ed2fd6ab68b5ef29" }
+version = "2026.1.1"
+source = { git = "https://github.com/inducer/pytools.git#295ffaebfacdb1ffb2a7ef85a0862f3ee0519c8f" }
 dependencies = [
     { name = "platformdirs" },
     { name = "siphash24" },
@@ -985,7 +986,7 @@ wheels = [
 [[package]]
 name = "sumpy"
 version = "2024.0"
-source = { git = "https://gitlab.tiker.net/inducer/sumpy.git#9b0e892f0fd932d0edf9fd017a89751cf1e654d4" }
+source = { git = "https://github.com/inducer/sumpy.git#83c5db03ba9266e8c2b24e5d3115142db6ca1be8" }
 dependencies = [
     { name = "arraycontext" },
     { name = "boxtree" },
@@ -1063,22 +1064,22 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arraycontext", git = "https://gitlab.tiker.net/inducer/arraycontext.git" },
-    { name = "boxtree", git = "https://gitlab.tiker.net/inducer/boxtree.git" },
+    { name = "arraycontext", git = "https://github.com/inducer/arraycontext.git" },
+    { name = "boxtree", git = "https://github.com/inducer/boxtree.git" },
     { name = "filelock", marker = "extra == 'test'" },
-    { name = "gmsh-interop", marker = "extra == 'gmsh-support'", git = "https://gitlab.tiker.net/inducer/gmsh_interop.git" },
-    { name = "gmsh-interop", marker = "extra == 'test'", git = "https://gitlab.tiker.net/inducer/gmsh_interop.git" },
-    { name = "loopy", git = "https://gitlab.tiker.net/inducer/loopy.git" },
-    { name = "meshmode", git = "https://gitlab.tiker.net/inducer/meshmode.git" },
-    { name = "modepy", git = "https://gitlab.tiker.net/inducer/modepy.git" },
-    { name = "pymbolic", git = "https://gitlab.tiker.net/inducer/pymbolic.git" },
+    { name = "gmsh-interop", marker = "extra == 'gmsh-support'", git = "https://github.com/inducer/gmsh_interop.git" },
+    { name = "gmsh-interop", marker = "extra == 'test'", git = "https://github.com/inducer/gmsh_interop.git" },
+    { name = "loopy", git = "https://github.com/inducer/loopy.git" },
+    { name = "meshmode", git = "https://github.com/inducer/meshmode.git" },
+    { name = "modepy", git = "https://github.com/inducer/modepy.git" },
+    { name = "pymbolic", git = "https://github.com/inducer/pymbolic.git" },
     { name = "pyopencl" },
-    { name = "pytential", git = "https://gitlab.tiker.net/inducer/pytential.git" },
+    { name = "pytential", git = "https://github.com/inducer/pytential.git" },
     { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytools", git = "https://gitlab.tiker.net/inducer/pytools.git" },
+    { name = "pytools", git = "https://github.com/inducer/pytools.git" },
     { name = "scipy" },
     { name = "sphinx", marker = "extra == 'doc'" },
     { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
-    { name = "sumpy", git = "https://gitlab.tiker.net/inducer/sumpy.git" },
+    { name = "sumpy", git = "https://github.com/inducer/sumpy.git" },
 ]
 provides-extras = ["gmsh-support", "test", "doc"]

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -332,6 +332,9 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
         ``mode == "canonical_single_table"`` means table level 0 is reused for
         all source-box levels with ``scaling_code`` and ``displacement_code``.
+        ``mode == "fixed_single_table"`` means table level 0 is used without
+        scaling and runtime checks require all source boxes to match the table
+        starting level.
         ``mode == "per_level_tables"`` means no kernel scaling is applied and
         the table level is selected from the source-box level.
         """
@@ -367,6 +370,22 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 ),
                 table_level_code="0.0",
                 notes="Uses user-provided scaling and displacement code with table level 0.",
+            )
+
+        if self.n_tables == 1:
+            return KernelScalingPolicy(
+                kernel_name=self.kname,
+                mode="fixed_single_table",
+                infer_kernel_scaling=False,
+                single_table_scaling_supported=False,
+                reference_table_level=0,
+                scaling_code="1.0",
+                displacement_code="0.0",
+                table_level_code="0.0",
+                notes=(
+                    "Uses the only cached table level without kernel scaling; "
+                    "runtime checks reject mixed source levels or a table level mismatch."
+                ),
             )
 
         return KernelScalingPolicy(

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -21,6 +21,8 @@ THE SOFTWARE.
 """
 
 __doc__ = """
+.. autoclass:: KernelScalingPolicy
+   :members:
 .. autoclass:: NearFieldEvalBase
    :members:
 .. autoclass:: NearFieldFromCSR
@@ -28,7 +30,7 @@ __doc__ = """
 """
 
 import logging
-from dataclasses import fields
+from dataclasses import dataclass, fields
 
 import numpy as np
 
@@ -42,6 +44,21 @@ logger = logging.getLogger(__name__)
 
 
 CASE_ENCODING_BIAS_DEFAULT = 1.0e-10
+
+
+@dataclass(frozen=True)
+class KernelScalingPolicy:
+    """Describes how a List 1 evaluator selects and rescales table data."""
+
+    kernel_name: str
+    mode: str
+    infer_kernel_scaling: bool
+    single_table_scaling_supported: bool
+    reference_table_level: int | None
+    scaling_code: str
+    displacement_code: str
+    table_level_code: str
+    notes: str
 
 
 def _array_layout_cache_token(ary, queue):
@@ -227,6 +244,148 @@ class NearFieldFromCSR(NearFieldEvalBase):
             or self._is_axis_source_derivative_of_laplace(3)
         )
 
+    def _inferred_scaling_code(self):
+        if self._is_axis_target_derivative_of_laplace(2):
+            logger.info("scaling for Grad(LapKnl2D)")
+            return "BOX_extent / table_root_extent"
+
+        if self._is_axis_target_derivative_of_laplace(3):
+            logger.info("scaling for Grad(LapKnl3D)")
+            return "BOX_extent / table_root_extent"
+
+        if self._is_axis_source_derivative_of_laplace(2):
+            logger.info("scaling for SourceGrad(LapKnl2D)")
+            return "BOX_extent / table_root_extent"
+
+        if self._is_axis_source_derivative_of_laplace(3):
+            logger.info("scaling for SourceGrad(LapKnl3D)")
+            return "BOX_extent / table_root_extent"
+
+        if self._is_laplace_kernel(2):
+            logger.info("scaling for LapKnl2D")
+            return "BOX_extent * BOX_extent / \
+                    (table_root_extent * table_root_extent)"
+
+        if self._is_constant_kernel(2):
+            logger.info("scaling for CstKnl2D")
+            return "BOX_extent * BOX_extent / \
+                    (table_root_extent * table_root_extent)"
+
+        if self._is_laplace_kernel(3):
+            logger.info("scaling for Lapknl3D")
+            return "BOX_extent * BOX_extent / \
+                    (table_root_extent * table_root_extent)"
+
+        if self._is_constant_kernel(3):
+            logger.info("scaling for CstKnl3D")
+            return "BOX_extent * BOX_extent * BOX_extent / \
+                    (table_root_extent * table_root_extent * table_root_extent)"
+
+        raise RuntimeError(f"no inferred scaling rule for {self.integral_kernel!r}")
+
+    def _inferred_displacement_code(self):
+        if self._is_axis_target_derivative_of_laplace(2):
+            logger.info("no displacement for Grad(LapKnl2D)")
+            return "0.0"
+
+        if self._is_axis_target_derivative_of_laplace(3):
+            logger.info("no displacement for Grad(LapKnl3D)")
+            return "0.0"
+
+        if self._is_axis_source_derivative_of_laplace(2):
+            logger.info("no displacement for SourceGrad(LapKnl2D)")
+            return "0.0"
+
+        if self._is_axis_source_derivative_of_laplace(3):
+            logger.info("no displacement for SourceGrad(LapKnl3D)")
+            return "0.0"
+
+        if self._is_laplace_kernel(2):
+            logger.info("displacement for laplace 2D")
+            s = "-0.5 / PI * scaling * \
+                    log(BOX_extent / table_root_extent) * \
+                    mode_nmlz[table_lev, sid]"
+            import math
+
+            return s.replace("PI", str(math.pi))
+
+        if self._is_constant_kernel(2):
+            logger.info("no displacement for CstKnl2D")
+            return "0.0"
+
+        if self._is_laplace_kernel(3):
+            logger.info("no displacement for LapKnl3D")
+            return "0.0"
+
+        if self._is_constant_kernel(3):
+            logger.info("no displacement for CstKnl3D")
+            return "0.0"
+
+        raise RuntimeError(f"no inferred displacement rule for {self.integral_kernel!r}")
+
+    def _inferred_table_level_code(self):
+        logger.info("scaling from table[0] for " + self.kname)
+        return "0.0"
+
+    def get_kernel_scaling_policy(self, box_name="sbox"):
+        """Return the table-level and scaling policy used by generated List 1 code.
+
+        ``mode == "canonical_single_table"`` means table level 0 is reused for
+        all source-box levels with ``scaling_code`` and ``displacement_code``.
+        ``mode == "per_level_tables"`` means no kernel scaling is applied and
+        the table level is selected from the source-box level.
+        """
+        if self.extra_kwargs.get("infer_kernel_scaling", False):
+            return KernelScalingPolicy(
+                kernel_name=self.kname,
+                mode="canonical_single_table",
+                infer_kernel_scaling=True,
+                single_table_scaling_supported=True,
+                reference_table_level=0,
+                scaling_code=self._inferred_scaling_code().replace("BOX", box_name),
+                displacement_code=self._inferred_displacement_code().replace(
+                    "BOX", box_name
+                ),
+                table_level_code=self._inferred_table_level_code().replace(
+                    "BOX", box_name
+                ),
+                notes="Uses table level 0 for all source-box levels with inferred exact scaling.",
+            )
+
+        if "kernel_scaling_code" in self.extra_kwargs:
+            return KernelScalingPolicy(
+                kernel_name=self.kname,
+                mode="custom_single_table",
+                infer_kernel_scaling=False,
+                single_table_scaling_supported=True,
+                reference_table_level=0,
+                scaling_code=self.extra_kwargs["kernel_scaling_code"].replace(
+                    "BOX", box_name
+                ),
+                displacement_code=self.extra_kwargs["kernel_displacement_code"].replace(
+                    "BOX", box_name
+                ),
+                table_level_code="0.0",
+                notes="Uses user-provided scaling and displacement code with table level 0.",
+            )
+
+        return KernelScalingPolicy(
+            kernel_name=self.kname,
+            mode="per_level_tables",
+            infer_kernel_scaling=False,
+            single_table_scaling_supported=False,
+            reference_table_level=None,
+            scaling_code="1.0",
+            displacement_code="0.0",
+            table_level_code=(
+                "(0 if BOX_level < table_starting_level "
+                "else (BOX_level - table_starting_level "
+                "if BOX_level - table_starting_level < n_tables "
+                "else n_tables - 1))"
+            ).replace("BOX", box_name),
+            notes="Selects one cached table level per source-box level without kernel scaling.",
+        )
+
     def codegen_vec_component(self, d=None):
         if d is None:
             dimension = self.dim - 1
@@ -330,60 +489,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
     def codegen_compute_scaling(self, box_name="sbox"):
         """box_name: the name of the box whose extent is used."""
-        if ("infer_kernel_scaling" in self.extra_kwargs) and (
-            self.extra_kwargs["infer_kernel_scaling"]
-        ):
-            if self._is_axis_target_derivative_of_laplace(2):
-                logger.info("scaling for Grad(LapKnl2D)")
-                code = "BOX_extent / table_root_extent"
-
-            elif self._is_axis_target_derivative_of_laplace(3):
-                logger.info("scaling for Grad(LapKnl3D)")
-                code = "BOX_extent / table_root_extent"
-
-            elif self._is_axis_source_derivative_of_laplace(2):
-                logger.info("scaling for SourceGrad(LapKnl2D)")
-                code = "BOX_extent / table_root_extent"
-
-            elif self._is_axis_source_derivative_of_laplace(3):
-                logger.info("scaling for SourceGrad(LapKnl3D)")
-                code = "BOX_extent / table_root_extent"
-
-            # Laplace 2D
-            elif self._is_laplace_kernel(2):
-                logger.info("scaling for LapKnl2D")
-                code = "BOX_extent * BOX_extent / \
-                        (table_root_extent * table_root_extent)"
-
-            # Constant 2D
-            elif self._is_constant_kernel(2):
-                logger.info("scaling for CstKnl2D")
-                code = "BOX_extent * BOX_extent / \
-                        (table_root_extent * table_root_extent)"
-
-            # Laplace 3D
-            elif self._is_laplace_kernel(3):
-                logger.info("scaling for Lapknl3D")
-                code = "BOX_extent * BOX_extent / \
-                        (table_root_extent * table_root_extent)"
-
-            # Constant 3D
-            elif self._is_constant_kernel(3):
-                logger.info("scaling for CstKnl3D")
-                code = "BOX_extent * BOX_extent * BOX_extent / \
-                        (table_root_extent * table_root_extent * table_root_extent)"
-
-            else:
-                logger.warning(
-                    "Kernel not scalable and not using multiple tables, "
-                    "to get correct results, please make sure that your "
-                    "tree is uniform and only needs one table."
-                )
-                code = "1.0"
-
-            return code.replace("BOX", box_name)
-
-        elif "kernel_scaling_code" in self.extra_kwargs:
+        if "kernel_scaling_code" in self.extra_kwargs:
             # user-defined scaling rule
             assert isinstance(self.extra_kwargs["kernel_scaling_code"], str)
             logger.info(
@@ -391,63 +497,16 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 self.extra_kwargs["kernel_scaling_code"],
                 self.kname,
             )
-            return self.extra_kwargs["kernel_scaling_code"].replace("BOX", box_name)
-        else:
+            return self.get_kernel_scaling_policy(box_name=box_name).scaling_code
+
+        if not self.extra_kwargs.get("infer_kernel_scaling", False):
             logger.info("not scaling for " + self.kname)
             logger.info("(using multiple tables)")
-            return "1.0"
+
+        return self.get_kernel_scaling_policy(box_name=box_name).scaling_code
 
     def codegen_compute_displacement(self, box_name="sbox"):
-        if ("infer_kernel_scaling" in self.extra_kwargs) and (
-            self.extra_kwargs["infer_kernel_scaling"]
-        ):
-            if self._is_axis_target_derivative_of_laplace(2):
-                logger.info("no displacement for Grad(LapKnl2D)")
-                code = "0.0"
-
-            elif self._is_axis_target_derivative_of_laplace(3):
-                logger.info("no displacement for Grad(LapKnl3D)")
-                code = "0.0"
-
-            elif self._is_axis_source_derivative_of_laplace(2):
-                logger.info("no displacement for SourceGrad(LapKnl2D)")
-                code = "0.0"
-
-            elif self._is_axis_source_derivative_of_laplace(3):
-                logger.info("no displacement for SourceGrad(LapKnl3D)")
-                code = "0.0"
-
-            # Laplace 2D
-            elif self._is_laplace_kernel(2):
-                logger.info("displacement for laplace 2D")
-                s = "-0.5 / PI * scaling * \
-                        log(BOX_extent / table_root_extent) * \
-                        mode_nmlz[table_lev, sid]"
-                import math
-
-                code = s.replace("PI", str(math.pi))
-
-            # Constant 2D
-            elif self._is_constant_kernel(2):
-                logger.info("no displacement for CstKnl2D")
-                code = "0.0"
-            # Laplace 3D
-            elif self._is_laplace_kernel(3):
-                logger.info("no displacement for LapKnl3D")
-                code = "0.0"
-            # Constant 3D
-            elif self._is_constant_kernel(3):
-                logger.info("no displacement for CstKnl3D")
-                code = "0.0"
-            else:
-                logger.warning(
-                    "Kernel not scalable and not using multiple tables, "
-                    "to get correct results, please make sure that either "
-                    "no displacement is needed, or the box "
-                    "tree is uniform and only needs one table."
-                )
-                code = "0.0"
-        elif "kernel_displacement_code" in self.extra_kwargs:
+        if "kernel_displacement_code" in self.extra_kwargs:
             # user-defined displacement rule
             assert isinstance(self.extra_kwargs["kernel_displacement_code"], str)
             logger.info(
@@ -455,53 +514,24 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 self.extra_kwargs["kernel_displacement_code"],
                 self.kname,
             )
-            code = self.extra_kwargs["kernel_displacement_code"].replace(
-                "BOX", box_name
-            )
-        else:
+            return self.get_kernel_scaling_policy(box_name=box_name).displacement_code
+
+        if not self.extra_kwargs.get("infer_kernel_scaling", False):
             logger.info("no displacement for " + self.kname)
             logger.info("(using multiple tables)")
-            code = "0.0"
 
-        return code.replace("BOX", box_name)
+        return self.get_kernel_scaling_policy(box_name=box_name).displacement_code
 
     def codegen_get_table_level(self, box_name="sbox"):
-        if ("infer_kernel_scaling" in self.extra_kwargs) and (
-            self.extra_kwargs["infer_kernel_scaling"]
-        ):
-            if (
-                self._is_laplace_kernel(2)
-                or self._is_laplace_kernel(3)
-                or self._is_constant_kernel(2)
-                or self._is_constant_kernel(3)
-                or self._is_axis_target_derivative_of_laplace(2)
-                or self._is_axis_target_derivative_of_laplace(3)
-                or self._is_axis_source_derivative_of_laplace(2)
-                or self._is_axis_source_derivative_of_laplace(3)
-            ):
-                logger.info("scaling from table[0] for " + self.kname)
-                code = "0.0"
-            else:
-                logger.warning(
-                    "Kernel not scalable and not using multiple tables, "
-                    "to get correct results, please make sure that your "
-                    "tree is uniform and only needs one table."
-                )
-                code = "0.0"
-        elif "kernel_scaling_code" in self.extra_kwargs:
+        if "kernel_scaling_code" in self.extra_kwargs:
             # Using custom scaling
-            code = "0.0"
-        else:
+            return self.get_kernel_scaling_policy(box_name=box_name).table_level_code
+
+        if not self.extra_kwargs.get("infer_kernel_scaling", False):
             logger.info("computing table level from box size")
             logger.info("(using multiple tables)")
-            code = (
-                "(0 if BOX_level < table_starting_level "
-                "else (BOX_level - table_starting_level "
-                "if BOX_level - table_starting_level < n_tables "
-                "else n_tables - 1))"
-            )
 
-        return code.replace("BOX", box_name)
+        return self.get_kernel_scaling_policy(box_name=box_name).table_level_code
 
     def codegen_exterior_part(self):
         """Computes the exterior contribution. This is nonzero for


### PR DESCRIPTION
## Summary
- Add immutable `KernelScalingPolicy` metadata for `NearFieldFromCSR`.
- Expose canonical single-table, custom single-table, and per-level table selection policies.
- Route scaling, displacement, and table-level code generation through the same policy source.
- Add focused tests covering policy metadata, unsupported inferred Helmholtz scaling, and policy/codegen equivalence.

## Paper 1 Linkage
Supports xywei/boxcode-paper#6 by making canonical-vs-per-level List 1 table behavior and scaling metadata introspectable in the implementation.

## Verification
- `python -m py_compile volumential/list1.py`
- `python -m py_compile test/test_volume_fmm.py`

Full pytest was not run locally because this session environment does not have `sumpy` installed.