### PR TITLE
test: audit mixed derivative split policy

### DIFF
--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -3721,6 +3721,55 @@ def test_source_kernel_derivation_preserves_source_derivatives():
     assert source_knl_no_source_deriv == base_knl
 
 
+def test_helmholtz_split_policy_rejects_mixed_source_target_derivative_chain():
+    from sumpy.kernel import (
+        AxisSourceDerivative,
+        AxisTargetDerivative,
+        DirectionalSourceDerivative,
+        HelmholtzKernel,
+    )
+
+    from volumential.expansion_wrangler_fpnd import FPNDExpansionWrangler
+
+    base_knl = HelmholtzKernel(2)
+    for out_knl in (
+        AxisTargetDerivative(0, AxisSourceDerivative(1, base_knl)),
+        AxisTargetDerivative(0, DirectionalSourceDerivative(base_knl, "dir_vec")),
+    ):
+        wrangler = FPNDExpansionWrangler.__new__(FPNDExpansionWrangler)
+        wrangler.tree_indep = SimpleNamespace(target_kernels=[out_knl])
+
+        supported, reason = wrangler._split_target_kernel_support_status()
+
+        assert not supported
+        assert "mixed source/target derivative wrapper chains" in reason
+
+
+def test_helmholtz_split_policy_accepts_single_source_or_target_derivative_chain():
+    from sumpy.kernel import (
+        AxisSourceDerivative,
+        AxisTargetDerivative,
+        DirectionalSourceDerivative,
+        HelmholtzKernel,
+    )
+
+    from volumential.expansion_wrangler_fpnd import FPNDExpansionWrangler
+
+    base_knl = HelmholtzKernel(2)
+
+    for out_knl in (
+        AxisTargetDerivative(0, base_knl),
+        AxisSourceDerivative(1, base_knl),
+        DirectionalSourceDerivative(base_knl, "dir_vec"),
+    ):
+        wrangler = FPNDExpansionWrangler.__new__(FPNDExpansionWrangler)
+        wrangler.tree_indep = SimpleNamespace(target_kernels=[out_knl])
+
+        supported, reason = wrangler._split_target_kernel_support_status()
+
+        assert supported, reason
+
+
 def test_volume_fmm_3d_laplace_source_target_derivative_antisymmetry(tmp_path):
     from sumpy.expansion import DefaultExpansionFactory
     from sumpy.kernel import AxisSourceDerivative, AxisTargetDerivative, LaplaceKernel

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1217,11 +1217,17 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         if self.helmholtz_split:
             split_supported, split_reason = self._split_target_kernel_support_status()
             if not split_supported:
-                logger.info(
-                    "[split:disable] unsupported target kernels: %s",
-                    split_reason,
-                )
-                self.helmholtz_split = False
+                if helmholtz_split is None:
+                    logger.info(
+                        "[split:disable] unsupported target kernels: %s",
+                        split_reason,
+                    )
+                    self.helmholtz_split = False
+                else:
+                    raise RuntimeError(
+                        "helmholtz_split does not support the requested target "
+                        f"kernels; {split_reason}"
+                    )
 
         if self.helmholtz_split:
             base_table_supported, base_table_reason = (
@@ -2463,6 +2469,14 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         return "__" + "__".join(parts)
 
     @staticmethod
+    def _helmholtz_split_wrapper_chain_has_mixed_source_target(wrappers):
+        has_target = any(kind == "axis_target" for kind, _value in wrappers)
+        has_source = any(
+            kind in ("axis_source", "directional_source") for kind, _value in wrappers
+        )
+        return has_target and has_source
+
+    @staticmethod
     def _apply_helmholtz_split_kernel_wrappers_with_chain(kernel, wrapper_chain):
         wrapped = kernel
         for kind, value in reversed(wrapper_chain):
@@ -2558,9 +2572,21 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 return False, f"unsupported dimension {base_knl.dim}"
 
             try:
-                self._extract_helmholtz_split_kernel_wrapper_chain(out_knl, base_knl)
+                wrapper_chain = self._extract_helmholtz_split_kernel_wrapper_chain(
+                    out_knl,
+                    base_knl,
+                )
             except NotImplementedError as exc:
                 return False, str(exc)
+
+            if self._helmholtz_split_wrapper_chain_has_mixed_source_target(
+                wrapper_chain
+            ):
+                return (
+                    False,
+                    "mixed source/target derivative wrapper chains are unsupported "
+                    "in split mode without a dedicated regression test and scaling rule",
+                )
 
             param_name = self._split_wave_number_parameter_name(base_knl)
             if not isinstance(param_name, str) or not param_name:


### PR DESCRIPTION
## Summary

- reject mixed source/target derivative wrapper chains in Helmholtz/Yukawa split-mode support checks unless that exact chain has dedicated validation
- make explicit `helmholtz_split=True` fail instead of silently disabling when target kernels are unsupported
- add dependency-light policy tests for mixed-chain rejection and single source/target/directional acceptance

Refs #71.

## Testing

- `rtk python -m py_compile volumential/expansion_wrangler_fpnd.py test/test_volume_fmm.py`
- `rtk git diff --check`

Local pytest collection is blocked in this fresh checkout because `sumpy` is not installed; GitHub CI should run the dependency-complete test suite.