### PR TITLE
fix(dmk): stabilize Lagrange mode evaluation

### DIFF
--- a/test/test_dmk_split.py
+++ b/test/test_dmk_split.py
@@ -1,13 +1,14 @@
 import numpy as np
 
 from volumential import dmk_split as dmk
+from volumential import lagrange
 from volumential import singular_integral_2d as sint
 
 
-def _safe_laplace2d_table_integrand(coeffs, target):
+def _safe_laplace2d_table_integrand(q_order, mode_index, target):
     def integrand(x, y):
         r = np.sqrt((x - target[0]) ** 2 + (y - target[1]) ** 2)
-        density = dmk.evaluate_polynomial_2d(coeffs, x, y)
+        density = dmk.evaluate_laplace2d_source_mode(q_order, mode_index, x, y)
 
         if np.isscalar(r):
             if r == 0:
@@ -22,9 +23,9 @@ def _safe_laplace2d_table_integrand(coeffs, target):
     return integrand
 
 
-def _duffy_reference_laplace2d(coeffs, target):
+def _duffy_reference_laplace2d(q_order, mode_index, target):
     value, _ = sint.box_quad_duffy_radial(
-        _safe_laplace2d_table_integrand(coeffs, target),
+        _safe_laplace2d_table_integrand(q_order, mode_index, target),
         0,
         1,
         0,
@@ -93,13 +94,80 @@ def test_window_order_validation_rejects_fractional_smoothness():
         raise AssertionError("fractional smoothness order should fail validation")
 
 
+def test_barycentric_tensor_lagrange_mode_is_exact_at_high_order_nodes():
+    q_order = 16
+    mode_index = 7 * q_order + 9
+    nodes, _ = dmk.gauss_legendre_rule(q_order)
+    xx, yy = np.meshgrid(nodes, nodes, indexing="ij")
+
+    values = dmk.evaluate_laplace2d_source_mode(q_order, mode_index, xx, yy)
+    expected = np.zeros((q_order, q_order))
+    expected[7, 9] = 1.0
+
+    np.testing.assert_array_equal(values, expected)
+
+
+def test_heat_smooth_integral_matches_manual_barycentric_quadrature():
+    q_order = 5
+    mode_index = 12
+    target = dmk.tensor_gauss_point(q_order, 12)
+    config = dmk.HeatKernelConfig(sigma=0.06)
+
+    split_value = dmk.laplace2d_heat_smooth_gauss_integral(
+        q_order,
+        mode_index,
+        target=target,
+        config=config,
+        smooth_order=48,
+    )
+    xx, yy, weights = dmk.gauss_legendre_tensor_points(48)
+    density = dmk.evaluate_laplace2d_source_mode(q_order, mode_index, xx, yy)
+    kernel = dmk.laplace2d_heat_smooth_kernel(
+        xx - target[0],
+        yy - target[1],
+        config,
+    )
+    manual = np.dot(weights, density * kernel)
+
+    np.testing.assert_allclose(split_value, manual, rtol=1.0e-13, atol=1.0e-13)
+
+
+def test_shifted_lagrange_mode_coefficients_reconstruct_source_mode():
+    q_order = 5
+    mode_index = 12
+    target = dmk.tensor_gauss_point(q_order, 17)
+    sample_x = np.array([0.15, 0.41, 0.75])
+    sample_y = np.array([0.22, 0.54, 0.86])
+
+    nodes, _ = dmk.gauss_legendre_rule(q_order)
+    mode_axes = lagrange.mode_index_to_axes(mode_index, q_order, dim=2)
+    shifted = lagrange.tensor_lagrange_mode_shifted_coefficients(
+        (nodes, nodes),
+        mode_axes,
+        target,
+        max_total_order=2 * (q_order - 1),
+    )
+    reconstructed = np.polynomial.polynomial.polyval2d(
+        sample_x - target[0],
+        sample_y - target[1],
+        shifted,
+    )
+    expected = dmk.evaluate_laplace2d_source_mode(
+        q_order,
+        mode_index,
+        sample_x,
+        sample_y,
+    )
+
+    np.testing.assert_allclose(reconstructed, expected, rtol=1.0e-13, atol=1.0e-12)
+
+
 def test_laplace2d_dmk_like_split_parameter_sweep_reaches_high_accuracy():
     q_order = 5
     mode_index = 12
     target_index = 12
-    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = dmk.tensor_gauss_point(q_order, target_index)
-    reference = _duffy_reference_laplace2d(coeffs, target)
+    reference = _duffy_reference_laplace2d(q_order, mode_index, target)
 
     rows = dmk.sweep_laplace2d_dmk_split(
         q_order=q_order,
@@ -143,9 +211,8 @@ def test_laplace2d_heat_split_reaches_high_accuracy_with_smooth_remainder():
     q_order = 5
     mode_index = 12
     target_index = 12
-    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = dmk.tensor_gauss_point(q_order, target_index)
-    reference = _duffy_reference_laplace2d(coeffs, target)
+    reference = _duffy_reference_laplace2d(q_order, mode_index, target)
 
     rows = dmk.sweep_laplace2d_heat_split(
         q_order=q_order,
@@ -169,12 +236,12 @@ def test_laplace2d_heat_split_shrinks_boundary_tail_to_tolerance():
     q_order = 5
     mode_index = 12
     target_index = 0
-    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = dmk.tensor_gauss_point(q_order, target_index)
     requested = dmk.HeatKernelConfig(sigma=0.06)
 
     result = dmk.laplace2d_heat_split_integral(
-        coeffs,
+        q_order,
+        mode_index,
         target=target,
         config=requested,
         expansion_order=8,
@@ -202,12 +269,12 @@ def test_laplace2d_heat_split_rejects_boundary_tail_without_shrinkage():
     q_order = 5
     mode_index = 12
     target_index = 0
-    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = dmk.tensor_gauss_point(q_order, target_index)
 
     try:
         dmk.laplace2d_heat_split_integral(
-            coeffs,
+            q_order,
+            mode_index,
             target=target,
             config=dmk.HeatKernelConfig(sigma=0.06, shrink_to_boundary=False),
             expansion_order=8,
@@ -223,7 +290,6 @@ def test_laplace2d_dmk_like_split_rejects_intersecting_local_support():
     q_order = 5
     mode_index = 12
     target_index = 0
-    coeffs = dmk.tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = dmk.tensor_gauss_point(q_order, target_index)
 
     config = dmk.CompactWindowConfig(
@@ -232,7 +298,8 @@ def test_laplace2d_dmk_like_split_rejects_intersecting_local_support():
 
     try:
         dmk.laplace2d_dmk_split_integral(
-            coeffs,
+            q_order,
+            mode_index,
             target=target,
             config=config,
             expansion_order=8,

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -39,6 +39,7 @@ if (
     )
 
 import volumential.nearfield_potential_table as npt
+from volumential import lagrange
 from volumential.table_manager import ConstantKernel
 
 
@@ -61,6 +62,30 @@ def _make_build_queue_or_skip():
             return cl.CommandQueue(cl.Context([devices[0]]))
 
     pytest.skip("No OpenCL devices available for table builds")
+
+
+def _make_legendre_table_without_cl(q_order, dim):
+    nodes = np.polynomial.legendre.leggauss(q_order)[0]
+    nodes = 0.5 * (nodes + 1.0)
+
+    table = npt.NearFieldInteractionTable.__new__(npt.NearFieldInteractionTable)
+    table.quad_order = q_order
+    table.dim = dim
+    table.n_q_points = q_order**dim
+    table.source_box_extent = 1.0
+    table.dtype = np.float64
+
+    if dim == 1:
+        q_points = [(x,) for x in nodes]
+    elif dim == 2:
+        q_points = [(x, y) for x in nodes for y in nodes]
+    elif dim == 3:
+        q_points = [(x, y, z) for x in nodes for y in nodes for z in nodes]
+    else:
+        raise NotImplementedError("dimension %d not supported" % dim)
+
+    table.q_points = np.asarray(q_points, dtype=np.float64)
+    return table
 
 
 def test_const_order_1():
@@ -236,6 +261,33 @@ def test_modes_cheb_coeffs():
     drive_test_modes_cheb_coeffs(3, 5, 5)
     drive_test_modes_cheb_coeffs(3, 5, 10)
     drive_test_modes_cheb_coeffs(3, 10, 10)
+
+
+def test_high_order_modes_are_barycentric_at_nodes():
+    q_order = 16
+    dim = 2
+    mode_index = 7 * q_order + 9
+    table = _make_legendre_table_without_cl(q_order, dim)
+
+    mode = table.get_template_mode(mode_index)
+    values = np.asarray([mode(*qpt) for qpt in table.q_points])
+    expected = np.zeros(q_order**dim)
+    expected[mode_index] = 1.0
+
+    np.testing.assert_array_equal(values, expected)
+
+
+def test_nearfield_batched_duffy_uses_shared_barycentric_weights():
+    table = _make_legendre_table_without_cl(q_order=16, dim=2)
+
+    xi, weights = table._get_barycentric_data()
+
+    np.testing.assert_allclose(
+        weights,
+        lagrange.barycentric_lagrange_weights(xi),
+        rtol=0.0,
+        atol=0.0,
+    )
 
 
 @pytest.mark.parametrize("q_order", [1, 2, 3, 5, 8])

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -92,6 +92,37 @@ def test_interpolation_target_coverage_reports_missing_targets():
         )
 
 
+def test_volume_fmm_loopy_interpolation_uses_shared_barycentric_weights():
+    from volumential import lagrange
+    from volumential.volume_fmm import compute_barycentric_lagrange_params
+
+    q_order = 16
+    nodes, weights = compute_barycentric_lagrange_params(q_order)
+
+    np.testing.assert_allclose(
+        weights,
+        lagrange.barycentric_lagrange_weights(nodes),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+    values = lagrange.evaluate_lagrange_basis_1d(nodes, 7, nodes, weights=weights)
+    expected = np.zeros(q_order)
+    expected[7] = 1.0
+    np.testing.assert_array_equal(values, expected)
+
+
+def test_barycentric_interp_matrix_is_exact_at_source_nodes():
+    from volumential.expansion_wrangler_fpnd import _barycentric_interp_matrix
+
+    source_nodes = np.polynomial.legendre.leggauss(16)[0]
+    source_nodes = 0.5 * (source_nodes + 1.0)
+
+    interp = _barycentric_interp_matrix(source_nodes, source_nodes)
+
+    np.testing.assert_allclose(interp, np.eye(source_nodes.size), rtol=0.0, atol=0.0)
+
+
 def test_list1_gallery_includes_mixed_source_levels():
     from volumential.list1_gallery import generate_interactions
 

--- a/volumential/dmk_split.py
+++ b/volumential/dmk_split.py
@@ -42,6 +42,13 @@ from math import comb, exp, lgamma, log, pi
 import numpy as np
 from scipy import special as sps
 
+from volumential.lagrange import (
+    evaluate_tensor_lagrange_mode as _evaluate_tensor_lagrange_mode,
+    legendre_gauss_lagrange_data,
+    mode_index_to_axes,
+    tensor_lagrange_mode_shifted_coefficients as _tensor_lagrange_shifted_coeffs,
+)
+
 
 EULER_GAMMA = 0.5772156649015329
 MACHINE_EPS = np.finfo(np.float64).eps
@@ -191,75 +198,43 @@ def minimum_boundary_spacing(q_order):
     return float(min(np.min(nodes), np.min(1.0 - nodes)))
 
 
-def lagrange_polynomial_coefficients(nodes, index):
-    """Return monomial coefficients for the 1D Lagrange basis polynomial.
-
-    Coefficients are in ascending order, i.e. ``c[k]`` multiplies ``x**k``.
-    """
-
-    nodes = np.asarray(nodes, dtype=np.float64)
-    if index < 0 or index >= nodes.size:
-        raise ValueError(f"basis index {index} outside node set of size {nodes.size}")
-
-    roots = np.delete(nodes, index)
-    coeffs = np.polynomial.polynomial.polyfromroots(roots)
-    denom = np.prod(nodes[index] - roots)
-    return coeffs / denom
+def _source_mode_nodes_and_axes(q_order, mode_index, bounds):
+    q_order = _validate_integer_order(q_order, "q_order", minimum=1)
+    axes = mode_index_to_axes(mode_index, q_order, dim=2)
+    nodes_by_axis = tuple(
+        legendre_gauss_lagrange_data(q_order, *axis_bounds)[0]
+        for axis_bounds in bounds
+    )
+    return nodes_by_axis, tuple(int(axis) for axis in axes)
 
 
-def tensor_lagrange_mode_coefficients(q_order, mode_index):
-    """Return monomial coefficients for a 2D tensor Lagrange source mode.
+def evaluate_laplace2d_source_mode(
+    q_order,
+    mode_index,
+    x,
+    y,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
+    """Evaluate a 2D source mode with barycentric Lagrange interpolation."""
 
-    The mode ordering matches :class:`NearFieldInteractionTable`: x-index first,
-    y-index second.
-    """
-
-    if mode_index < 0 or mode_index >= q_order * q_order:
-        raise ValueError(
-            f"mode_index must be in [0, {q_order * q_order}), got {mode_index}"
-        )
-
-    ix = mode_index // q_order
-    iy = mode_index % q_order
-    nodes, _ = gauss_legendre_rule(q_order)
-    cx = lagrange_polynomial_coefficients(nodes, ix)
-    cy = lagrange_polynomial_coefficients(nodes, iy)
-    return np.multiply.outer(cx, cy)
+    nodes_by_axis, mode_axes = _source_mode_nodes_and_axes(q_order, mode_index, bounds)
+    return _evaluate_tensor_lagrange_mode(nodes_by_axis, mode_axes, (x, y))
 
 
-def evaluate_polynomial_2d(coeffs, x, y):
-    """Evaluate an ascending-coefficient 2D polynomial."""
-
-    return np.polynomial.polynomial.polyval2d(x, y, coeffs)
-
-
-def shifted_polynomial_coefficients(coeffs, center, max_total_order=None):
-    """Expand ``p(x, y)`` in powers of ``x-center[0]`` and ``y-center[1]``."""
-
-    coeffs = np.asarray(coeffs, dtype=np.float64)
-    tx, ty = center
-    shifted = np.zeros_like(coeffs, dtype=np.float64)
-
-    for i in range(coeffs.shape[0]):
-        for j in range(coeffs.shape[1]):
-            cij = coeffs[i, j]
-            if cij == 0:
-                continue
-
-            for a in range(i + 1):
-                x_scale = comb(i, a) * tx ** (i - a)
-                for b in range(j + 1):
-                    if max_total_order is not None and a + b > max_total_order:
-                        continue
-                    shifted[a, b] += cij * x_scale * comb(j, b) * ty ** (j - b)
-
-    if max_total_order is not None:
-        for a in range(shifted.shape[0]):
-            for b in range(shifted.shape[1]):
-                if a + b > max_total_order:
-                    shifted[a, b] = 0.0
-
-    return shifted
+def _source_mode_shifted_coefficients(
+    q_order,
+    mode_index,
+    target,
+    max_total_order,
+    bounds,
+):
+    nodes_by_axis, mode_axes = _source_mode_nodes_and_axes(q_order, mode_index, bounds)
+    return _tensor_lagrange_shifted_coeffs(
+        nodes_by_axis,
+        mode_axes,
+        center=target,
+        max_total_order=max_total_order,
+    )
 
 
 def _smoothstep_coefficients(smoothness_order):
@@ -597,7 +572,14 @@ def laplace2d_heat_local_moment(mx, my, config):
     return angular * radial
 
 
-def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
+def laplace2d_local_expansion_integral(
+    q_order,
+    mode_index,
+    target,
+    expansion_order,
+    config,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
     """Evaluate the local compact singular contribution by Taylor moments."""
 
     expansion_order = _validate_integer_order(
@@ -605,10 +587,12 @@ def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
         "expansion_order",
         minimum=0,
     )
-    shifted = shifted_polynomial_coefficients(
-        coeffs,
-        center=target,
+    shifted = _source_mode_shifted_coefficients(
+        q_order,
+        mode_index,
+        target=target,
         max_total_order=expansion_order,
+        bounds=bounds,
     )
     total = 0.0
     for mx in range(shifted.shape[0]):
@@ -621,7 +605,14 @@ def laplace2d_local_expansion_integral(coeffs, target, expansion_order, config):
     return float(total)
 
 
-def laplace2d_heat_local_expansion_integral(coeffs, target, expansion_order, config):
+def laplace2d_heat_local_expansion_integral(
+    q_order,
+    mode_index,
+    target,
+    expansion_order,
+    config,
+    bounds=((0.0, 1.0), (0.0, 1.0)),
+):
     """Evaluate the heat-local contribution by full-space Taylor moments."""
 
     expansion_order = _validate_integer_order(
@@ -629,10 +620,12 @@ def laplace2d_heat_local_expansion_integral(coeffs, target, expansion_order, con
         "expansion_order",
         minimum=0,
     )
-    shifted = shifted_polynomial_coefficients(
-        coeffs,
-        center=target,
+    shifted = _source_mode_shifted_coefficients(
+        q_order,
+        mode_index,
+        target=target,
         max_total_order=expansion_order,
+        bounds=bounds,
     )
     total = 0.0
     for mx in range(shifted.shape[0]):
@@ -646,7 +639,8 @@ def laplace2d_heat_local_expansion_integral(coeffs, target, expansion_order, con
 
 
 def laplace2d_smooth_gauss_integral(
-    coeffs,
+    q_order,
+    mode_index,
     target,
     config,
     smooth_order,
@@ -655,13 +649,20 @@ def laplace2d_smooth_gauss_integral(
     """Evaluate the smooth remainder contribution by tensor-product Gauss."""
 
     xx, yy, weights = gauss_legendre_tensor_points(smooth_order, bounds=bounds)
-    density = evaluate_polynomial_2d(coeffs, xx, yy)
+    density = evaluate_laplace2d_source_mode(
+        q_order,
+        mode_index,
+        xx,
+        yy,
+        bounds=bounds,
+    )
     kernel = laplace2d_smooth_kernel(xx - target[0], yy - target[1], config)
     return float(np.dot(weights, density * kernel))
 
 
 def laplace2d_heat_smooth_gauss_integral(
-    coeffs,
+    q_order,
+    mode_index,
     target,
     config,
     smooth_order,
@@ -670,13 +671,20 @@ def laplace2d_heat_smooth_gauss_integral(
     """Evaluate the heat-smoothed contribution by tensor-product Gauss."""
 
     xx, yy, weights = gauss_legendre_tensor_points(smooth_order, bounds=bounds)
-    density = evaluate_polynomial_2d(coeffs, xx, yy)
+    density = evaluate_laplace2d_source_mode(
+        q_order,
+        mode_index,
+        xx,
+        yy,
+        bounds=bounds,
+    )
     kernel = laplace2d_heat_smooth_kernel(xx - target[0], yy - target[1], config)
     return float(np.dot(weights, density * kernel))
 
 
 def laplace2d_dmk_split_integral(
-    coeffs,
+    q_order,
+    mode_index,
     target,
     config,
     expansion_order,
@@ -701,16 +709,19 @@ def laplace2d_dmk_split_integral(
 
     if relation == "inside":
         local_value = laplace2d_local_expansion_integral(
-            coeffs,
+            q_order,
+            mode_index,
             target=target,
             expansion_order=expansion_order,
             config=config,
+            bounds=bounds,
         )
     else:
         local_value = 0.0
 
     smooth_value = laplace2d_smooth_gauss_integral(
-        coeffs,
+        q_order,
+        mode_index,
         target=target,
         config=config,
         smooth_order=smooth_order,
@@ -726,7 +737,8 @@ def laplace2d_dmk_split_integral(
 
 
 def laplace2d_heat_split_integral(
-    coeffs,
+    q_order,
+    mode_index,
     target,
     config,
     expansion_order,
@@ -756,16 +768,19 @@ def laplace2d_heat_split_integral(
 
     if relation == "tail-contained":
         local_value = laplace2d_heat_local_expansion_integral(
-            coeffs,
+            q_order,
+            mode_index,
             target=target,
             expansion_order=expansion_order,
             config=effective_config,
+            bounds=bounds,
         )
     else:
         local_value = 0.0
 
     smooth_value = laplace2d_heat_smooth_gauss_integral(
-        coeffs,
+        q_order,
+        mode_index,
         target=target,
         config=effective_config,
         smooth_order=smooth_order,
@@ -781,7 +796,8 @@ def laplace2d_heat_split_integral(
 
 
 def laplace2d_full_gauss_integral(
-    coeffs,
+    q_order,
+    mode_index,
     target,
     quad_order,
     bounds=((0.0, 1.0), (0.0, 1.0)),
@@ -792,7 +808,14 @@ def laplace2d_full_gauss_integral(
     r = np.sqrt((xx - target[0]) ** 2 + (yy - target[1]) ** 2)
     if np.any(r == 0):
         raise ValueError("full Gauss reference hit the singular target point")
-    integrand = evaluate_polynomial_2d(coeffs, xx, yy) * laplace2d_kernel_radius(r)
+    density = evaluate_laplace2d_source_mode(
+        q_order,
+        mode_index,
+        xx,
+        yy,
+        bounds=bounds,
+    )
+    integrand = density * laplace2d_kernel_radius(r)
     return float(np.dot(weights, integrand))
 
 
@@ -809,7 +832,6 @@ def sweep_laplace2d_dmk_split(
 ):
     """Sweep split parameters for one 2D Laplace table entry."""
 
-    coeffs = tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = tensor_gauss_point(q_order, target_index)
     sigmas = tuple(sigmas)
     expansion_orders = tuple(
@@ -832,7 +854,8 @@ def sweep_laplace2d_dmk_split(
             for smooth_order in smooth_orders:
                 try:
                     result = laplace2d_dmk_split_integral(
-                        coeffs,
+                        q_order,
+                        mode_index,
                         target=target,
                         config=config,
                         expansion_order=expansion_order,
@@ -882,7 +905,6 @@ def sweep_laplace2d_heat_split(
 ):
     """Sweep heat-kernel split parameters for one 2D Laplace table entry."""
 
-    coeffs = tensor_lagrange_mode_coefficients(q_order, mode_index)
     target = tensor_gauss_point(q_order, target_index)
     sigmas = tuple(sigmas)
     expansion_orders = tuple(
@@ -901,7 +923,8 @@ def sweep_laplace2d_heat_split(
             for smooth_order in smooth_orders:
                 try:
                     result = laplace2d_heat_split_integral(
-                        coeffs,
+                        q_order,
+                        mode_index,
                         target=target,
                         config=config,
                         expansion_order=expansion_order,

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -51,6 +51,7 @@ from volumential.expansion_wrangler_interface import (
     ExpansionWranglerInterface,
     TreeIndependentDataForWranglerInterface,
 )
+from volumential.lagrange import barycentric_lagrange_weights
 from volumential.nearfield_potential_table import NearFieldInteractionTable
 
 
@@ -79,15 +80,13 @@ def _gauss_legendre_nodes_and_weights(order):
 
 
 def _barycentric_interp_matrix(source_nodes, target_nodes):
-    from scipy.interpolate import BarycentricInterpolator as Interpolator
-
     source_nodes = np.asarray(source_nodes, dtype=np.float64)
     target_nodes = np.asarray(target_nodes, dtype=np.float64)
 
     if source_nodes.size == 1:
         return np.ones((target_nodes.size, 1), dtype=np.float64)
 
-    weights = np.asarray(Interpolator(xi=source_nodes, yi=None).wi, dtype=np.float64)
+    weights = barycentric_lagrange_weights(source_nodes)
     interp_mat = np.empty((target_nodes.size, source_nodes.size), dtype=np.float64)
 
     for i, x_tgt in enumerate(target_nodes):

--- a/volumential/lagrange.py
+++ b/volumential/lagrange.py
@@ -1,0 +1,206 @@
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+__doc__ = """Stable Lagrange basis evaluation helpers."""
+
+import numpy as np
+
+
+def _validate_integer_order(order, name, minimum):
+    if isinstance(order, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer, got {order!r}")
+
+    try:
+        order_int = int(order)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer, got {order!r}") from exc
+
+    if order_int != order:
+        raise ValueError(f"{name} must be an integer, got {order!r}")
+    if order_int < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {order!r}")
+
+    return order_int
+
+
+def barycentric_lagrange_weights(nodes):
+    """Return first-kind barycentric weights for distinct interpolation nodes."""
+
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if nodes.ndim != 1:
+        raise ValueError("nodes must be one-dimensional")
+
+    diffs = nodes[:, np.newaxis] - nodes[np.newaxis, :]
+    np.fill_diagonal(diffs, 1.0)
+    if np.any(diffs == 0):
+        raise ValueError("nodes must be distinct")
+
+    return 1.0 / np.prod(diffs, axis=1)
+
+
+def evaluate_lagrange_basis_1d(nodes, index, x, weights=None):
+    """Evaluate one Lagrange basis function with the barycentric formula."""
+
+    index = _validate_integer_order(index, "index", minimum=0)
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if index < 0 or index >= nodes.size:
+        raise ValueError(f"basis index {index} outside node set of size {nodes.size}")
+    if weights is None:
+        weights = barycentric_lagrange_weights(nodes)
+    else:
+        weights = np.asarray(weights, dtype=np.float64)
+        if weights.shape != nodes.shape:
+            raise ValueError("weights must have the same shape as nodes")
+
+    x_arr = np.asarray(x, dtype=np.float64)
+    diffs = x_arr[..., np.newaxis] - nodes
+    flat_diffs = diffs.reshape(-1, nodes.size)
+    exact_node = flat_diffs == 0.0
+    exact_row = np.any(exact_node, axis=1)
+    flat_result = np.empty(flat_diffs.shape[0], dtype=np.float64)
+
+    if np.any(exact_row):
+        flat_result[exact_row] = exact_node[exact_row, index]
+    if np.any(~exact_row):
+        terms = weights / flat_diffs[~exact_row]
+        flat_result[~exact_row] = terms[:, index] / np.sum(terms, axis=1)
+
+    result = flat_result.reshape(x_arr.shape)
+    if np.isscalar(x):
+        return float(result)
+    return result
+
+
+def evaluate_tensor_lagrange_mode(nodes_by_axis, mode_axes, coords, weights_by_axis=None):
+    """Evaluate a tensor-product Lagrange mode using barycentric form."""
+
+    if len(nodes_by_axis) != len(mode_axes) or len(coords) != len(mode_axes):
+        raise ValueError("nodes, mode axes, and coordinates must have matching dims")
+    if weights_by_axis is None:
+        weights_by_axis = [None] * len(mode_axes)
+    elif len(weights_by_axis) != len(mode_axes):
+        raise ValueError("weights and mode axes must have matching dimensions")
+
+    result = None
+    for nodes, index, coord, weights in zip(
+        nodes_by_axis,
+        mode_axes,
+        coords,
+        weights_by_axis,
+    ):
+        axis_values = evaluate_lagrange_basis_1d(nodes, index, coord, weights=weights)
+        if result is None:
+            result = axis_values
+        else:
+            result = result * axis_values
+
+    return result
+
+
+def lagrange_basis_shifted_coefficients(nodes, index, center, max_order=None):
+    """Return coefficients of one basis in powers of ``x-center``."""
+
+    index = _validate_integer_order(index, "index", minimum=0)
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if nodes.ndim != 1:
+        raise ValueError("nodes must be one-dimensional")
+    if index < 0 or index >= nodes.size:
+        raise ValueError(f"basis index {index} outside node set of size {nodes.size}")
+    if max_order is not None:
+        max_order = _validate_integer_order(max_order, "max_order", minimum=0)
+
+    roots = np.delete(nodes, index)
+    coeffs = np.polynomial.polynomial.polyfromroots(roots - center)
+    coeffs = coeffs / np.prod(nodes[index] - roots)
+    if max_order is not None:
+        coeffs = coeffs[: max_order + 1]
+    return coeffs
+
+
+def tensor_lagrange_mode_shifted_coefficients(
+    nodes_by_axis,
+    mode_axes,
+    center,
+    max_total_order=None,
+):
+    """Return target-centered coefficients for a tensor Lagrange mode."""
+
+    if len(nodes_by_axis) != len(mode_axes) or len(center) != len(mode_axes):
+        raise ValueError("nodes, mode axes, and center must have matching dims")
+    if max_total_order is not None:
+        max_total_order = _validate_integer_order(
+            max_total_order,
+            "max_total_order",
+            minimum=0,
+        )
+
+    axis_coeffs = [
+        lagrange_basis_shifted_coefficients(
+            nodes,
+            index,
+            axis_center,
+            max_order=max_total_order,
+        )
+        for nodes, index, axis_center in zip(nodes_by_axis, mode_axes, center)
+    ]
+
+    coeffs = axis_coeffs[0]
+    for axis_coeff in axis_coeffs[1:]:
+        coeffs = np.multiply.outer(coeffs, axis_coeff)
+
+    if max_total_order is not None:
+        for idx in np.ndindex(coeffs.shape):
+            if sum(idx) > max_total_order:
+                coeffs[idx] = 0.0
+
+    return coeffs
+
+
+def legendre_gauss_lagrange_data(order, a=0.0, b=1.0):
+    """Return Legendre-Gauss nodes and barycentric weights on ``[a, b]``."""
+
+    order = _validate_integer_order(order, "order", minimum=1)
+    nodes, _ = np.polynomial.legendre.leggauss(order)
+    center = 0.5 * (a + b)
+    radius = 0.5 * (b - a)
+    nodes = center + radius * nodes
+    return nodes, barycentric_lagrange_weights(nodes)
+
+
+def mode_index_to_axes(mode_index, q_order, dim):
+    """Return tensor-product axis indices for a flat mode index."""
+
+    mode_index = _validate_integer_order(mode_index, "mode_index", minimum=0)
+    q_order = _validate_integer_order(q_order, "q_order", minimum=1)
+    dim = _validate_integer_order(dim, "dim", minimum=1)
+    if mode_index >= q_order**dim:
+        raise ValueError(f"mode_index must be in [0, {q_order**dim}), got {mode_index}")
+
+    axes = np.empty(dim, dtype=np.int32)
+    residual = mode_index
+    for axis in range(dim - 1, -1, -1):
+        axes[axis] = residual % q_order
+        residual //= q_order
+    return axes
+
+
+# vim: foldmethod=marker:filetype=python

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass
 from functools import partial
 
 import numpy as np
-from scipy.interpolate import BarycentricInterpolator as Interpolator
 
 import loopy as lp
 import pyopencl as cl
@@ -35,6 +34,10 @@ from pytools import memoize_method
 
 import volumential.list1_gallery as gallery
 import volumential.singular_integral_2d as squad
+from volumential.lagrange import (
+    barycentric_lagrange_weights,
+    evaluate_lagrange_basis_1d,
+)
 
 
 logger = logging.getLogger("NearFieldInteractionTable")
@@ -693,12 +696,7 @@ class NearFieldInteractionTable:
         )
         assert len(xi) == self.quad_order
 
-        yi = []
-        for d in range(self.dim):
-            yi.append(np.zeros(self.quad_order, dtype=self.dtype))
-            yi[d][idx[d]] = 1
-
-        axis_interp = [Interpolator(xi, yi[d]) for d in range(self.dim)]
+        bary_w = barycentric_lagrange_weights(xi)
 
         def mode(*coords):
             assert len(coords) == self.dim
@@ -706,11 +704,7 @@ class NearFieldInteractionTable:
             is_scalar = all(np.asarray(coord).ndim == 0 for coord in coords)
             fvals = np.ones(coords0.shape, dtype=self.dtype)
             for d, coord in zip(range(self.dim), coords):
-                val = axis_interp[d](np.array(coord))
-                if is_scalar:
-                    val = np.asarray(val)
-                    if val.size == 1:
-                        val = val.item()
+                val = evaluate_lagrange_basis_1d(xi, idx[d], coord, weights=bary_w)
                 fvals = np.multiply(fvals, val)
             if is_scalar and fvals.size == 1:
                 return fvals.item()
@@ -742,12 +736,7 @@ class NearFieldInteractionTable:
         xi = np.array([p[self.dim - 1] for p in self.q_points[: self.quad_order]])
         assert len(xi) == self.quad_order
 
-        yi = []
-        for d in range(self.dim):
-            yi.append(np.zeros(self.quad_order, dtype=self.dtype))
-            yi[d][idx[d]] = 1
-
-        axis_interp = [Interpolator(xi, yi[d]) for d in range(self.dim)]
+        bary_w = barycentric_lagrange_weights(xi)
 
         def _to_source_box_coords(coord):
             coord = np.asarray(coord)
@@ -764,11 +753,12 @@ class NearFieldInteractionTable:
             is_scalar = all(np.asarray(coord).ndim == 0 for coord in coords)
             fvals = np.ones(coords0.shape, dtype=self.dtype)
             for d, coord in zip(range(self.dim), coords):
-                val = axis_interp[d](_to_source_box_coords(coord))
-                if is_scalar:
-                    val = np.asarray(val)
-                    if val.size == 1:
-                        val = val.item()
+                val = evaluate_lagrange_basis_1d(
+                    xi,
+                    idx[d],
+                    _to_source_box_coords(coord),
+                    weights=bary_w,
+                )
                 fvals = np.multiply(fvals, val)
             if is_scalar and fvals.size == 1:
                 return fvals.item()
@@ -1056,12 +1046,7 @@ class NearFieldInteractionTable:
             [p[self.dim - 1] for p in self.q_points[: self.quad_order]],
             dtype=geom_dtype,
         )
-        bw = np.ones(self.quad_order, dtype=geom_dtype)
-        for i in range(self.quad_order):
-            for j in range(self.quad_order):
-                if i != j:
-                    bw[i] /= xi[i] - xi[j]
-        return xi, bw.astype(geom_dtype)
+        return xi, barycentric_lagrange_weights(xi).astype(geom_dtype)
 
     def _get_invariant_entry_info(self):
         return self._get_orbit_canonical_info()

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -67,6 +67,7 @@ from volumential.expansion_wrangler_fpnd import (
     FPNDSumpyExpansionWrangler,
 )
 from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
+from volumential.lagrange import barycentric_lagrange_weights
 
 
 logger = logging.getLogger(__name__)
@@ -1195,20 +1196,11 @@ def compute_barycentric_lagrange_params(q_order):
     q_points_1d = (q_points_1d + 1) * 0.5
     q_weights_1d *= 0.5
 
+    q_points_1d = np.asarray(q_points_1d, dtype=np.float64)
     if q_order == 1:
-        return (
-            np.asarray(q_points_1d, dtype=np.float64),
-            np.ones(1, dtype=np.float64),
-        )
+        return q_points_1d, np.ones(1, dtype=np.float64)
 
-    # interpolation weights for barycentric Lagrange interpolation
-    from scipy.interpolate import BarycentricInterpolator as Interpolator
-
-    interp = Interpolator(xi=q_points_1d, yi=None)
-    interp_weights = interp.wi
-    interp_points = interp.xi
-
-    return (interp_points, interp_weights)
+    return q_points_1d, barycentric_lagrange_weights(q_points_1d)
 
 
 def _infer_tree_local_interp_points_1d(tree, traversal, q_order, queue):
@@ -1522,11 +1514,8 @@ def interpolate_volume_potential(
         blpoints = np.asarray(interp_points_1d, dtype=np.float64)
         blweights = np.ones(1, dtype=np.float64)
     else:
-        from scipy.interpolate import BarycentricInterpolator as Interpolator
-
-        interp = Interpolator(xi=interp_points_1d, yi=None)
-        blpoints = interp.xi
-        blweights = interp.wi
+        blpoints = np.asarray(interp_points_1d, dtype=np.float64)
+        blweights = barycentric_lagrange_weights(blpoints)
     blpoints = cl.array.to_device(queue, blpoints)
     blweights = cl.array.to_device(queue, blweights)
     use_mode_to_source_ids = bool(kwargs.pop("use_mode_to_source_ids", False))


### PR DESCRIPTION
## Summary

- Add shared barycentric Lagrange helpers for weights, basis evaluation, mode axes, and target-centered local coefficients.
- Replace DMK split prototype source-mode evaluation with barycentric mode evaluation and remove global monomial Lagrange coefficient paths.
- Route nearfield table modes, batched Duffy loopy setup weights, volume-FMM loopy interpolation weights, and interpolation resampling through the shared helper.
- Add high-order nodal exactness and shared-weight regressions.

## Notes

This is stacked on `feat/dmk-table-build-split` / PR #105. It targets that branch so the stability fix remains reviewable separately.

## Verification

- `rtk uv run pytest test/test_dmk_split.py test/test_import.py test/test_version.py`
- `rtk uv run python -m compileall volumential/dmk_split.py volumential/lagrange.py volumential/nearfield_potential_table.py volumential/volume_fmm.py volumential/expansion_wrangler_fpnd.py`
- `rtk git diff --check`
- Direct no-CL barycentric helper check via `uv run python`

Local Ruff is unavailable because `uv run ruff` cannot spawn `ruff`. Local pytest collection for the nearfield/volume modules is blocked by missing OpenCL platform discovery; the pure paths added there were verified by direct Python checks and should be covered by CI.
