### PR TITLE
Add Helmholtz split cache accounting

### DIFF
--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -249,6 +249,72 @@ def test_autobuild_split_source_levels_uses_base_table_levels():
     assert inferred_levels == [-1]
 
 
+def test_helmholtz_split_cache_accounting_separates_parameter_count():
+    from volumential.expansion_wrangler_fpnd import FPNDExpansionWrangler
+
+    def table(data, reduced=False):
+        return SimpleNamespace(
+            data=np.asarray(data, dtype=np.float64),
+            table_data_is_symmetry_reduced=reduced,
+        )
+
+    wrangler = FPNDExpansionWrangler.__new__(FPNDExpansionWrangler)
+    wrangler.helmholtz_split = True
+    wrangler.helmholtz_split_order = 3
+    wrangler.near_field_table = {
+        "LaplaceKernel(2)": [
+            table([1.0, 2.0, 3.0]),
+            table([4.0, np.nan, 6.0], reduced=True),
+        ],
+    }
+    wrangler.helmholtz_split_term_tables = {
+        ("power_log", 2): [table([7.0, 8.0])],
+        ("power_log", 4): [table([9.0, np.nan, 11.0], reduced=True)],
+    }
+
+    one_parameter = wrangler.get_helmholtz_split_cache_accounting(parameter_count=1)
+    three_parameters = wrangler.get_helmholtz_split_cache_accounting(
+        parameter_count=[2.0, 4.0, 8.0]
+    )
+
+    assert one_parameter.split_enabled
+    assert one_parameter.split_order == 3
+    assert one_parameter.base_table_count == 2
+    assert one_parameter.split_term_table_count == 2
+    assert one_parameter.basis_table_count == 4
+    assert one_parameter.split_term_keys == (("power_log", 2), ("power_log", 4))
+    assert one_parameter.uses_online_coefficients
+    assert one_parameter.uses_online_remainder
+    assert one_parameter.base_table_payload_bytes == 5 * np.dtype(np.float64).itemsize
+    assert one_parameter.split_term_table_payload_bytes == (
+        4 * np.dtype(np.float64).itemsize
+    )
+    assert one_parameter.total_table_payload_bytes == (
+        one_parameter.base_table_payload_bytes
+        + one_parameter.split_term_table_payload_bytes
+    )
+
+    assert three_parameters.parameter_count == 3
+    assert three_parameters.basis_table_count == one_parameter.basis_table_count
+    assert (
+        three_parameters.total_table_payload_bytes
+        == one_parameter.total_table_payload_bytes
+    )
+
+
+def test_helmholtz_split_cache_accounting_rejects_empty_parameter_sweep():
+    from volumential.expansion_wrangler_fpnd import FPNDExpansionWrangler
+
+    wrangler = FPNDExpansionWrangler.__new__(FPNDExpansionWrangler)
+    wrangler.helmholtz_split = True
+    wrangler.helmholtz_split_order = 1
+    wrangler.near_field_table = {}
+    wrangler.helmholtz_split_term_tables = {}
+
+    with pytest.raises(ValueError, match="parameter_count must be >= 1"):
+        wrangler.get_helmholtz_split_cache_accounting(parameter_count=0)
+
+
 def test_rebuild_tob_from_geometry_restores_unit_level_edges():
     from boxtree import make_tree_of_boxes_root, refine_and_coarsen_tree_of_boxes
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -25,6 +25,7 @@ import logging
 import hashlib
 import math
 from collections import OrderedDict
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -55,6 +56,29 @@ from volumential.nearfield_potential_table import NearFieldInteractionTable
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HelmholtzSplitCacheAccounting:
+    split_enabled: bool
+    split_order: int
+    parameter_count: int
+    base_table_count: int
+    split_term_table_count: int
+    basis_table_count: int
+    base_table_payload_bytes: int
+    split_term_table_payload_bytes: int
+    total_table_payload_bytes: int
+    split_term_keys: tuple
+    uses_online_coefficients: bool
+    uses_online_remainder: bool
+
+
+def _nearfield_table_payload_bytes(table):
+    data = np.asarray(table.data)
+    if bool(getattr(table, "table_data_is_symmetry_reduced", False)):
+        return int(np.count_nonzero(np.isfinite(data)) * data.dtype.itemsize)
+    return int(data.nbytes)
 
 
 def _table_data_fingerprint(arr, sample_bytes=4096):
@@ -1579,6 +1603,58 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         self._nearfield_device_payload_cache_max = 16
 
     # }}} End constructor
+
+    def get_helmholtz_split_cache_accounting(self, parameter_count=1):
+        """Return table-storage accounting for Helmholtz/Yukawa split mode."""
+        if not isinstance(parameter_count, int):
+            try:
+                parameter_count = len(parameter_count)
+            except TypeError as exc:
+                raise TypeError(
+                    "parameter_count must be an integer or a sized parameter collection"
+                ) from exc
+        parameter_count = int(parameter_count)
+        if parameter_count < 1:
+            raise ValueError("parameter_count must be >= 1")
+
+        base_tables = [
+            table
+            for tables in self.near_field_table.values()
+            for table in tables
+        ]
+        split_term_items = sorted(
+            self.helmholtz_split_term_tables.items(),
+            key=lambda item: _format_helmholtz_split_term_key(item[0]),
+        )
+        split_term_tables = [
+            table
+            for _, tables in split_term_items
+            for table in tables
+        ]
+
+        base_table_payload_bytes = sum(
+            _nearfield_table_payload_bytes(table) for table in base_tables
+        )
+        split_term_table_payload_bytes = sum(
+            _nearfield_table_payload_bytes(table) for table in split_term_tables
+        )
+
+        return HelmholtzSplitCacheAccounting(
+            split_enabled=bool(self.helmholtz_split),
+            split_order=int(self.helmholtz_split_order),
+            parameter_count=parameter_count,
+            base_table_count=len(base_tables),
+            split_term_table_count=len(split_term_tables),
+            basis_table_count=len(base_tables) + len(split_term_tables),
+            base_table_payload_bytes=int(base_table_payload_bytes),
+            split_term_table_payload_bytes=int(split_term_table_payload_bytes),
+            total_table_payload_bytes=int(
+                base_table_payload_bytes + split_term_table_payload_bytes
+            ),
+            split_term_keys=tuple(key for key, _ in split_term_items),
+            uses_online_coefficients=bool(self.helmholtz_split and split_term_tables),
+            uses_online_remainder=bool(self.helmholtz_split),
+        )
 
     # {{{ data vector utilities
 


### PR DESCRIPTION
## Summary
- Add `HelmholtzSplitCacheAccounting` for split-kernel evidence reporting.
- Report split order, parameter count, base-table count, split-term table count, basis-table count, table payload bytes, split-term keys, and online coefficient/remainder flags.
- Add lightweight tests proving table storage remains fixed while parameter sweep size changes.

## Paper 1 Linkage
Supports xywei/boxcode-paper#9 by separating split-basis table storage from parameter sweep size and exposing cache accounting for Helmholtz/Yukawa split evidence.

## Verification
- `python -m py_compile volumential/expansion_wrangler_fpnd.py test/test_volume_fmm.py`
- Direct invocation of the new split-accounting tests in a disposable uv dependency environment.

Local full pytest is not used because this machine has no OpenCL platform; CI runs the normal suite with its portable OpenCL context.