### PR TITLE
feat(dmk): prototype compact local table split

### DIFF
--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -165,7 +165,40 @@ def test_laplace2d_heat_split_reaches_high_accuracy_with_smooth_remainder():
     assert high_smooth_order["abs_error"] < 1.0e-6 * low_smooth_order["abs_error"]
 
 
-def test_laplace2d_heat_split_rejects_boundary_intersecting_tail():
+def test_laplace2d_heat_split_shrinks_boundary_tail_to_tolerance():
+    q_order = 5
+    mode_index = 12
+    target_index = 0
+    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = dmk.tensor_gauss_point(q_order, target_index)
+    requested = dmk.HeatKernelConfig(sigma=0.06)
+
+    result = dmk.laplace2d_heat_split_integral(
+        coeffs,
+        target=target,
+        config=requested,
+        expansion_order=8,
+        smooth_order=48,
+    )
+
+    assert result.support_relation == "tail-contained"
+    assert result.effective_sigma < requested.sigma
+    boundary_distance = min(target[0], 1.0 - target[0], target[1], 1.0 - target[1])
+    effective = dmk.HeatKernelConfig(sigma=result.effective_sigma)
+    assert (
+        dmk.laplace2d_heat_local_kernel_radius(boundary_distance, effective)
+        <= requested.boundary_kernel_tol
+    )
+    assert (
+        dmk.laplace2d_heat_tail_integral_bound(
+            boundary_distance,
+            result.effective_sigma,
+        )
+        <= requested.boundary_truncation_tol
+    )
+
+
+def test_laplace2d_heat_split_rejects_boundary_tail_without_shrinkage():
     q_order = 5
     mode_index = 12
     target_index = 0
@@ -176,7 +209,7 @@ def test_laplace2d_heat_split_rejects_boundary_intersecting_tail():
         dmk.laplace2d_heat_split_integral(
             coeffs,
             target=target,
-            config=dmk.HeatKernelConfig(sigma=0.06),
+            config=dmk.HeatKernelConfig(sigma=0.06, shrink_to_boundary=False),
             expansion_order=8,
             smooth_order=48,
         )

--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -79,14 +79,14 @@ def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
     low_expansion = next(
         row
         for row in rows
-        if row["sigma"] == 0.35
+        if np.isclose(row["sigma"], 0.35)
         and row["expansion_order"] == 2
         and row["smooth_order"] == 220
     )
     high_expansion = next(
         row
         for row in rows
-        if row["sigma"] == 0.35
+        if np.isclose(row["sigma"], 0.35)
         and row["expansion_order"] == 8
         and row["smooth_order"] == 220
     )
@@ -97,7 +97,7 @@ def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
     low_smooth_order = next(
         row
         for row in rows
-        if row["sigma"] == 0.35
+        if np.isclose(row["sigma"], 0.35)
         and row["expansion_order"] == 8
         and row["smooth_order"] == 64
     )

--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -58,6 +58,26 @@ def test_compact_window_support_avoids_gauss_node_boundary_intersection():
     ) == "outside"
 
 
+def test_heat_kernel_split_recombines_laplace_kernel_off_target():
+    config = dmk.HeatKernelConfig(sigma=0.06)
+    radii = np.array([0.01, 0.05, 0.2, 1.0])
+
+    local = dmk.laplace2d_heat_local_kernel_radius(radii, config)
+    smooth = dmk.laplace2d_heat_smooth_kernel(radii, np.zeros_like(radii), config)
+
+    np.testing.assert_allclose(
+        local + smooth,
+        dmk.laplace2d_kernel_radius(radii),
+        rtol=1.0e-14,
+        atol=1.0e-14,
+    )
+    assert np.isfinite(dmk.laplace2d_heat_smooth_kernel(0.0, 0.0, config))
+    assert np.isclose(
+        dmk.laplace2d_heat_local_moment(0, 0, config),
+        config.sigma**2 / 4.0,
+    )
+
+
 def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
     q_order = 5
     mode_index = 12
@@ -102,6 +122,32 @@ def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
         and row["smooth_order"] == 64
     )
     assert high_expansion["abs_error"] < 1.0e-3 * low_smooth_order["abs_error"]
+
+
+def test_laplace2d_heat_split_reaches_high_accuracy_with_smooth_remainder():
+    q_order = 5
+    mode_index = 12
+    target_index = 12
+    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = dmk.tensor_gauss_point(q_order, target_index)
+    reference = _duffy_reference_laplace2d(coeffs, target)
+
+    rows = dmk.sweep_laplace2d_heat_split(
+        q_order=q_order,
+        mode_index=mode_index,
+        target_index=target_index,
+        sigmas=[0.06],
+        expansion_orders=[8],
+        smooth_orders=[24, 48],
+        reference_value=reference,
+    )
+
+    low_smooth_order = next(row for row in rows if row["smooth_order"] == 24)
+    high_smooth_order = next(row for row in rows if row["smooth_order"] == 48)
+
+    assert high_smooth_order["support_relation"] == "heat-tail"
+    assert high_smooth_order["abs_error"] < 1.0e-12
+    assert high_smooth_order["abs_error"] < 1.0e-6 * low_smooth_order["abs_error"]
 
 
 def test_laplace2d_dmk_like_split_rejects_intersecting_local_support():

--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -61,6 +61,9 @@ def test_compact_window_support_avoids_gauss_node_boundary_intersection():
 def test_heat_kernel_split_recombines_laplace_kernel_off_target():
     config = dmk.HeatKernelConfig(sigma=0.06)
     radii = np.array([0.01, 0.05, 0.2, 1.0])
+    expected_target_value = (dmk.EULER_GAMMA - 2.0 * np.log(config.sigma)) / (
+        4.0 * np.pi
+    )
 
     local = dmk.laplace2d_heat_local_kernel_radius(radii, config)
     smooth = dmk.laplace2d_heat_smooth_kernel(radii, np.zeros_like(radii), config)
@@ -71,11 +74,23 @@ def test_heat_kernel_split_recombines_laplace_kernel_off_target():
         rtol=1.0e-14,
         atol=1.0e-14,
     )
-    assert np.isfinite(dmk.laplace2d_heat_smooth_kernel(0.0, 0.0, config))
+    assert np.isclose(
+        dmk.laplace2d_heat_smooth_kernel(0.0, 0.0, config),
+        expected_target_value,
+    )
     assert np.isclose(
         dmk.laplace2d_heat_local_moment(0, 0, config),
         config.sigma**2 / 4.0,
     )
+
+
+def test_window_order_validation_rejects_fractional_smoothness():
+    try:
+        dmk.CompactWindowConfig(sigma=0.1, smoothness_order=4.9)
+    except ValueError as exc:
+        assert "smoothness_order must be an integer" in str(exc)
+    else:
+        raise AssertionError("fractional smoothness order should fail validation")
 
 
 def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
@@ -145,9 +160,30 @@ def test_laplace2d_heat_split_reaches_high_accuracy_with_smooth_remainder():
     low_smooth_order = next(row for row in rows if row["smooth_order"] == 24)
     high_smooth_order = next(row for row in rows if row["smooth_order"] == 48)
 
-    assert high_smooth_order["support_relation"] == "heat-tail"
+    assert high_smooth_order["support_relation"] == "tail-contained"
     assert high_smooth_order["abs_error"] < 1.0e-12
     assert high_smooth_order["abs_error"] < 1.0e-6 * low_smooth_order["abs_error"]
+
+
+def test_laplace2d_heat_split_rejects_boundary_intersecting_tail():
+    q_order = 5
+    mode_index = 12
+    target_index = 0
+    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = dmk.tensor_gauss_point(q_order, target_index)
+
+    try:
+        dmk.laplace2d_heat_split_integral(
+            coeffs,
+            target=target,
+            config=dmk.HeatKernelConfig(sigma=0.06),
+            expansion_order=8,
+            smooth_order=48,
+        )
+    except ValueError as exc:
+        assert "heat-local tail intersects" in str(exc)
+    else:
+        raise AssertionError("boundary-intersecting heat tail should be rejected")
 
 
 def test_laplace2d_dmk_like_split_rejects_intersecting_local_support():

--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -127,3 +127,24 @@ def test_laplace2d_dmk_like_split_rejects_intersecting_local_support():
         assert "compact support intersects" in str(exc)
     else:
         raise AssertionError("intersecting compact support should be rejected")
+
+
+def test_laplace2d_dmk_like_split_sweep_does_not_hide_invalid_orders():
+    q_order = 5
+    mode_index = 12
+    target_index = 12
+
+    try:
+        dmk.sweep_laplace2d_dmk_split(
+            q_order=q_order,
+            mode_index=mode_index,
+            target_index=target_index,
+            sigmas=[0.35],
+            expansion_orders=[8],
+            smooth_orders=[0],
+            reference_value=0.0,
+        )
+    except ValueError as exc:
+        assert "order must be >= 1" in str(exc)
+    else:
+        raise AssertionError("invalid smooth order should not be reported as support")

--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -1,0 +1,129 @@
+import numpy as np
+
+from volumential import dmk_split as dmk
+from volumential import singular_integral_2d as sint
+
+
+def _safe_laplace2d_table_integrand(coeffs, target):
+    def integrand(x, y):
+        r = np.sqrt((x - target[0]) ** 2 + (y - target[1]) ** 2)
+        density = dmk.evaluate_polynomial_2d(coeffs, x, y)
+
+        if np.isscalar(r):
+            if r == 0:
+                return 0.0
+            return density * dmk.laplace2d_kernel_radius(r)
+
+        result = np.zeros_like(r, dtype=np.float64)
+        mask = r > 0
+        result[mask] = density[mask] * dmk.laplace2d_kernel_radius(r[mask])
+        return result
+
+    return integrand
+
+
+def _duffy_reference_laplace2d(coeffs, target):
+    value, _ = sint.box_quad_duffy_radial(
+        _safe_laplace2d_table_integrand(coeffs, target),
+        0,
+        1,
+        0,
+        1,
+        target,
+        radial_rule="tanh-sinh-fast",
+        deg_theta=80,
+        radial_quad_order=181,
+    )
+    return value
+
+
+def test_compact_window_support_avoids_gauss_node_boundary_intersection():
+    q_order = 5
+    target = dmk.tensor_gauss_point(q_order, 0)
+    spacing = dmk.minimum_boundary_spacing(q_order)
+
+    assert dmk.support_relation_to_box(
+        target,
+        dmk.CompactWindowConfig(sigma=0.99 * spacing),
+    ) == "inside"
+
+    assert dmk.support_relation_to_box(
+        target,
+        dmk.CompactWindowConfig(sigma=1.01 * spacing),
+    ) == "intersects"
+
+    assert dmk.support_relation_to_box(
+        (-0.1, 0.5),
+        dmk.CompactWindowConfig(sigma=0.05),
+    ) == "outside"
+
+
+def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
+    q_order = 5
+    mode_index = 12
+    target_index = 12
+    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = dmk.tensor_gauss_point(q_order, target_index)
+    reference = _duffy_reference_laplace2d(coeffs, target)
+
+    rows = dmk.sweep_laplace2d_dmk_split(
+        q_order=q_order,
+        mode_index=mode_index,
+        target_index=target_index,
+        sigmas=[0.15, 0.25, 0.35],
+        expansion_orders=[2, 4, 6, 8],
+        smooth_orders=[64, 96, 160, 220],
+        reference_value=reference,
+    )
+
+    low_expansion = next(
+        row
+        for row in rows
+        if row["sigma"] == 0.35
+        and row["expansion_order"] == 2
+        and row["smooth_order"] == 220
+    )
+    high_expansion = next(
+        row
+        for row in rows
+        if row["sigma"] == 0.35
+        and row["expansion_order"] == 8
+        and row["smooth_order"] == 220
+    )
+    assert high_expansion["support_relation"] == "inside"
+    assert high_expansion["abs_error"] < 1.0e-11
+    assert high_expansion["abs_error"] < 1.0e-8 * low_expansion["abs_error"]
+
+    low_smooth_order = next(
+        row
+        for row in rows
+        if row["sigma"] == 0.35
+        and row["expansion_order"] == 8
+        and row["smooth_order"] == 64
+    )
+    assert high_expansion["abs_error"] < 1.0e-3 * low_smooth_order["abs_error"]
+
+
+def test_laplace2d_dmk_like_split_rejects_intersecting_local_support():
+    q_order = 5
+    mode_index = 12
+    target_index = 0
+    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = dmk.tensor_gauss_point(q_order, target_index)
+
+    config = dmk.CompactWindowConfig(
+        sigma=1.1 * dmk.minimum_boundary_spacing(q_order),
+    )
+
+    try:
+        dmk.laplace2d_dmk_split_integral(
+            coeffs,
+            target=target,
+            config=config,
+            expansion_order=8,
+            smooth_order=64,
+        )
+    except ValueError as exc:
+        assert "compact support intersects" in str(exc)
+    else:
+        raise AssertionError("intersecting compact support should be rejected")

--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -148,3 +148,51 @@ def test_laplace2d_dmk_like_split_sweep_does_not_hide_invalid_orders():
         assert "order must be >= 1" in str(exc)
     else:
         raise AssertionError("invalid smooth order should not be reported as support")
+
+
+def test_laplace2d_dmk_like_split_sweep_rejects_invalid_expansion_order():
+    try:
+        dmk.sweep_laplace2d_dmk_split(
+            q_order=5,
+            mode_index=12,
+            target_index=12,
+            sigmas=[0.35],
+            expansion_orders=[-1],
+            smooth_orders=[64],
+            reference_value=0.0,
+        )
+    except ValueError as exc:
+        assert "expansion_order must be >= 0" in str(exc)
+    else:
+        raise AssertionError("invalid expansion order should fail validation")
+
+
+def test_gauss_legendre_rule_rejects_fractional_order():
+    try:
+        dmk.gauss_legendre_rule(64.9)
+    except ValueError as exc:
+        assert "order must be an integer" in str(exc)
+    else:
+        raise AssertionError("fractional quadrature order should fail validation")
+
+
+def test_laplace2d_dmk_like_split_sweep_materializes_generator_inputs():
+    rows = dmk.sweep_laplace2d_dmk_split(
+        q_order=3,
+        mode_index=4,
+        target_index=4,
+        sigmas=(sigma for sigma in [0.1, 0.2]),
+        expansion_orders=(order for order in [0, 2]),
+        smooth_orders=(order for order in [6, 8]),
+        reference_value=0.0,
+    )
+
+    assert {
+        (row["sigma"], row["expansion_order"], row["smooth_order"])
+        for row in rows
+    } == {
+        (sigma, expansion_order, smooth_order)
+        for sigma in [0.1, 0.2]
+        for expansion_order in [0, 2]
+        for smooth_order in [6, 8]
+    }

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -37,9 +37,13 @@ not wired into the production table manager yet.
 """
 
 from dataclasses import dataclass
-from math import comb, lgamma, log, pi
+from math import comb, exp, lgamma, log, pi
 
 import numpy as np
+from scipy import special as sps
+
+
+EULER_GAMMA = 0.5772156649015329
 
 
 @dataclass(frozen=True)
@@ -69,6 +73,22 @@ class CompactWindowConfig:
                 "smoothness_order must be nonnegative, "
                 f"got {self.smoothness_order!r}"
             )
+
+
+@dataclass(frozen=True)
+class HeatKernelConfig:
+    """Heat-kernel smoothing scale for the 2D Laplace split.
+
+    This uses the Gaussian-smoothed Green's function.  In 3D this corresponds to
+    the familiar ``erf(r/sigma)/r`` smooth part; for 2D Laplace the local residual
+    is ``E1((r/sigma)**2)/(4*pi)``.
+    """
+
+    sigma: float
+
+    def __post_init__(self):
+        if not np.isfinite(self.sigma) or self.sigma <= 0:
+            raise ValueError(f"sigma must be positive and finite, got {self.sigma!r}")
 
 
 @dataclass(frozen=True)
@@ -288,6 +308,49 @@ def laplace2d_smooth_kernel(dx, dy, config):
     return result
 
 
+def laplace2d_heat_local_kernel_radius(r, config):
+    """Heat-kernel local residual for 2D Laplace.
+
+    The residual is ``E1((r/sigma)**2)/(4*pi)``.  It has the same logarithmic
+    singularity as the original Green's function but decays exponentially away
+    from the target.
+    """
+
+    r_arr = np.asarray(r, dtype=np.float64)
+    z = (r_arr / config.sigma) ** 2
+    result = sps.exp1(z) / (4.0 * pi)
+    if np.isscalar(r):
+        return float(result)
+    return result
+
+
+def laplace2d_heat_smooth_kernel(dx, dy, config):
+    """Gaussian-smoothed 2D Laplace Green's function.
+
+    This is ``G(r) - E1((r/sigma)**2)/(4*pi)`` and has the finite target value
+    ``(EulerGamma - 2*log(sigma))/(4*pi)``.
+    """
+
+    r = np.sqrt(np.asarray(dx) ** 2 + np.asarray(dy) ** 2)
+    result = np.empty(np.shape(r), dtype=np.float64)
+    zero = r == 0
+    if np.any(~zero):
+        rr = r[~zero] if np.ndim(r) else r
+        vals = laplace2d_kernel_radius(rr) - laplace2d_heat_local_kernel_radius(
+            rr,
+            config,
+        )
+        if np.ndim(r):
+            result[~zero] = vals
+        else:
+            result = np.asarray(vals, dtype=np.float64)
+    if np.any(zero):
+        result[zero] = (EULER_GAMMA - 2.0 * log(config.sigma)) / (4.0 * pi)
+    if np.isscalar(dx) and np.isscalar(dy):
+        return float(result)
+    return result
+
+
 def support_relation_to_box(
     target,
     config,
@@ -374,6 +437,23 @@ def laplace2d_local_moment(mx, my, config):
     return angular * radial
 
 
+def laplace2d_heat_local_moment(mx, my, config):
+    """Full-space moment of the heat-kernel local residual."""
+
+    angular = _angular_moment(mx, my)
+    if angular == 0.0:
+        return 0.0
+
+    total_degree = mx + my
+    sigma_power = config.sigma ** (total_degree + 2)
+    radial = (
+        sigma_power
+        * exp(lgamma(0.5 * total_degree + 1.0))
+        / (8.0 * pi * (0.5 * total_degree + 1.0))
+    )
+    return angular * radial
+
+
 def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
     """Evaluate the local compact singular contribution by Taylor moments."""
 
@@ -398,6 +478,30 @@ def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
     return float(total)
 
 
+def laplace2d_heat_local_expansion_integral(coeffs, target, expansion_order, config):
+    """Evaluate the heat-local contribution by full-space Taylor moments."""
+
+    expansion_order = _validate_integer_order(
+        expansion_order,
+        "expansion_order",
+        minimum=0,
+    )
+    shifted = shifted_polynomial_coefficients(
+        coeffs,
+        center=target,
+        max_total_order=expansion_order,
+    )
+    total = 0.0
+    for mx in range(shifted.shape[0]):
+        for my in range(shifted.shape[1]):
+            if mx + my > expansion_order:
+                continue
+            coeff = shifted[mx, my]
+            if coeff != 0:
+                total += coeff * laplace2d_heat_local_moment(mx, my, config)
+    return float(total)
+
+
 def laplace2d_smooth_gauss_integral(
     coeffs,
     target,
@@ -410,6 +514,21 @@ def laplace2d_smooth_gauss_integral(
     xx, yy, weights = gauss_legendre_tensor_points(smooth_order, bounds=bounds)
     density = evaluate_polynomial_2d(coeffs, xx, yy)
     kernel = laplace2d_smooth_kernel(xx - target[0], yy - target[1], config)
+    return float(np.dot(weights, density * kernel))
+
+
+def laplace2d_heat_smooth_gauss_integral(
+    coeffs,
+    target,
+    config,
+    smooth_order,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
+    """Evaluate the heat-smoothed contribution by tensor-product Gauss."""
+
+    xx, yy, weights = gauss_legendre_tensor_points(smooth_order, bounds=bounds)
+    density = evaluate_polynomial_2d(coeffs, xx, yy)
+    kernel = laplace2d_heat_smooth_kernel(xx - target[0], yy - target[1], config)
     return float(np.dot(weights, density * kernel))
 
 
@@ -459,6 +578,49 @@ def laplace2d_dmk_split_integral(
         local_value=local_value,
         smooth_value=smooth_value,
         support_relation=relation,
+    )
+
+
+def laplace2d_heat_split_integral(
+    coeffs,
+    target,
+    config,
+    expansion_order,
+    smooth_order,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
+    """Evaluate one 2D Laplace table entry by a heat-kernel split.
+
+    The local part uses full-space Taylor moments of the exponentially decaying
+    residual.  For finite boxes this is most accurate when ``sigma`` is small
+    compared with the target's distance to the source-box boundary.
+    """
+
+    expansion_order = _validate_integer_order(
+        expansion_order,
+        "expansion_order",
+        minimum=0,
+    )
+    smooth_order = _validate_integer_order(smooth_order, "smooth_order", minimum=1)
+
+    local_value = laplace2d_heat_local_expansion_integral(
+        coeffs,
+        target=target,
+        expansion_order=expansion_order,
+        config=config,
+    )
+    smooth_value = laplace2d_heat_smooth_gauss_integral(
+        coeffs,
+        target=target,
+        config=config,
+        smooth_order=smooth_order,
+        bounds=bounds,
+    )
+    return Laplace2DDMKSplitResult(
+        value=local_value + smooth_value,
+        local_value=local_value,
+        smooth_value=smooth_value,
+        support_relation="heat-tail",
     )
 
 
@@ -547,6 +709,58 @@ def sweep_laplace2d_dmk_split(
                             "error_message": str(exc),
                         }
                     )
+
+    return rows
+
+
+def sweep_laplace2d_heat_split(
+    q_order,
+    mode_index,
+    target_index,
+    sigmas,
+    expansion_orders,
+    smooth_orders,
+    reference_value,
+):
+    """Sweep heat-kernel split parameters for one 2D Laplace table entry."""
+
+    coeffs = tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = tensor_gauss_point(q_order, target_index)
+    sigmas = tuple(sigmas)
+    expansion_orders = tuple(
+        _validate_integer_order(order, "expansion_order", minimum=0)
+        for order in expansion_orders
+    )
+    smooth_orders = tuple(
+        _validate_integer_order(order, "smooth_order", minimum=1)
+        for order in smooth_orders
+    )
+    rows = []
+
+    for sigma in sigmas:
+        config = HeatKernelConfig(sigma=float(sigma))
+        for expansion_order in expansion_orders:
+            for smooth_order in smooth_orders:
+                result = laplace2d_heat_split_integral(
+                    coeffs,
+                    target=target,
+                    config=config,
+                    expansion_order=expansion_order,
+                    smooth_order=smooth_order,
+                )
+                error = abs(result.value - reference_value)
+                rows.append(
+                    {
+                        "sigma": float(sigma),
+                        "expansion_order": expansion_order,
+                        "smooth_order": smooth_order,
+                        "value": result.value,
+                        "local_value": result.local_value,
+                        "smooth_value": result.smooth_value,
+                        "support_relation": result.support_relation,
+                        "abs_error": float(error),
+                    }
+                )
 
     return rows
 

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -81,6 +81,10 @@ class Laplace2DDMKSplitResult:
     support_relation: str
 
 
+class CompactSupportIntersectionError(ValueError):
+    """Raised when compact local support intersects the source box boundary."""
+
+
 def gauss_legendre_rule(order, a=0.0, b=1.0):
     """Return Gauss-Legendre nodes/weights on ``[a, b]``."""
 
@@ -400,7 +404,7 @@ def laplace2d_dmk_split_integral(
 
     relation = support_relation_to_box(target, config, bounds=bounds)
     if relation == "intersects":
-        raise ValueError(
+        raise CompactSupportIntersectionError(
             "compact support intersects the source box boundary; choose a smaller "
             "sigma or use an intersection-aware local integration path"
         )
@@ -492,7 +496,7 @@ def sweep_laplace2d_dmk_split(
                             "abs_error": float(error),
                         }
                     )
-                except ValueError as exc:
+                except CompactSupportIntersectionError as exc:
                     rows.append(
                         {
                             "sigma": float(sigma),

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -44,6 +44,7 @@ from scipy import special as sps
 
 
 EULER_GAMMA = 0.5772156649015329
+MACHINE_EPS = np.finfo(np.float64).eps
 
 
 @dataclass(frozen=True)
@@ -89,15 +90,25 @@ class HeatKernelConfig:
     """
 
     sigma: float
-    tail_cutoff_sigma: float = 5.0
+    boundary_kernel_tol: float = MACHINE_EPS
+    boundary_truncation_tol: float = MACHINE_EPS
+    shrink_to_boundary: bool = True
 
     def __post_init__(self):
         if not np.isfinite(self.sigma) or self.sigma <= 0:
             raise ValueError(f"sigma must be positive and finite, got {self.sigma!r}")
-        if not np.isfinite(self.tail_cutoff_sigma) or self.tail_cutoff_sigma <= 0:
+        if not np.isfinite(self.boundary_kernel_tol) or self.boundary_kernel_tol <= 0:
             raise ValueError(
-                "tail_cutoff_sigma must be positive and finite, "
-                f"got {self.tail_cutoff_sigma!r}"
+                "boundary_kernel_tol must be positive and finite, "
+                f"got {self.boundary_kernel_tol!r}"
+            )
+        if (
+            not np.isfinite(self.boundary_truncation_tol)
+            or self.boundary_truncation_tol <= 0
+        ):
+            raise ValueError(
+                "boundary_truncation_tol must be positive and finite, "
+                f"got {self.boundary_truncation_tol!r}"
             )
 
 
@@ -109,6 +120,7 @@ class Laplace2DDMKSplitResult:
     local_value: float
     smooth_value: float
     support_relation: str
+    effective_sigma: float | None = None
 
 
 class CompactSupportIntersectionError(ValueError):
@@ -338,6 +350,35 @@ def laplace2d_heat_local_kernel_radius(r, config):
     return result
 
 
+def _laplace2d_heat_local_kernel_radius_with_sigma(r, sigma):
+    z = (np.asarray(r, dtype=np.float64) / sigma) ** 2
+    result = sps.exp1(z) / (4.0 * pi)
+    if np.isscalar(r):
+        return float(result)
+    return result
+
+
+def laplace2d_heat_tail_integral_bound(distance, sigma):
+    """Bound the heat-local residual mass outside radius ``distance``.
+
+    This is the radial full-space bound for unit-bounded density:
+    ``int_distance^inf E1((r/sigma)^2)/(4*pi) 2*pi*r dr``.
+    """
+
+    if distance < 0:
+        raise ValueError(f"distance must be nonnegative, got {distance!r}")
+    if not np.isfinite(sigma) or sigma <= 0:
+        raise ValueError(f"sigma must be positive and finite, got {sigma!r}")
+    if distance == 0:
+        return sigma**2 / 4.0
+
+    scaled_distance_sq = (distance / sigma) ** 2
+    tail = np.exp(-scaled_distance_sq) - scaled_distance_sq * sps.exp1(
+        scaled_distance_sq
+    )
+    return float((sigma**2 / 4.0) * max(tail, 0.0))
+
+
 def laplace2d_heat_smooth_kernel(dx, dy, config):
     """Gaussian-smoothed 2D Laplace Green's function.
 
@@ -405,21 +446,81 @@ def heat_tail_relation_to_box(
 ):
     """Classify the effective heat-local tail relative to a source box."""
 
+    return heat_tail_plan_for_box(target, config, bounds=bounds, tol=tol)[0]
+
+
+def _heat_boundary_criteria_met(distance, sigma, config):
+    if distance <= 0:
+        return False
+
+    return (
+        _laplace2d_heat_local_kernel_radius_with_sigma(distance, sigma)
+        <= config.boundary_kernel_tol
+        and laplace2d_heat_tail_integral_bound(distance, sigma)
+        <= config.boundary_truncation_tol
+    )
+
+
+def _shrink_heat_sigma_for_boundary(distance, config):
+    if _heat_boundary_criteria_met(distance, config.sigma, config):
+        return config.sigma
+    if not config.shrink_to_boundary or distance <= 0:
+        return None
+
+    lo = 0.0
+    hi = config.sigma
+    for _ in range(80):
+        mid = 0.5 * (lo + hi)
+        if mid == 0:
+            break
+        if _heat_boundary_criteria_met(distance, mid, config):
+            lo = mid
+        else:
+            hi = mid
+
+    if lo == 0.0:
+        return None
+    return lo
+
+
+def _heat_config_with_sigma(config, sigma):
+    return HeatKernelConfig(
+        sigma=sigma,
+        boundary_kernel_tol=config.boundary_kernel_tol,
+        boundary_truncation_tol=config.boundary_truncation_tol,
+        shrink_to_boundary=config.shrink_to_boundary,
+    )
+
+
+def heat_tail_plan_for_box(
+    target,
+    config,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+    tol=0.0,
+):
+    """Return heat-tail relation and an optionally shrunk safe config."""
+
     tx, ty = target
     (a, b), (c, d) = bounds
-    radius = config.tail_cutoff_sigma * config.sigma
 
     if a <= tx <= b and c <= ty <= d:
         boundary_distance = min(tx - a, b - tx, ty - c, d - ty)
-        if boundary_distance + tol >= radius:
-            return "tail-contained"
+        effective_sigma = _shrink_heat_sigma_for_boundary(
+            boundary_distance + tol,
+            config,
+        )
+        if effective_sigma is not None:
+            return "tail-contained", _heat_config_with_sigma(config, effective_sigma)
+        return "tail-intersects", config
 
     dx = max(a - tx, 0.0, tx - b)
     dy = max(c - ty, 0.0, ty - d)
-    if np.hypot(dx, dy) + tol >= radius:
-        return "tail-outside"
+    closest_distance = np.hypot(dx, dy) + tol
+    effective_sigma = _shrink_heat_sigma_for_boundary(closest_distance, config)
+    if effective_sigma is not None:
+        return "tail-outside", _heat_config_with_sigma(config, effective_sigma)
 
-    return "tail-intersects"
+    return "tail-intersects", config
 
 
 def _integral_power(lo, hi, exponent):
@@ -620,6 +721,7 @@ def laplace2d_dmk_split_integral(
         local_value=local_value,
         smooth_value=smooth_value,
         support_relation=relation,
+        effective_sigma=config.sigma,
     )
 
 
@@ -645,7 +747,7 @@ def laplace2d_heat_split_integral(
     )
     smooth_order = _validate_integer_order(smooth_order, "smooth_order", minimum=1)
 
-    relation = heat_tail_relation_to_box(target, config, bounds=bounds)
+    relation, effective_config = heat_tail_plan_for_box(target, config, bounds=bounds)
     if relation == "tail-intersects":
         raise HeatTailBoundaryError(
             "heat-local tail intersects the source box boundary; choose a smaller "
@@ -657,7 +759,7 @@ def laplace2d_heat_split_integral(
             coeffs,
             target=target,
             expansion_order=expansion_order,
-            config=config,
+            config=effective_config,
         )
     else:
         local_value = 0.0
@@ -665,7 +767,7 @@ def laplace2d_heat_split_integral(
     smooth_value = laplace2d_heat_smooth_gauss_integral(
         coeffs,
         target=target,
-        config=config,
+        config=effective_config,
         smooth_order=smooth_order,
         bounds=bounds,
     )
@@ -674,6 +776,7 @@ def laplace2d_heat_split_integral(
         local_value=local_value,
         smooth_value=smooth_value,
         support_relation=relation,
+        effective_sigma=effective_config.sigma,
     )
 
 
@@ -739,6 +842,7 @@ def sweep_laplace2d_dmk_split(
                     rows.append(
                         {
                             "sigma": float(sigma),
+                            "effective_sigma": result.effective_sigma,
                             "expansion_order": expansion_order,
                             "smooth_order": smooth_order,
                             "value": result.value,
@@ -752,6 +856,7 @@ def sweep_laplace2d_dmk_split(
                     rows.append(
                         {
                             "sigma": float(sigma),
+                            "effective_sigma": np.nan,
                             "expansion_order": expansion_order,
                             "smooth_order": smooth_order,
                             "value": np.nan,
@@ -806,6 +911,7 @@ def sweep_laplace2d_heat_split(
                     rows.append(
                         {
                             "sigma": float(sigma),
+                            "effective_sigma": result.effective_sigma,
                             "expansion_order": expansion_order,
                             "smooth_order": smooth_order,
                             "value": result.value,
@@ -819,6 +925,7 @@ def sweep_laplace2d_heat_split(
                     rows.append(
                         {
                             "sigma": float(sigma),
+                            "effective_sigma": np.nan,
                             "expansion_order": expansion_order,
                             "smooth_order": smooth_order,
                             "value": np.nan,

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -510,4 +510,4 @@ def sweep_laplace2d_dmk_split(
     return rows
 
 
-# vim: foldmethod=marker:filetype=pyopencl
+# vim: foldmethod=marker:filetype=python

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -85,13 +85,29 @@ class CompactSupportIntersectionError(ValueError):
     """Raised when compact local support intersects the source box boundary."""
 
 
+def _validate_integer_order(order, name, minimum):
+    if isinstance(order, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer, got {order!r}")
+
+    try:
+        order_int = int(order)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer, got {order!r}") from exc
+
+    if order_int != order:
+        raise ValueError(f"{name} must be an integer, got {order!r}")
+    if order_int < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {order!r}")
+
+    return order_int
+
+
 def gauss_legendre_rule(order, a=0.0, b=1.0):
     """Return Gauss-Legendre nodes/weights on ``[a, b]``."""
 
-    if order < 1:
-        raise ValueError(f"order must be >= 1, got {order}")
+    order = _validate_integer_order(order, "order", minimum=1)
 
-    nodes, weights = np.polynomial.legendre.leggauss(int(order))
+    nodes, weights = np.polynomial.legendre.leggauss(order)
     center = 0.5 * (a + b)
     radius = 0.5 * (b - a)
     return center + radius * nodes, radius * weights
@@ -361,6 +377,11 @@ def laplace2d_local_moment(mx, my, config):
 def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
     """Evaluate the local compact singular contribution by Taylor moments."""
 
+    expansion_order = _validate_integer_order(
+        expansion_order,
+        "expansion_order",
+        minimum=0,
+    )
     shifted = shifted_polynomial_coefficients(
         coeffs,
         center=target,
@@ -401,6 +422,13 @@ def laplace2d_dmk_split_integral(
     bounds=((0.0, 1.0), (0.0, 1.0)),
 ):
     """Evaluate one 2D Laplace table entry by the experimental DMK-like split."""
+
+    expansion_order = _validate_integer_order(
+        expansion_order,
+        "expansion_order",
+        minimum=0,
+    )
+    smooth_order = _validate_integer_order(smooth_order, "smooth_order", minimum=1)
 
     relation = support_relation_to_box(target, config, bounds=bounds)
     if relation == "intersects":
@@ -465,6 +493,15 @@ def sweep_laplace2d_dmk_split(
 
     coeffs = tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = tensor_gauss_point(q_order, target_index)
+    sigmas = tuple(sigmas)
+    expansion_orders = tuple(
+        _validate_integer_order(order, "expansion_order", minimum=0)
+        for order in expansion_orders
+    )
+    smooth_orders = tuple(
+        _validate_integer_order(order, "smooth_order", minimum=1)
+        for order in smooth_orders
+    )
     rows = []
 
     for sigma in sigmas:
@@ -480,15 +517,15 @@ def sweep_laplace2d_dmk_split(
                         coeffs,
                         target=target,
                         config=config,
-                        expansion_order=int(expansion_order),
-                        smooth_order=int(smooth_order),
+                        expansion_order=expansion_order,
+                        smooth_order=smooth_order,
                     )
                     error = abs(result.value - reference_value)
                     rows.append(
                         {
                             "sigma": float(sigma),
-                            "expansion_order": int(expansion_order),
-                            "smooth_order": int(smooth_order),
+                            "expansion_order": expansion_order,
+                            "smooth_order": smooth_order,
                             "value": result.value,
                             "local_value": result.local_value,
                             "smooth_value": result.smooth_value,
@@ -500,8 +537,8 @@ def sweep_laplace2d_dmk_split(
                     rows.append(
                         {
                             "sigma": float(sigma),
-                            "expansion_order": int(expansion_order),
-                            "smooth_order": int(smooth_order),
+                            "expansion_order": expansion_order,
+                            "smooth_order": smooth_order,
                             "value": np.nan,
                             "local_value": np.nan,
                             "smooth_value": np.nan,

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -1,0 +1,513 @@
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+__doc__ = """Experimental DMK-like near-field table-build splitting.
+
+This module prototypes a table-entry decomposition that is deliberately
+different from Volumential's existing Helmholtz/Yukawa ``S_p/R_p`` split.  The
+kernel is split before quadrature into
+
+* a compactly supported local singular part, evaluated from an asymptotic
+  Taylor expansion of the source mode and analytic radial/angular moments, and
+* a smooth remainder, evaluated by tensor-product Gauss quadrature that may use
+  a higher order than the table's interpolation order.
+
+The first implementation targets 2D Laplace table entries on the template box.
+It is intended for convergence experiments and for scoping issue #104; it is
+not wired into the production table manager yet.
+"""
+
+from dataclasses import dataclass
+from math import comb, lgamma, log, pi
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CompactWindowConfig:
+    """Compact radial window used by the DMK-like table split.
+
+    ``sigma`` is the support radius.  The window is one for
+    ``r <= plateau_fraction*sigma`` and zero for ``r >= sigma``.  Between those
+    radii it uses a generalized smoothstep polynomial with the requested number
+    of vanishing derivatives at both transition endpoints.
+    """
+
+    sigma: float
+    plateau_fraction: float = 0.5
+    smoothness_order: int = 4
+
+    def __post_init__(self):
+        if not np.isfinite(self.sigma) or self.sigma <= 0:
+            raise ValueError(f"sigma must be positive and finite, got {self.sigma!r}")
+        if not 0 < self.plateau_fraction < 1:
+            raise ValueError(
+                "plateau_fraction must be between 0 and 1, "
+                f"got {self.plateau_fraction!r}"
+            )
+        if self.smoothness_order < 0:
+            raise ValueError(
+                "smoothness_order must be nonnegative, "
+                f"got {self.smoothness_order!r}"
+            )
+
+
+@dataclass(frozen=True)
+class Laplace2DDMKSplitResult:
+    """Result of one split table-entry evaluation."""
+
+    value: float
+    local_value: float
+    smooth_value: float
+    support_relation: str
+
+
+def gauss_legendre_rule(order, a=0.0, b=1.0):
+    """Return Gauss-Legendre nodes/weights on ``[a, b]``."""
+
+    if order < 1:
+        raise ValueError(f"order must be >= 1, got {order}")
+
+    nodes, weights = np.polynomial.legendre.leggauss(int(order))
+    center = 0.5 * (a + b)
+    radius = 0.5 * (b - a)
+    return center + radius * nodes, radius * weights
+
+
+def gauss_legendre_tensor_points(order, bounds=((0.0, 1.0), (0.0, 1.0))):
+    """Return flattened tensor-product Gauss nodes and weights in 2D."""
+
+    x_nodes, x_weights = gauss_legendre_rule(order, *bounds[0])
+    y_nodes, y_weights = gauss_legendre_rule(order, *bounds[1])
+    xx, yy = np.meshgrid(x_nodes, y_nodes, indexing="ij")
+    wx, wy = np.meshgrid(x_weights, y_weights, indexing="ij")
+    return xx.ravel(), yy.ravel(), (wx * wy).ravel()
+
+
+def tensor_gauss_point(q_order, point_index, bounds=((0.0, 1.0), (0.0, 1.0))):
+    """Return a Volumential-compatible 2D tensor Gauss target point."""
+
+    if point_index < 0 or point_index >= q_order * q_order:
+        raise ValueError(
+            f"point_index must be in [0, {q_order * q_order}), got {point_index}"
+        )
+
+    ix = point_index // q_order
+    iy = point_index % q_order
+    x_nodes, _ = gauss_legendre_rule(q_order, *bounds[0])
+    y_nodes, _ = gauss_legendre_rule(q_order, *bounds[1])
+    return (float(x_nodes[ix]), float(y_nodes[iy]))
+
+
+def minimum_boundary_spacing(q_order):
+    """Return the nearest distance from any ``q_order`` Gauss node to ``[0, 1]``."""
+
+    nodes, _ = gauss_legendre_rule(q_order)
+    return float(min(np.min(nodes), np.min(1.0 - nodes)))
+
+
+def lagrange_polynomial_coefficients(nodes, index):
+    """Return monomial coefficients for the 1D Lagrange basis polynomial.
+
+    Coefficients are in ascending order, i.e. ``c[k]`` multiplies ``x**k``.
+    """
+
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if index < 0 or index >= nodes.size:
+        raise ValueError(f"basis index {index} outside node set of size {nodes.size}")
+
+    roots = np.delete(nodes, index)
+    coeffs = np.polynomial.polynomial.polyfromroots(roots)
+    denom = np.prod(nodes[index] - roots)
+    return coeffs / denom
+
+
+def tensor_lagrange_mode_coefficients(q_order, mode_index):
+    """Return monomial coefficients for a 2D tensor Lagrange source mode.
+
+    The mode ordering matches :class:`NearFieldInteractionTable`: x-index first,
+    y-index second.
+    """
+
+    if mode_index < 0 or mode_index >= q_order * q_order:
+        raise ValueError(
+            f"mode_index must be in [0, {q_order * q_order}), got {mode_index}"
+        )
+
+    ix = mode_index // q_order
+    iy = mode_index % q_order
+    nodes, _ = gauss_legendre_rule(q_order)
+    cx = lagrange_polynomial_coefficients(nodes, ix)
+    cy = lagrange_polynomial_coefficients(nodes, iy)
+    return np.multiply.outer(cx, cy)
+
+
+def evaluate_polynomial_2d(coeffs, x, y):
+    """Evaluate an ascending-coefficient 2D polynomial."""
+
+    return np.polynomial.polynomial.polyval2d(x, y, coeffs)
+
+
+def shifted_polynomial_coefficients(coeffs, center, max_total_order=None):
+    """Expand ``p(x, y)`` in powers of ``x-center[0]`` and ``y-center[1]``."""
+
+    coeffs = np.asarray(coeffs, dtype=np.float64)
+    tx, ty = center
+    shifted = np.zeros_like(coeffs, dtype=np.float64)
+
+    for i in range(coeffs.shape[0]):
+        for j in range(coeffs.shape[1]):
+            cij = coeffs[i, j]
+            if cij == 0:
+                continue
+
+            for a in range(i + 1):
+                x_scale = comb(i, a) * tx ** (i - a)
+                for b in range(j + 1):
+                    if max_total_order is not None and a + b > max_total_order:
+                        continue
+                    shifted[a, b] += cij * x_scale * comb(j, b) * ty ** (j - b)
+
+    if max_total_order is not None:
+        for a in range(shifted.shape[0]):
+            for b in range(shifted.shape[1]):
+                if a + b > max_total_order:
+                    shifted[a, b] = 0.0
+
+    return shifted
+
+
+def _smoothstep_coefficients(smoothness_order):
+    """Return coefficients of the generalized smoothstep polynomial."""
+
+    n = int(smoothness_order)
+    coeffs = np.zeros(2 * n + 2, dtype=np.float64)
+    for k in range(n + 1):
+        power = n + 1 + k
+        coeffs[power] = ((-1) ** k) * comb(n + k, k) * comb(2 * n + 1, n - k)
+    return coeffs
+
+
+def _window_transition_polynomial(config):
+    """Return ``eta(t)`` coefficients on ``plateau_fraction < t < 1``."""
+
+    a = float(config.plateau_fraction)
+    scale = 1.0 - a
+    smoothstep = _smoothstep_coefficients(config.smoothness_order)
+    coeffs = np.zeros_like(smoothstep)
+    coeffs[0] = 1.0
+
+    for j, sj in enumerate(smoothstep):
+        if sj == 0:
+            continue
+        prefactor = -sj / scale**j
+        for ell in range(j + 1):
+            coeffs[ell] += prefactor * comb(j, ell) * (-a) ** (j - ell)
+
+    return coeffs
+
+
+def compact_window(t, config):
+    """Evaluate the compact radial window at ``t = r/sigma``."""
+
+    t_arr = np.asarray(t, dtype=np.float64)
+    result = np.zeros(t_arr.shape, dtype=np.float64)
+    plateau = t_arr <= config.plateau_fraction
+    transition = np.logical_and(t_arr > config.plateau_fraction, t_arr < 1.0)
+    result[plateau] = 1.0
+    if np.any(transition):
+        coeffs = _window_transition_polynomial(config)
+        result[transition] = np.polynomial.polynomial.polyval(t_arr[transition], coeffs)
+    result = np.clip(result, 0.0, 1.0)
+    if np.isscalar(t):
+        return float(result)
+    return result
+
+
+def laplace2d_kernel_radius(r):
+    """2D Laplace Green's function as a function of radius."""
+
+    return -np.log(r) / (2.0 * pi)
+
+
+def laplace2d_smooth_kernel(dx, dy, config):
+    """Smooth remainder kernel ``G(r)*(1-eta(r/sigma))``."""
+
+    r = np.sqrt(np.asarray(dx) ** 2 + np.asarray(dy) ** 2)
+    result = np.zeros(np.shape(r), dtype=np.float64)
+    active = r > config.plateau_fraction * config.sigma
+    if np.any(active):
+        rr = r[active] if np.ndim(r) else r
+        window = compact_window(rr / config.sigma, config)
+        vals = laplace2d_kernel_radius(rr) * (1.0 - window)
+        if np.ndim(r):
+            result[active] = vals
+        else:
+            result = np.asarray(vals, dtype=np.float64)
+    if np.isscalar(dx) and np.isscalar(dy):
+        return float(result)
+    return result
+
+
+def support_relation_to_box(
+    target,
+    config,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+    tol=0.0,
+):
+    """Classify compact-window support relative to a rectangular source box.
+
+    Returns ``"inside"`` if the entire support disk lies in the box, ``"outside"``
+    if it is disjoint from the box, and ``"intersects"`` otherwise.
+    """
+
+    tx, ty = target
+    (a, b), (c, d) = bounds
+    sigma = config.sigma
+
+    if a <= tx <= b and c <= ty <= d:
+        boundary_distance = min(tx - a, b - tx, ty - c, d - ty)
+        if boundary_distance + tol >= sigma:
+            return "inside"
+
+    dx = max(a - tx, 0.0, tx - b)
+    dy = max(c - ty, 0.0, ty - d)
+    if np.hypot(dx, dy) + tol >= sigma:
+        return "outside"
+
+    return "intersects"
+
+
+def _integral_power(lo, hi, exponent):
+    return (hi ** (exponent + 1) - lo ** (exponent + 1)) / (exponent + 1)
+
+
+def _integral_power_log(lo, hi, exponent):
+    power = exponent + 1
+
+    def antiderivative(x):
+        if x == 0:
+            return 0.0
+        return x**power * (log(x) / power - 1.0 / power**2)
+
+    return antiderivative(hi) - antiderivative(lo)
+
+
+def _window_power_integrals(config, exponent):
+    """Return ``int t**exponent eta(t) dt`` and with an extra ``log(t)``."""
+
+    a = float(config.plateau_fraction)
+    coeffs = _window_transition_polynomial(config)
+
+    plain = _integral_power(0.0, a, exponent)
+    log_part = _integral_power_log(0.0, a, exponent)
+
+    for degree, coeff in enumerate(coeffs):
+        if coeff == 0:
+            continue
+        total_degree = exponent + degree
+        plain += coeff * _integral_power(a, 1.0, total_degree)
+        log_part += coeff * _integral_power_log(a, 1.0, total_degree)
+
+    return plain, log_part
+
+
+def _angular_moment(mx, my):
+    if mx % 2 or my % 2:
+        return 0.0
+
+    a = mx // 2
+    b = my // 2
+    return float(2.0 * np.exp(lgamma(a + 0.5) + lgamma(b + 0.5) - lgamma(a + b + 1)))
+
+
+def laplace2d_local_moment(mx, my, config):
+    """Moment of the compactly supported 2D Laplace local kernel."""
+
+    angular = _angular_moment(mx, my)
+    if angular == 0.0:
+        return 0.0
+
+    radial_power = mx + my + 1
+    plain, log_part = _window_power_integrals(config, radial_power)
+    sigma_power = config.sigma ** (mx + my + 2)
+    radial = -(sigma_power / (2.0 * pi)) * (log(config.sigma) * plain + log_part)
+    return angular * radial
+
+
+def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
+    """Evaluate the local compact singular contribution by Taylor moments."""
+
+    shifted = shifted_polynomial_coefficients(
+        coeffs,
+        center=target,
+        max_total_order=expansion_order,
+    )
+    total = 0.0
+    for mx in range(shifted.shape[0]):
+        for my in range(shifted.shape[1]):
+            if mx + my > expansion_order:
+                continue
+            coeff = shifted[mx, my]
+            if coeff != 0:
+                total += coeff * laplace2d_local_moment(mx, my, config)
+    return float(total)
+
+
+def laplace2d_smooth_gauss_integral(
+    coeffs,
+    target,
+    config,
+    smooth_order,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
+    """Evaluate the smooth remainder contribution by tensor-product Gauss."""
+
+    xx, yy, weights = gauss_legendre_tensor_points(smooth_order, bounds=bounds)
+    density = evaluate_polynomial_2d(coeffs, xx, yy)
+    kernel = laplace2d_smooth_kernel(xx - target[0], yy - target[1], config)
+    return float(np.dot(weights, density * kernel))
+
+
+def laplace2d_dmk_split_integral(
+    coeffs,
+    target,
+    config,
+    expansion_order,
+    smooth_order,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
+    """Evaluate one 2D Laplace table entry by the experimental DMK-like split."""
+
+    relation = support_relation_to_box(target, config, bounds=bounds)
+    if relation == "intersects":
+        raise ValueError(
+            "compact support intersects the source box boundary; choose a smaller "
+            "sigma or use an intersection-aware local integration path"
+        )
+
+    if relation == "inside":
+        local_value = laplace2d_local_expansion_integral(
+            coeffs,
+            target=target,
+            expansion_order=expansion_order,
+            config=config,
+        )
+    else:
+        local_value = 0.0
+
+    smooth_value = laplace2d_smooth_gauss_integral(
+        coeffs,
+        target=target,
+        config=config,
+        smooth_order=smooth_order,
+        bounds=bounds,
+    )
+    return Laplace2DDMKSplitResult(
+        value=local_value + smooth_value,
+        local_value=local_value,
+        smooth_value=smooth_value,
+        support_relation=relation,
+    )
+
+
+def laplace2d_full_gauss_integral(
+    coeffs,
+    target,
+    quad_order,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
+    """High-order tensor Gauss integral of the unsplit nonsingular case."""
+
+    xx, yy, weights = gauss_legendre_tensor_points(quad_order, bounds=bounds)
+    r = np.sqrt((xx - target[0]) ** 2 + (yy - target[1]) ** 2)
+    if np.any(r == 0):
+        raise ValueError("full Gauss reference hit the singular target point")
+    integrand = evaluate_polynomial_2d(coeffs, xx, yy) * laplace2d_kernel_radius(r)
+    return float(np.dot(weights, integrand))
+
+
+def sweep_laplace2d_dmk_split(
+    q_order,
+    mode_index,
+    target_index,
+    sigmas,
+    expansion_orders,
+    smooth_orders,
+    reference_value,
+    plateau_fraction=0.5,
+    smoothness_order=4,
+):
+    """Sweep split parameters for one 2D Laplace table entry."""
+
+    coeffs = tensor_lagrange_mode_coefficients(q_order, mode_index)
+    target = tensor_gauss_point(q_order, target_index)
+    rows = []
+
+    for sigma in sigmas:
+        config = CompactWindowConfig(
+            sigma=float(sigma),
+            plateau_fraction=plateau_fraction,
+            smoothness_order=smoothness_order,
+        )
+        for expansion_order in expansion_orders:
+            for smooth_order in smooth_orders:
+                try:
+                    result = laplace2d_dmk_split_integral(
+                        coeffs,
+                        target=target,
+                        config=config,
+                        expansion_order=int(expansion_order),
+                        smooth_order=int(smooth_order),
+                    )
+                    error = abs(result.value - reference_value)
+                    rows.append(
+                        {
+                            "sigma": float(sigma),
+                            "expansion_order": int(expansion_order),
+                            "smooth_order": int(smooth_order),
+                            "value": result.value,
+                            "local_value": result.local_value,
+                            "smooth_value": result.smooth_value,
+                            "support_relation": result.support_relation,
+                            "abs_error": float(error),
+                        }
+                    )
+                except ValueError as exc:
+                    rows.append(
+                        {
+                            "sigma": float(sigma),
+                            "expansion_order": int(expansion_order),
+                            "smooth_order": int(smooth_order),
+                            "value": np.nan,
+                            "local_value": np.nan,
+                            "smooth_value": np.nan,
+                            "support_relation": "intersects",
+                            "abs_error": np.inf,
+                            "error_message": str(exc),
+                        }
+                    )
+
+    return rows
+
+
+# vim: foldmethod=marker:filetype=pyopencl

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -63,15 +63,19 @@ class CompactWindowConfig:
     def __post_init__(self):
         if not np.isfinite(self.sigma) or self.sigma <= 0:
             raise ValueError(f"sigma must be positive and finite, got {self.sigma!r}")
+        object.__setattr__(
+            self,
+            "smoothness_order",
+            _validate_integer_order(
+                self.smoothness_order,
+                "smoothness_order",
+                minimum=0,
+            ),
+        )
         if not 0 < self.plateau_fraction < 1:
             raise ValueError(
                 "plateau_fraction must be between 0 and 1, "
                 f"got {self.plateau_fraction!r}"
-            )
-        if self.smoothness_order < 0:
-            raise ValueError(
-                "smoothness_order must be nonnegative, "
-                f"got {self.smoothness_order!r}"
             )
 
 
@@ -85,10 +89,16 @@ class HeatKernelConfig:
     """
 
     sigma: float
+    tail_cutoff_sigma: float = 5.0
 
     def __post_init__(self):
         if not np.isfinite(self.sigma) or self.sigma <= 0:
             raise ValueError(f"sigma must be positive and finite, got {self.sigma!r}")
+        if not np.isfinite(self.tail_cutoff_sigma) or self.tail_cutoff_sigma <= 0:
+            raise ValueError(
+                "tail_cutoff_sigma must be positive and finite, "
+                f"got {self.tail_cutoff_sigma!r}"
+            )
 
 
 @dataclass(frozen=True)
@@ -103,6 +113,10 @@ class Laplace2DDMKSplitResult:
 
 class CompactSupportIntersectionError(ValueError):
     """Raised when compact local support intersects the source box boundary."""
+
+
+class HeatTailBoundaryError(ValueError):
+    """Raised when heat-local full-space moments are unsafe for a finite box."""
 
 
 def _validate_integer_order(order, name, minimum):
@@ -332,22 +346,25 @@ def laplace2d_heat_smooth_kernel(dx, dy, config):
     """
 
     r = np.sqrt(np.asarray(dx) ** 2 + np.asarray(dy) ** 2)
+    if np.isscalar(dx) and np.isscalar(dy):
+        if r == 0:
+            return (EULER_GAMMA - 2.0 * log(config.sigma)) / (4.0 * pi)
+        return float(
+            laplace2d_kernel_radius(r)
+            - laplace2d_heat_local_kernel_radius(r, config)
+        )
+
     result = np.empty(np.shape(r), dtype=np.float64)
     zero = r == 0
     if np.any(~zero):
-        rr = r[~zero] if np.ndim(r) else r
+        rr = r[~zero]
         vals = laplace2d_kernel_radius(rr) - laplace2d_heat_local_kernel_radius(
             rr,
             config,
         )
-        if np.ndim(r):
-            result[~zero] = vals
-        else:
-            result = np.asarray(vals, dtype=np.float64)
+        result[~zero] = vals
     if np.any(zero):
         result[zero] = (EULER_GAMMA - 2.0 * log(config.sigma)) / (4.0 * pi)
-    if np.isscalar(dx) and np.isscalar(dy):
-        return float(result)
     return result
 
 
@@ -378,6 +395,31 @@ def support_relation_to_box(
         return "outside"
 
     return "intersects"
+
+
+def heat_tail_relation_to_box(
+    target,
+    config,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+    tol=0.0,
+):
+    """Classify the effective heat-local tail relative to a source box."""
+
+    tx, ty = target
+    (a, b), (c, d) = bounds
+    radius = config.tail_cutoff_sigma * config.sigma
+
+    if a <= tx <= b and c <= ty <= d:
+        boundary_distance = min(tx - a, b - tx, ty - c, d - ty)
+        if boundary_distance + tol >= radius:
+            return "tail-contained"
+
+    dx = max(a - tx, 0.0, tx - b)
+    dy = max(c - ty, 0.0, ty - d)
+    if np.hypot(dx, dy) + tol >= radius:
+        return "tail-outside"
+
+    return "tail-intersects"
 
 
 def _integral_power(lo, hi, exponent):
@@ -603,12 +645,23 @@ def laplace2d_heat_split_integral(
     )
     smooth_order = _validate_integer_order(smooth_order, "smooth_order", minimum=1)
 
-    local_value = laplace2d_heat_local_expansion_integral(
-        coeffs,
-        target=target,
-        expansion_order=expansion_order,
-        config=config,
-    )
+    relation = heat_tail_relation_to_box(target, config, bounds=bounds)
+    if relation == "tail-intersects":
+        raise HeatTailBoundaryError(
+            "heat-local tail intersects the source box boundary; choose a smaller "
+            "sigma or use boundary-corrected local moments"
+        )
+
+    if relation == "tail-contained":
+        local_value = laplace2d_heat_local_expansion_integral(
+            coeffs,
+            target=target,
+            expansion_order=expansion_order,
+            config=config,
+        )
+    else:
+        local_value = 0.0
+
     smooth_value = laplace2d_heat_smooth_gauss_integral(
         coeffs,
         target=target,
@@ -620,7 +673,7 @@ def laplace2d_heat_split_integral(
         value=local_value + smooth_value,
         local_value=local_value,
         smooth_value=smooth_value,
-        support_relation="heat-tail",
+        support_relation=relation,
     )
 
 
@@ -741,26 +794,41 @@ def sweep_laplace2d_heat_split(
         config = HeatKernelConfig(sigma=float(sigma))
         for expansion_order in expansion_orders:
             for smooth_order in smooth_orders:
-                result = laplace2d_heat_split_integral(
-                    coeffs,
-                    target=target,
-                    config=config,
-                    expansion_order=expansion_order,
-                    smooth_order=smooth_order,
-                )
-                error = abs(result.value - reference_value)
-                rows.append(
-                    {
-                        "sigma": float(sigma),
-                        "expansion_order": expansion_order,
-                        "smooth_order": smooth_order,
-                        "value": result.value,
-                        "local_value": result.local_value,
-                        "smooth_value": result.smooth_value,
-                        "support_relation": result.support_relation,
-                        "abs_error": float(error),
-                    }
-                )
+                try:
+                    result = laplace2d_heat_split_integral(
+                        coeffs,
+                        target=target,
+                        config=config,
+                        expansion_order=expansion_order,
+                        smooth_order=smooth_order,
+                    )
+                    error = abs(result.value - reference_value)
+                    rows.append(
+                        {
+                            "sigma": float(sigma),
+                            "expansion_order": expansion_order,
+                            "smooth_order": smooth_order,
+                            "value": result.value,
+                            "local_value": result.local_value,
+                            "smooth_value": result.smooth_value,
+                            "support_relation": result.support_relation,
+                            "abs_error": float(error),
+                        }
+                    )
+                except HeatTailBoundaryError as exc:
+                    rows.append(
+                        {
+                            "sigma": float(sigma),
+                            "expansion_order": expansion_order,
+                            "smooth_order": smooth_order,
+                            "value": np.nan,
+                            "local_value": np.nan,
+                            "smooth_value": np.nan,
+                            "support_relation": "tail-intersects",
+                            "abs_error": np.inf,
+                            "error_message": str(exc),
+                        }
+                    )
 
     return rows
 


### PR DESCRIPTION
## Summary

- Add an experimental 2D Laplace DMK-like table-entry split for issue #104.
- Split each entry into a compact singular/local part evaluated by analytic Taylor moments and a smooth remainder evaluated by supersampled tensor Gauss quadrature.
- Add convergence tests sweeping support radius `sigma`, local expansion order, and smooth quadrature order against the existing Duffy radial reference.

## Notes

- This is intentionally not the existing Helmholtz/Yukawa `S_p/R_p` split.
- The prototype rejects compact supports that intersect the source box boundary; the first experiment relies on fixed Gauss target spacing so the support is fully inside or outside the box.
- The tested high-accuracy fixture reaches the `1e-12` regime with `q=5`, `sigma=0.35`, expansion order `8`, and smooth quadrature order `220`.
- DMK paper parameter guidance used for scoping: continuous box-code tests report density polynomial orders around `q=16` in 2D and `q=16`/`20` in 3D for precision sweeps through `1e-3`, `1e-6`, `1e-9`, and `1e-12`.

Closes #104.

## Tests

- `uv run pytest test/test_dmk_split.py test/test_duffy_tanh_sinh.py test/test_singular_integral_2d.py`
- `uv run python -m compileall volumential/dmk_split.py`
- `uv run pytest test/test_import.py test/test_version.py`
