### PR TITLE
bench: add performance suite driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,5 +166,7 @@ jobs:
           python benchmarks/table_equivalence_cache.py --mode smoke
           python benchmarks/accuracy_preservation.py --mode smoke
           python benchmarks/adaptive_timing.py --mode smoke
+          python benchmarks/performance_suite.py --list-cases
+          python benchmarks/performance_suite.py --mode smoke --dry-run
 
 # vim: sw=2

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,7 +25,9 @@ without executing benchmarks, `--backend <auto|pocl-cpu|cuda-gpu>` to preserve
 device selection for benchmark scripts that expose a backend option, and
 `--list-cases` to inspect the registered cases without importing
 OpenCL-dependent benchmark modules. The manifest is written even when a case
-fails, so partial controlled runs remain auditable.
+fails, so partial controlled runs remain auditable. The suite passes each case
+an output-local cache directory under `<out-dir>/<case>/cache`, keeping table
+caches with the promoted run artifacts instead of relying on script defaults.
 
 ## Table Equivalence And Cache Economics
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,8 +21,11 @@ python benchmarks/performance_suite.py --mode full --out-dir /path/to/raw-runs/p
 The suite currently covers canonical table equivalence/cache economics,
 accuracy preservation, split-parameter coverage, and adaptive timing. Use
 `--case <name>` to run a subset, `--dry-run` to emit the command manifest
-without executing benchmarks, and `--list-cases` to inspect the registered
-cases without importing OpenCL-dependent benchmark modules.
+without executing benchmarks, `--backend <auto|pocl-cpu|cuda-gpu>` to preserve
+device selection for benchmark scripts that expose a backend option, and
+`--list-cases` to inspect the registered cases without importing
+OpenCL-dependent benchmark modules. The manifest is written even when a case
+fails, so partial controlled runs remain auditable.
 
 ## Table Equivalence And Cache Economics
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,6 +2,28 @@
 
 These scripts emit reproducible CSV artifacts for manuscript evidence. Keep smoke modes lightweight enough for CI/local checks and reserve full sweeps for controlled machines such as `ipa`.
 
+## Performance Suite Driver
+
+Use the suite driver to run the maintained benchmark set with a shared output
+layout and JSON command manifest:
+
+```bash
+python benchmarks/performance_suite.py --mode smoke --out-dir build/benchmarks/performance-suite
+```
+
+For full runs, execute on a controlled machine such as `ipa` and wrap the suite
+with the paper repository metadata tool before promoting results:
+
+```bash
+python benchmarks/performance_suite.py --mode full --out-dir /path/to/raw-runs/performance-suite
+```
+
+The suite currently covers canonical table equivalence/cache economics,
+accuracy preservation, split-parameter coverage, and adaptive timing. Use
+`--case <name>` to run a subset, `--dry-run` to emit the command manifest
+without executing benchmarks, and `--list-cases` to inspect the registered
+cases without importing OpenCL-dependent benchmark modules.
+
 ## Table Equivalence And Cache Economics
 
 ```bash

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -67,6 +67,10 @@ def _case_output_arg(case: SuiteCase, case_dir: Path) -> list[str]:
     return ["--out", str(case_dir / case.output_name)]
 
 
+def _case_cache_arg(case_dir: Path) -> list[str]:
+    return ["--cache-dir", str(case_dir / "cache")]
+
+
 def _run_case(
     case: SuiteCase, *, mode: str, backend: str, out_dir: Path, dry_run: bool
 ) -> dict[str, object]:
@@ -78,6 +82,7 @@ def _run_case(
         "--mode",
         mode,
         *_case_output_arg(case, case_dir),
+        *_case_cache_arg(case_dir),
     ]
     if case.accepts_backend:
         command.extend(["--backend", backend])

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -25,6 +25,7 @@ class SuiteCase:
     description: str
     script: str
     output_name: str | None
+    accepts_backend: bool = False
 
 
 SUITE_CASES = (
@@ -45,14 +46,19 @@ SUITE_CASES = (
         description="Helmholtz/Yukawa split-order and parameter coverage",
         script="benchmarks/split_parameter_sweep.py",
         output_name="split_parameter_sweep.csv",
+        accepts_backend=True,
     ),
     SuiteCase(
         name="adaptive-timing",
         description="adaptive-tree geometry, table build/load, and FMM wall time",
         script="benchmarks/adaptive_timing.py",
         output_name="adaptive_timing.csv",
+        accepts_backend=True,
     ),
 )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _case_output_arg(case: SuiteCase, case_dir: Path) -> list[str]:
@@ -61,15 +67,27 @@ def _case_output_arg(case: SuiteCase, case_dir: Path) -> list[str]:
     return ["--out", str(case_dir / case.output_name)]
 
 
-def _run_case(case: SuiteCase, *, mode: str, out_dir: Path, dry_run: bool) -> dict[str, object]:
+def _run_case(
+    case: SuiteCase, *, mode: str, backend: str, out_dir: Path, dry_run: bool
+) -> dict[str, object]:
     case_dir = out_dir / case.name
-    command = [sys.executable, case.script, "--mode", mode, *_case_output_arg(case, case_dir)]
+    script_path = REPO_ROOT / case.script
+    command = [
+        sys.executable,
+        str(script_path),
+        "--mode",
+        mode,
+        *_case_output_arg(case, case_dir),
+    ]
+    if case.accepts_backend:
+        command.extend(["--backend", backend])
 
     record: dict[str, object] = {
         "name": case.name,
         "description": case.description,
         "mode": mode,
         "command": command,
+        "backend": backend if case.accepts_backend else None,
         "out_dir": str(case_dir),
         "dry_run": dry_run,
     }
@@ -79,11 +97,9 @@ def _run_case(case: SuiteCase, *, mode: str, out_dir: Path, dry_run: bool) -> di
 
     case_dir.mkdir(parents=True, exist_ok=True)
     start = time.perf_counter()
-    completed = subprocess.run(command, check=False)
+    completed = subprocess.run(command, check=False, cwd=REPO_ROOT)
     record["elapsed_s"] = time.perf_counter() - start
     record["returncode"] = completed.returncode
-    if completed.returncode != 0:
-        raise SystemExit(completed.returncode)
     return record
 
 
@@ -95,6 +111,12 @@ def _write_manifest(records: list[dict[str, object]], manifest_path: Path) -> No
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "pocl-cpu", "cuda-gpu"),
+        default="auto",
+        help="OpenCL backend for suite cases that expose --backend",
+    )
     parser.add_argument("--out-dir", type=Path, default=Path("build/benchmarks/performance-suite"))
     parser.add_argument("--case", choices=[case.name for case in SUITE_CASES], action="append")
     parser.add_argument("--manifest", type=Path, default=None)
@@ -113,12 +135,22 @@ def main() -> None:
         return
 
     records = [
-        _run_case(case, mode=args.mode, out_dir=args.out_dir, dry_run=args.dry_run)
+        _run_case(
+            case,
+            mode=args.mode,
+            backend=args.backend,
+            out_dir=args.out_dir,
+            dry_run=args.dry_run,
+        )
         for case in selected
     ]
     manifest_path = args.manifest or (args.out_dir / "manifest.json")
     _write_manifest(records, manifest_path)
     print(f"wrote {manifest_path}")
+
+    failures = [record for record in records if record.get("returncode") not in (None, 0)]
+    if failures:
+        raise SystemExit(int(failures[0]["returncode"]))
 
 
 if __name__ == "__main__":

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run the maintained performance benchmark suite.
+
+This wrapper standardizes the benchmark commands used for scaling, cache,
+parameter, and adaptive timing evidence. Smoke mode is intended for quick local
+or CI checks. Full mode is intended for controlled machines such as ``ipa`` and
+should be wrapped by the paper repository's metadata capture tool when results
+are promoted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SuiteCase:
+    name: str
+    description: str
+    script: str
+    output_name: str | None
+
+
+SUITE_CASES = (
+    SuiteCase(
+        name="table-equivalence-cache",
+        description="canonical table scaling, cold build, warm load, payload size",
+        script="benchmarks/table_equivalence_cache.py",
+        output_name=None,
+    ),
+    SuiteCase(
+        name="accuracy-preservation",
+        description="FMM output preservation for canonical rescaled tables",
+        script="benchmarks/accuracy_preservation.py",
+        output_name="accuracy_preservation.csv",
+    ),
+    SuiteCase(
+        name="split-parameter-sweep",
+        description="Helmholtz/Yukawa split-order and parameter coverage",
+        script="benchmarks/split_parameter_sweep.py",
+        output_name="split_parameter_sweep.csv",
+    ),
+    SuiteCase(
+        name="adaptive-timing",
+        description="adaptive-tree geometry, table build/load, and FMM wall time",
+        script="benchmarks/adaptive_timing.py",
+        output_name="adaptive_timing.csv",
+    ),
+)
+
+
+def _case_output_arg(case: SuiteCase, case_dir: Path) -> list[str]:
+    if case.output_name is None:
+        return ["--out-dir", str(case_dir)]
+    return ["--out", str(case_dir / case.output_name)]
+
+
+def _run_case(case: SuiteCase, *, mode: str, out_dir: Path, dry_run: bool) -> dict[str, object]:
+    case_dir = out_dir / case.name
+    command = [sys.executable, case.script, "--mode", mode, *_case_output_arg(case, case_dir)]
+
+    record: dict[str, object] = {
+        "name": case.name,
+        "description": case.description,
+        "mode": mode,
+        "command": command,
+        "out_dir": str(case_dir),
+        "dry_run": dry_run,
+    }
+
+    if dry_run:
+        return record
+
+    case_dir.mkdir(parents=True, exist_ok=True)
+    start = time.perf_counter()
+    completed = subprocess.run(command, check=False)
+    record["elapsed_s"] = time.perf_counter() - start
+    record["returncode"] = completed.returncode
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+    return record
+
+
+def _write_manifest(records: list[dict[str, object]], manifest_path: Path) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps({"cases": records}, indent=2, sort_keys=True) + "\n")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
+    parser.add_argument("--out-dir", type=Path, default=Path("build/benchmarks/performance-suite"))
+    parser.add_argument("--case", choices=[case.name for case in SUITE_CASES], action="append")
+    parser.add_argument("--manifest", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true", help="write commands without running cases")
+    parser.add_argument("--list-cases", action="store_true", help="print suite cases and exit")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    selected = [case for case in SUITE_CASES if args.case is None or case.name in args.case]
+    if args.list_cases:
+        for case in selected:
+            print(f"{case.name}: {case.description}")
+        return
+
+    records = [
+        _run_case(case, mode=args.mode, out_dir=args.out_dir, dry_run=args.dry_run)
+        for case in selected
+    ]
+    manifest_path = args.manifest or (args.out_dir / "manifest.json")
+    _write_manifest(records, manifest_path)
+    print(f"wrote {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -134,17 +134,19 @@ def main() -> None:
             print(f"{case.name}: {case.description}")
         return
 
+    out_dir = args.out_dir.resolve()
+    manifest_path = args.manifest.resolve() if args.manifest is not None else out_dir / "manifest.json"
+
     records = [
         _run_case(
             case,
             mode=args.mode,
             backend=args.backend,
-            out_dir=args.out_dir,
+            out_dir=out_dir,
             dry_run=args.dry_run,
         )
         for case in selected
     ]
-    manifest_path = args.manifest or (args.out_dir / "manifest.json")
     _write_manifest(records, manifest_path)
     print(f"wrote {manifest_path}")
 


### PR DESCRIPTION
## Summary

- Add `benchmarks/performance_suite.py` to orchestrate the maintained performance benchmark set with a shared output layout and JSON manifest.
- Document smoke/full suite usage, subsets, dry-run mode, and `ipa`/metadata guidance.
- Add CI smoke checks for suite registration and dry-run behavior without running heavy benchmarks.

## Verification

- `python benchmarks/performance_suite.py --list-cases`
- `python benchmarks/performance_suite.py --mode smoke --dry-run --out-dir /tmp/opencode/volumential-performance-suite-dryrun`
- `rtk git diff --check`

Addresses part of #66.