### PR TITLE
fix: report live sqlite cache bytes

### DIFF
--- a/benchmarks/table_equivalence_cache.py
+++ b/benchmarks/table_equivalence_cache.py
@@ -159,6 +159,12 @@ def _timing_value(timings: dict[str, Any], group: str, key: str) -> float | int 
     return subgroup.get(key)
 
 
+def _sqlite_database_bytes(connection) -> int:
+    page_count = int(connection.execute("PRAGMA page_count").fetchone()[0])
+    page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+    return page_count * page_size
+
+
 def _full_table_data(table) -> np.ndarray:
     if getattr(table, "table_data_is_symmetry_reduced", False):
         return np.asarray(table.reconstruct_full_table_from_symmetry(), dtype=table.dtype)
@@ -220,7 +226,7 @@ def _cache_row(
     is_recomputed: bool,
     timings: dict[str, Any],
     table,
-    cache_path: Path,
+    cache_bytes: int,
 ) -> dict[str, Any]:
     diagnostics = table.get_symmetry_reduction_diagnostics()
     timing_group = "compute" if cache_state == "cold" else "load"
@@ -251,7 +257,7 @@ def _cache_row(
         ),
         "kwargs_load_s": _as_float(_timing_value(timings, "load", "kwargs_load_s")),
         "payload_bytes": payload_bytes,
-        "cache_bytes": cache_path.stat().st_size if cache_path.exists() else 0,
+        "cache_bytes": cache_bytes,
         **asdict(diagnostics),
     }
 
@@ -315,7 +321,7 @@ def run_benchmark(*, mode: str, cache_dir: Path):
                             is_recomputed=is_recomputed,
                             timings=dict(tm.last_get_table_timings),
                             table=table,
-                            cache_path=cache_path,
+                            cache_bytes=_sqlite_database_bytes(tm.datafile),
                         )
                     )
 
@@ -350,7 +356,7 @@ def run_benchmark(*, mode: str, cache_dir: Path):
                             is_recomputed=is_recomputed,
                             timings=dict(tm.last_get_table_timings),
                             table=table,
-                            cache_path=cache_path,
+                            cache_bytes=_sqlite_database_bytes(tm.datafile),
                         )
                     )
 


### PR DESCRIPTION
Closes #93.

Supports xywei/boxcode-paper#11.

## Summary
- report SQLite cache size from live database page count and page size
- avoid stale `Path.stat()` readings while the table-manager connection is open

## Validation
- `rtk python -m py_compile benchmarks/table_equivalence_cache.py`
- `rtk uvx ruff check --select E9,F63,F7,F82 benchmarks/table_equivalence_cache.py`
