### PR TITLE
fix: restore accuracy benchmark source normalization

### DIFF
--- a/benchmarks/accuracy_preservation.py
+++ b/benchmarks/accuracy_preservation.py
@@ -109,10 +109,9 @@ def _build_manufactured_problem(dim):
     g2 = expp(-alpha_2 * r2_sq)
 
     solution_expr = g1 + coeff_2 * g2
-    source_expr = (
-        (2 * dim * alpha_1 - 4 * alpha_1**2 * r1_sq) * g1
-        + coeff_2 * (2 * dim * alpha_2 - 4 * alpha_2**2 * r2_sq) * g2
-    ) / (4.0 * np.pi)
+    source_expr = (2 * dim * alpha_1 - 4 * alpha_1**2 * r1_sq) * g1 + coeff_2 * (
+        2 * dim * alpha_2 - 4 * alpha_2**2 * r2_sq
+    ) * g2
 
     return source_expr, solution_expr, [x, y, z]
 


### PR DESCRIPTION
## Summary
- remove the extra 1/(4*pi) factor from the accuracy benchmark manufactured source
- keep the direct P2P path labeled as a diagnostic rather than the table reference

## Validation
- python -m py_compile benchmarks/accuracy_preservation.py
- uvx ruff check --select E9,F63,F7,F82 benchmarks/accuracy_preservation.py
- follow-up ipa smoke/full benchmark planned before paper import

Supports Paper 1 issue #12.