### PR TITLE
Add symmetry reduction diagnostics

### DIFF
--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -552,6 +552,105 @@ def test_online_symmetry_maps_match_orbit_canonical_signs(
         assert np.isclose(mapped_sign, canonical_sign)
 
 
+def _symmetry_diagnostic_test_table(kernel_case):
+    from sumpy.kernel import (
+        AxisSourceDerivative,
+        AxisTargetDerivative,
+        DirectionalSourceDerivative,
+        LaplaceKernel,
+    )
+
+    symmetry_source_direction = None
+    kernel_type = "const"
+    kernel_func = npt.constant_one
+    sumpy_kernel = ConstantKernel(2)
+
+    if kernel_case == "target-derivative":
+        kernel_type = "inv_power"
+        sumpy_kernel = AxisTargetDerivative(0, LaplaceKernel(2))
+    elif kernel_case == "source-derivative":
+        kernel_type = "inv_power"
+        sumpy_kernel = AxisSourceDerivative(1, LaplaceKernel(2))
+    elif kernel_case == "directional-source":
+        kernel_type = "inv_power"
+        sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(2), "dir_vec")
+        symmetry_source_direction = np.array([1.0, 0.0])
+    elif kernel_case == "mixed-source-target":
+        kernel_type = "inv_power"
+        sumpy_kernel = AxisTargetDerivative(
+            0,
+            AxisSourceDerivative(1, LaplaceKernel(2)),
+        )
+    elif kernel_case != "scalar":
+        raise ValueError(f"unknown kernel_case {kernel_case!r}")
+
+    q1d = np.linspace(0.25, 0.75, 3)
+    precomputed_q_points = np.array(
+        [(x, y) for x in q1d for y in q1d],
+        dtype=np.float64,
+    )
+
+    return npt.NearFieldInteractionTable(
+        quad_order=3,
+        dim=2,
+        build_method="DuffyRadial",
+        kernel_func=kernel_func,
+        kernel_type=kernel_type,
+        sumpy_kernel=sumpy_kernel,
+        derive_kernel_func=False,
+        symmetry_source_direction=symmetry_source_direction,
+        precomputed_q_points=precomputed_q_points,
+        progress_bar=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel_case",
+    [
+        "scalar",
+        "target-derivative",
+        "source-derivative",
+        "directional-source",
+        "mixed-source-target",
+    ],
+)
+def test_symmetry_diagnostics_reconstruct_full_table(kernel_case):
+    table = _symmetry_diagnostic_test_table(kernel_case)
+    orbit_info = table._get_orbit_canonical_info()
+    entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+    canonical_entry_ids = np.asarray(orbit_info["canonical_entry_ids"], dtype=np.int64)
+    canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=table.dtype)
+
+    rng = np.random.default_rng(seed=101)
+    reference_data = np.empty(len(table.data), dtype=table.dtype)
+    reference_data.fill(np.nan)
+    reference_data[entry_ids] = rng.normal(size=len(entry_ids))
+    reference_data[:] = canonical_scales * reference_data[canonical_entry_ids]
+
+    reconstructed = table.reconstruct_full_table_from_symmetry(reference_data)
+    np.testing.assert_allclose(reconstructed, reference_data, rtol=0.0, atol=0.0)
+
+    diagnostics = table.get_symmetry_reduction_diagnostics(reference_data)
+    assert diagnostics.full_entry_count == len(table.data)
+    assert diagnostics.representative_count == len(entry_ids)
+    assert diagnostics.compression_ratio > 1.0
+    assert diagnostics.reconstructed_payload_bytes < diagnostics.unreduced_payload_bytes
+    assert diagnostics.metadata_payload_bytes > 0
+    assert sum(
+        orbit_size * count
+        for orbit_size, count in diagnostics.orbit_size_histogram
+    ) == len(table.data)
+    assert diagnostics.max_reconstruction_error == 0.0
+    assert diagnostics.l2_reconstruction_error == 0.0
+
+    if kernel_case == "scalar":
+        assert diagnostics.negative_scale_count == 0
+        assert diagnostics.sign_metadata_count == 0
+    else:
+        assert diagnostics.negative_scale_count > 0
+        assert diagnostics.sign_metadata_count >= diagnostics.negative_scale_count
+
+
 def test_duffy_radial_routes_queue_to_batched_builder(monkeypatch):
     table = npt.NearFieldInteractionTable(
         quad_order=2,

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -552,7 +552,7 @@ def test_online_symmetry_maps_match_orbit_canonical_signs(
         assert np.isclose(mapped_sign, canonical_sign)
 
 
-def _symmetry_diagnostic_test_table(kernel_case):
+def _symmetry_diagnostic_test_table(kernel_case, dtype=np.float64):
     from sumpy.kernel import (
         AxisSourceDerivative,
         AxisTargetDerivative,
@@ -600,6 +600,7 @@ def _symmetry_diagnostic_test_table(kernel_case):
         derive_kernel_func=False,
         symmetry_source_direction=symmetry_source_direction,
         precomputed_q_points=precomputed_q_points,
+        dtype=dtype,
         progress_bar=False,
     )
 
@@ -649,6 +650,27 @@ def test_symmetry_diagnostics_reconstruct_full_table(kernel_case):
     else:
         assert diagnostics.negative_scale_count > 0
         assert diagnostics.sign_metadata_count >= diagnostics.negative_scale_count
+
+
+def test_symmetry_diagnostics_count_signs_for_complex_tables():
+    table = _symmetry_diagnostic_test_table(
+        "target-derivative",
+        dtype=np.complex128,
+    )
+    orbit_info = table._get_orbit_canonical_info()
+    entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+    canonical_entry_ids = np.asarray(orbit_info["canonical_entry_ids"], dtype=np.int64)
+    canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=table.dtype)
+
+    reference_data = np.empty(len(table.data), dtype=table.dtype)
+    reference_data.fill(np.nan + 1j * np.nan)
+    reference_data[entry_ids] = np.arange(1, len(entry_ids) + 1) * (1.0 + 2.0j)
+    reference_data[:] = canonical_scales * reference_data[canonical_entry_ids]
+
+    diagnostics = table.get_symmetry_reduction_diagnostics(reference_data)
+    assert diagnostics.negative_scale_count > 0
+    assert diagnostics.sign_metadata_count >= diagnostics.negative_scale_count
+    assert diagnostics.max_reconstruction_error == 0.0
 
 
 def test_duffy_radial_routes_queue_to_batched_builder(monkeypatch):

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -198,6 +198,21 @@ class DuffyBuildConfig:
     auto_tune_candidates: object = None
 
 
+@dataclass(frozen=True)
+class SymmetryReductionDiagnostics:
+    full_entry_count: int
+    representative_count: int
+    compression_ratio: float
+    orbit_size_histogram: tuple
+    sign_metadata_count: int
+    negative_scale_count: int
+    unreduced_payload_bytes: int
+    reconstructed_payload_bytes: int
+    metadata_payload_bytes: int
+    max_reconstruction_error: object = None
+    l2_reconstruction_error: object = None
+
+
 def _self_tp(vec, tpd=2):
     """
     Self tensor product
@@ -1065,6 +1080,84 @@ class NearFieldInteractionTable:
 
     def _get_invariant_entry_info(self):
         return self._get_orbit_canonical_info()
+
+    def reconstruct_full_table_from_symmetry(self, canonical_data=None):
+        """Reconstruct full table data from orbit-canonical representatives."""
+        orbit_info = self._get_orbit_canonical_info()
+        canonical_entry_ids = np.asarray(orbit_info["canonical_entry_ids"], dtype=np.int64)
+        canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=self.dtype)
+
+        if canonical_data is None:
+            canonical_data = self.data
+        canonical_data = np.asarray(canonical_data, dtype=self.dtype)
+
+        if canonical_data.shape[0] != len(self.data):
+            raise ValueError(
+                "canonical_data must be indexed by full table entry ids; "
+                f"expected length {len(self.data)}, got {canonical_data.shape[0]}"
+            )
+
+        return canonical_scales * canonical_data[canonical_entry_ids]
+
+    def get_symmetry_reduction_diagnostics(self, reference_data=None):
+        """Return paper-facing symmetry-reduction counts and reconstruction errors."""
+        orbit_info = self._get_orbit_canonical_info()
+        entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+        canonical_entry_ids = np.asarray(orbit_info["canonical_entry_ids"], dtype=np.int64)
+        canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=self.dtype)
+
+        full_entry_count = int(len(canonical_entry_ids))
+        representative_count = int(len(entry_ids))
+        unique_ids, orbit_sizes = np.unique(canonical_entry_ids, return_counts=True)
+        del unique_ids
+        size_values, size_counts = np.unique(orbit_sizes, return_counts=True)
+        orbit_size_histogram = tuple(
+            (int(size), int(count))
+            for size, count in zip(size_values.tolist(), size_counts.tolist())
+        )
+
+        scale_differs = ~np.isclose(canonical_scales, self.dtype(1))
+        sign_metadata_count = int(np.count_nonzero(scale_differs))
+        negative_scale_count = int(np.count_nonzero(canonical_scales < 0))
+
+        unreduced_payload_bytes = int(full_entry_count * np.dtype(self.dtype).itemsize)
+        reconstructed_payload_bytes = int(
+            representative_count * np.dtype(self.dtype).itemsize
+        )
+        metadata_payload_bytes = int(canonical_entry_ids.nbytes + canonical_scales.nbytes)
+
+        max_reconstruction_error = None
+        l2_reconstruction_error = None
+        if reference_data is None:
+            reference_data = self.data
+        reference_data = np.asarray(reference_data, dtype=self.dtype)
+        if reference_data.shape[0] != full_entry_count:
+            raise ValueError(
+                "reference_data must be indexed by full table entry ids; "
+                f"expected length {full_entry_count}, got {reference_data.shape[0]}"
+            )
+
+        if np.all(np.isfinite(reference_data[canonical_entry_ids])) and np.all(
+            np.isfinite(reference_data)
+        ):
+            reconstructed = self.reconstruct_full_table_from_symmetry(reference_data)
+            errors = np.abs(reconstructed - reference_data)
+            max_reconstruction_error = float(np.max(errors))
+            l2_reconstruction_error = float(np.linalg.norm(errors))
+
+        return SymmetryReductionDiagnostics(
+            full_entry_count=full_entry_count,
+            representative_count=representative_count,
+            compression_ratio=float(full_entry_count / representative_count),
+            orbit_size_histogram=orbit_size_histogram,
+            sign_metadata_count=sign_metadata_count,
+            negative_scale_count=negative_scale_count,
+            unreduced_payload_bytes=unreduced_payload_bytes,
+            reconstructed_payload_bytes=reconstructed_payload_bytes,
+            metadata_payload_bytes=metadata_payload_bytes,
+            max_reconstruction_error=max_reconstruction_error,
+            l2_reconstruction_error=l2_reconstruction_error,
+        )
 
     @memoize_method
     def _get_case_target_points(self):

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1105,6 +1105,7 @@ class NearFieldInteractionTable:
         entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
         canonical_entry_ids = np.asarray(orbit_info["canonical_entry_ids"], dtype=np.int64)
         canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=self.dtype)
+        canonical_scale_signs = np.real(canonical_scales).astype(np.float64)
 
         full_entry_count = int(len(canonical_entry_ids))
         representative_count = int(len(entry_ids))
@@ -1116,9 +1117,9 @@ class NearFieldInteractionTable:
             for size, count in zip(size_values.tolist(), size_counts.tolist())
         )
 
-        scale_differs = ~np.isclose(canonical_scales, self.dtype(1))
+        scale_differs = ~np.isclose(canonical_scale_signs, 1.0)
         sign_metadata_count = int(np.count_nonzero(scale_differs))
-        negative_scale_count = int(np.count_nonzero(canonical_scales < 0))
+        negative_scale_count = int(np.count_nonzero(canonical_scale_signs < 0))
 
         unreduced_payload_bytes = int(full_entry_count * np.dtype(self.dtype).itemsize)
         reconstructed_payload_bytes = int(


### PR DESCRIPTION
## Summary
- Add `SymmetryReductionDiagnostics` for paper-facing orbit reduction counts.
- Add `reconstruct_full_table_from_symmetry()` to rebuild full table data from canonical representatives and signs.
- Add `get_symmetry_reduction_diagnostics()` with entry counts, compression ratio, orbit-size histogram, sign metadata counts, payload bytes, and reconstruction errors.
- Add direct reconstruction tests for scalar, target derivative, source derivative, directional source derivative, and mixed source/target derivative kernels.

## Paper 1 Linkage
Supports xywei/boxcode-paper#7 by making symmetry-reduction diagnostics and full-table reconstruction checks available from the implementation.

## Verification
- `python -m py_compile volumential/nearfield_potential_table.py test/test_nearfield_potential_table.py`
- Direct invocation of `test_symmetry_diagnostics_reconstruct_full_table` for all new parameter cases in a disposable uv dependency environment.

Local pytest collection is not used here because this machine has no OpenCL platform; the new tests avoid OpenCL table construction and CI will run the normal suite with its portable OpenCL context.