### PR TITLE
fix: centralize Lagrange interpolation weights

### DIFF
--- a/test/test_lagrange.py
+++ b/test/test_lagrange.py
@@ -1,0 +1,50 @@
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+
+from volumential import lagrange
+
+
+def test_high_order_weights_remain_finite_after_float32_cast():
+    q_order = 512
+    nodes = 0.5 * (np.polynomial.legendre.leggauss(q_order)[0] + 1.0)
+
+    weights = lagrange.barycentric_lagrange_weights(nodes)
+    weights32 = weights.astype(np.float32)
+
+    assert np.all(np.isfinite(weights))
+    assert np.all(np.isfinite(weights32))
+    np.testing.assert_allclose(
+        np.max(np.abs(weights)), 1.0, rtol=0.0, atol=0.0
+    )
+
+    terms = weights32 / (np.float32(0.5) - nodes.astype(np.float32))
+    basis_values = terms / np.sum(terms)
+
+    assert np.all(np.isfinite(basis_values))
+    np.testing.assert_allclose(
+        np.sum(basis_values), 1.0, rtol=1.0e-6, atol=1.0e-6
+    )
+
+
+# vim: foldmethod=marker:filetype=python

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -39,6 +39,7 @@ if (
     )
 
 import volumential.nearfield_potential_table as npt
+from volumential import lagrange
 from volumential.table_manager import ConstantKernel
 
 
@@ -61,6 +62,30 @@ def _make_build_queue_or_skip():
             return cl.CommandQueue(cl.Context([devices[0]]))
 
     pytest.skip("No OpenCL devices available for table builds")
+
+
+def _make_legendre_table_without_cl(q_order, dim):
+    nodes = np.polynomial.legendre.leggauss(q_order)[0]
+    nodes = 0.5 * (nodes + 1.0)
+
+    table = npt.NearFieldInteractionTable.__new__(npt.NearFieldInteractionTable)
+    table.quad_order = q_order
+    table.dim = dim
+    table.n_q_points = q_order**dim
+    table.source_box_extent = 1.0
+    table.dtype = np.float64
+
+    if dim == 1:
+        q_points = [(x,) for x in nodes]
+    elif dim == 2:
+        q_points = [(x, y) for x in nodes for y in nodes]
+    elif dim == 3:
+        q_points = [(x, y, z) for x in nodes for y in nodes for z in nodes]
+    else:
+        raise NotImplementedError("dimension %d not supported" % dim)
+
+    table.q_points = np.asarray(q_points, dtype=np.float64)
+    return table
 
 
 def test_const_order_1():
@@ -236,6 +261,33 @@ def test_modes_cheb_coeffs():
     drive_test_modes_cheb_coeffs(3, 5, 5)
     drive_test_modes_cheb_coeffs(3, 5, 10)
     drive_test_modes_cheb_coeffs(3, 10, 10)
+
+
+def test_high_order_modes_are_barycentric_at_nodes():
+    q_order = 16
+    dim = 2
+    mode_index = 7 * q_order + 9
+    table = _make_legendre_table_without_cl(q_order, dim)
+
+    mode = table.get_template_mode(mode_index)
+    values = np.asarray([mode(*qpt) for qpt in table.q_points])
+    expected = np.zeros(q_order**dim)
+    expected[mode_index] = 1.0
+
+    np.testing.assert_array_equal(values, expected)
+
+
+def test_nearfield_batched_duffy_uses_shared_barycentric_weights():
+    table = _make_legendre_table_without_cl(q_order=16, dim=2)
+
+    xi, weights = table._get_barycentric_data()
+
+    np.testing.assert_allclose(
+        weights,
+        lagrange.barycentric_lagrange_weights(xi),
+        rtol=0.0,
+        atol=0.0,
+    )
 
 
 @pytest.mark.parametrize("q_order", [1, 2, 3, 5, 8])

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -123,6 +123,25 @@ def test_barycentric_interp_matrix_is_exact_at_source_nodes():
     np.testing.assert_allclose(interp, np.eye(source_nodes.size), rtol=0.0, atol=0.0)
 
 
+def test_barycentric_interp_matrix_matches_shared_near_node_behavior():
+    from volumential import lagrange
+    from volumential.expansion_wrangler_fpnd import _barycentric_interp_matrix
+
+    source_nodes = np.polynomial.legendre.leggauss(16)[0]
+    source_nodes = 0.5 * (source_nodes + 1.0)
+    target_node = np.nextafter(source_nodes[7], source_nodes[8])
+
+    interp = _barycentric_interp_matrix(source_nodes, np.array([target_node]))
+    expected = np.array(
+        [
+            lagrange.evaluate_lagrange_basis_1d(source_nodes, i, target_node)
+            for i in range(source_nodes.size)
+        ]
+    )
+
+    np.testing.assert_allclose(interp[0], expected, rtol=1.0e-14, atol=1.0e-14)
+
+
 def test_list1_gallery_includes_mixed_source_levels():
     from volumential.list1_gallery import generate_interactions
 

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -92,6 +92,37 @@ def test_interpolation_target_coverage_reports_missing_targets():
         )
 
 
+def test_volume_fmm_loopy_interpolation_uses_shared_barycentric_weights():
+    from volumential import lagrange
+    from volumential.volume_fmm import compute_barycentric_lagrange_params
+
+    q_order = 16
+    nodes, weights = compute_barycentric_lagrange_params(q_order)
+
+    np.testing.assert_allclose(
+        weights,
+        lagrange.barycentric_lagrange_weights(nodes),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+    values = lagrange.evaluate_lagrange_basis_1d(nodes, 7, nodes, weights=weights)
+    expected = np.zeros(q_order)
+    expected[7] = 1.0
+    np.testing.assert_array_equal(values, expected)
+
+
+def test_barycentric_interp_matrix_is_exact_at_source_nodes():
+    from volumential.expansion_wrangler_fpnd import _barycentric_interp_matrix
+
+    source_nodes = np.polynomial.legendre.leggauss(16)[0]
+    source_nodes = 0.5 * (source_nodes + 1.0)
+
+    interp = _barycentric_interp_matrix(source_nodes, source_nodes)
+
+    np.testing.assert_allclose(interp, np.eye(source_nodes.size), rtol=0.0, atol=0.0)
+
+
 def test_list1_gallery_includes_mixed_source_levels():
     from volumential.list1_gallery import generate_interactions
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -115,7 +115,7 @@ def _barycentric_interp_matrix(source_nodes, target_nodes):
 
     for i, x_tgt in enumerate(target_nodes):
         diff = x_tgt - source_nodes
-        hit = np.where(np.abs(diff) < 1.0e-15)[0]
+        hit = np.where(diff == 0.0)[0]
         if hit.size:
             interp_mat[i, :] = 0.0
             interp_mat[i, int(hit[0])] = 1.0

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -52,6 +52,7 @@ from volumential.expansion_wrangler_interface import (
     ExpansionWranglerInterface,
     TreeIndependentDataForWranglerInterface,
 )
+from volumential.lagrange import barycentric_lagrange_weights
 from volumential.nearfield_potential_table import NearFieldInteractionTable
 
 
@@ -103,15 +104,13 @@ def _gauss_legendre_nodes_and_weights(order):
 
 
 def _barycentric_interp_matrix(source_nodes, target_nodes):
-    from scipy.interpolate import BarycentricInterpolator as Interpolator
-
     source_nodes = np.asarray(source_nodes, dtype=np.float64)
     target_nodes = np.asarray(target_nodes, dtype=np.float64)
 
     if source_nodes.size == 1:
         return np.ones((target_nodes.size, 1), dtype=np.float64)
 
-    weights = np.asarray(Interpolator(xi=source_nodes, yi=None).wi, dtype=np.float64)
+    weights = barycentric_lagrange_weights(source_nodes)
     interp_mat = np.empty((target_nodes.size, source_nodes.size), dtype=np.float64)
 
     for i, x_tgt in enumerate(target_nodes):

--- a/volumential/lagrange.py
+++ b/volumential/lagrange.py
@@ -1,0 +1,93 @@
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+__doc__ = """Stable Lagrange basis evaluation helpers."""
+
+import numpy as np
+
+
+def _validate_integer_order(order, name, minimum):
+    if isinstance(order, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer, got {order!r}")
+
+    try:
+        order_int = int(order)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer, got {order!r}") from exc
+
+    if order_int != order:
+        raise ValueError(f"{name} must be an integer, got {order!r}")
+    if order_int < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {order!r}")
+
+    return order_int
+
+
+def barycentric_lagrange_weights(nodes):
+    """Return first-kind barycentric weights for distinct interpolation nodes."""
+
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if nodes.ndim != 1:
+        raise ValueError("nodes must be one-dimensional")
+
+    diffs = nodes[:, np.newaxis] - nodes[np.newaxis, :]
+    np.fill_diagonal(diffs, 1.0)
+    if np.any(diffs == 0):
+        raise ValueError("nodes must be distinct")
+
+    return 1.0 / np.prod(diffs, axis=1)
+
+
+def evaluate_lagrange_basis_1d(nodes, index, x, weights=None):
+    """Evaluate one Lagrange basis function with the barycentric formula."""
+
+    index = _validate_integer_order(index, "index", minimum=0)
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if index >= nodes.size:
+        raise ValueError(f"basis index {index} outside node set of size {nodes.size}")
+    if weights is None:
+        weights = barycentric_lagrange_weights(nodes)
+    else:
+        weights = np.asarray(weights, dtype=np.float64)
+        if weights.shape != nodes.shape:
+            raise ValueError("weights must have the same shape as nodes")
+
+    x_arr = np.asarray(x, dtype=np.float64)
+    diffs = x_arr[..., np.newaxis] - nodes
+    flat_diffs = diffs.reshape(-1, nodes.size)
+    exact_node = flat_diffs == 0.0
+    exact_row = np.any(exact_node, axis=1)
+    flat_result = np.empty(flat_diffs.shape[0], dtype=np.float64)
+
+    if np.any(exact_row):
+        flat_result[exact_row] = exact_node[exact_row, index]
+    if np.any(~exact_row):
+        terms = weights / flat_diffs[~exact_row]
+        flat_result[~exact_row] = terms[:, index] / np.sum(terms, axis=1)
+
+    result = flat_result.reshape(x_arr.shape)
+    if np.isscalar(x):
+        return float(result)
+    return result
+
+
+# vim: foldmethod=marker:filetype=python

--- a/volumential/lagrange.py
+++ b/volumential/lagrange.py
@@ -54,7 +54,9 @@ def barycentric_lagrange_weights(nodes):
     if np.any(diffs == 0):
         raise ValueError("nodes must be distinct")
 
-    return 1.0 / np.prod(diffs, axis=1)
+    signs = np.prod(np.sign(diffs), axis=1)
+    log_abs_weights = -np.sum(np.log(np.abs(diffs)), axis=1)
+    return signs * np.exp(log_abs_weights - np.max(log_abs_weights))
 
 
 def evaluate_lagrange_basis_1d(nodes, index, x, weights=None):

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass
 from functools import partial
 
 import numpy as np
-from scipy.interpolate import BarycentricInterpolator as Interpolator
 
 import loopy as lp
 import pyopencl as cl
@@ -35,6 +34,10 @@ from pytools import memoize_method
 
 import volumential.list1_gallery as gallery
 import volumential.singular_integral_2d as squad
+from volumential.lagrange import (
+    barycentric_lagrange_weights,
+    evaluate_lagrange_basis_1d,
+)
 
 
 logger = logging.getLogger("NearFieldInteractionTable")
@@ -708,12 +711,7 @@ class NearFieldInteractionTable:
         )
         assert len(xi) == self.quad_order
 
-        yi = []
-        for d in range(self.dim):
-            yi.append(np.zeros(self.quad_order, dtype=self.dtype))
-            yi[d][idx[d]] = 1
-
-        axis_interp = [Interpolator(xi, yi[d]) for d in range(self.dim)]
+        bary_w = barycentric_lagrange_weights(xi)
 
         def mode(*coords):
             assert len(coords) == self.dim
@@ -721,11 +719,7 @@ class NearFieldInteractionTable:
             is_scalar = all(np.asarray(coord).ndim == 0 for coord in coords)
             fvals = np.ones(coords0.shape, dtype=self.dtype)
             for d, coord in zip(range(self.dim), coords):
-                val = axis_interp[d](np.array(coord))
-                if is_scalar:
-                    val = np.asarray(val)
-                    if val.size == 1:
-                        val = val.item()
+                val = evaluate_lagrange_basis_1d(xi, idx[d], coord, weights=bary_w)
                 fvals = np.multiply(fvals, val)
             if is_scalar and fvals.size == 1:
                 return fvals.item()
@@ -757,12 +751,7 @@ class NearFieldInteractionTable:
         xi = np.array([p[self.dim - 1] for p in self.q_points[: self.quad_order]])
         assert len(xi) == self.quad_order
 
-        yi = []
-        for d in range(self.dim):
-            yi.append(np.zeros(self.quad_order, dtype=self.dtype))
-            yi[d][idx[d]] = 1
-
-        axis_interp = [Interpolator(xi, yi[d]) for d in range(self.dim)]
+        bary_w = barycentric_lagrange_weights(xi)
 
         def _to_source_box_coords(coord):
             coord = np.asarray(coord)
@@ -779,11 +768,12 @@ class NearFieldInteractionTable:
             is_scalar = all(np.asarray(coord).ndim == 0 for coord in coords)
             fvals = np.ones(coords0.shape, dtype=self.dtype)
             for d, coord in zip(range(self.dim), coords):
-                val = axis_interp[d](_to_source_box_coords(coord))
-                if is_scalar:
-                    val = np.asarray(val)
-                    if val.size == 1:
-                        val = val.item()
+                val = evaluate_lagrange_basis_1d(
+                    xi,
+                    idx[d],
+                    _to_source_box_coords(coord),
+                    weights=bary_w,
+                )
                 fvals = np.multiply(fvals, val)
             if is_scalar and fvals.size == 1:
                 return fvals.item()
@@ -1071,12 +1061,7 @@ class NearFieldInteractionTable:
             [p[self.dim - 1] for p in self.q_points[: self.quad_order]],
             dtype=geom_dtype,
         )
-        bw = np.ones(self.quad_order, dtype=geom_dtype)
-        for i in range(self.quad_order):
-            for j in range(self.quad_order):
-                if i != j:
-                    bw[i] /= xi[i] - xi[j]
-        return xi, bw.astype(geom_dtype)
+        return xi, barycentric_lagrange_weights(xi).astype(geom_dtype)
 
     def _get_invariant_entry_info(self):
         return self._get_orbit_canonical_info()

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -67,6 +67,7 @@ from volumential.expansion_wrangler_fpnd import (
     FPNDSumpyExpansionWrangler,
 )
 from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
+from volumential.lagrange import barycentric_lagrange_weights
 
 
 logger = logging.getLogger(__name__)
@@ -1195,20 +1196,11 @@ def compute_barycentric_lagrange_params(q_order):
     q_points_1d = (q_points_1d + 1) * 0.5
     q_weights_1d *= 0.5
 
+    q_points_1d = np.asarray(q_points_1d, dtype=np.float64)
     if q_order == 1:
-        return (
-            np.asarray(q_points_1d, dtype=np.float64),
-            np.ones(1, dtype=np.float64),
-        )
+        return q_points_1d, np.ones(1, dtype=np.float64)
 
-    # interpolation weights for barycentric Lagrange interpolation
-    from scipy.interpolate import BarycentricInterpolator as Interpolator
-
-    interp = Interpolator(xi=q_points_1d, yi=None)
-    interp_weights = interp.wi
-    interp_points = interp.xi
-
-    return (interp_points, interp_weights)
+    return q_points_1d, barycentric_lagrange_weights(q_points_1d)
 
 
 def _infer_tree_local_interp_points_1d(tree, traversal, q_order, queue):
@@ -1522,11 +1514,8 @@ def interpolate_volume_potential(
         blpoints = np.asarray(interp_points_1d, dtype=np.float64)
         blweights = np.ones(1, dtype=np.float64)
     else:
-        from scipy.interpolate import BarycentricInterpolator as Interpolator
-
-        interp = Interpolator(xi=interp_points_1d, yi=None)
-        blpoints = interp.xi
-        blweights = interp.wi
+        blpoints = np.asarray(interp_points_1d, dtype=np.float64)
+        blweights = barycentric_lagrange_weights(blpoints)
     blpoints = cl.array.to_device(queue, blpoints)
     blweights = cl.array.to_device(queue, blweights)
     use_mode_to_source_ids = bool(kwargs.pop("use_mode_to_source_ids", False))


### PR DESCRIPTION
## Summary

- Add shared barycentric Lagrange helpers for stable weights and 1D basis evaluation.
- Scale shared barycentric weights by log-magnitude so high-order nodes keep finite downstream `float32` casts without changing barycentric ratios.
- Route nearfield table mode evaluation, batched Duffy loopy weight setup, volume-FMM loopy interpolation weights, and interpolation resampling through the shared helper.
- Remove duplicated SciPy `BarycentricInterpolator` weight construction and manual barycentric weight loops.
- Add high-order nodal exactness, exact-node interpolation, and shared-weight regressions.

## Notes

This targets `main` as a parallel production improvement. It intentionally excludes the experimental DMK split prototype changes from PR #105/#106.

## High-Order Weight Scaling Data

Comparison script computes old raw reciprocal-product weights and the new scaled weights on Gauss-Legendre nodes mapped to `[0, 1]`. Partition errors are `abs(sum(L_i(x)) - 1)` at an off-node target. Low-order behavior is unchanged, while the scaled path prevents `float32` overflow and `NaN` basis values at high order.

| q | raw max | scaled max | raw float32 finite? | scaled float32 finite? | raw64 partition err | scaled64 partition err | raw32 partition err | scaled32 partition err |
|---:|---:|---:|:---:|:---:|---:|---:|---:|---:|
| 8 | 2.69e+03 | 1.00e+00 | yes | yes | 0.00e+00 | 1.11e-16 | 0.00e+00 | 0.00e+00 |
| 16 | 9.21e+07 | 1.00e+00 | yes | yes | 0.00e+00 | 0.00e+00 | 5.96e-08 | 5.96e-08 |
| 64 | 1.87e+36 | 1.00e+00 | yes | yes | 0.00e+00 | 2.22e-16 | 0.00e+00 | 5.96e-08 |
| 128 | 3.19e+74 | 1.00e+00 | no | yes | 2.22e-16 | 4.44e-16 | NaN | 2.38e-07 |
| 256 | 1.85e+151 | 1.00e+00 | no | yes | 2.22e-16 | 0.00e+00 | NaN | 0.00e+00 |
| 512 | 1.24e+305 | 1.00e+00 | no | yes | 2.22e-16 | 2.22e-16 | NaN | 0.00e+00 |

## Nearfield Table-Build Accuracy

These rows exercise the actual fused Duffy nearfield table-builder on sampled 2D Laplace table entries, using ordered Gauss-Legendre source nodes and comparing the built entry against an independent tensor Gauss-Legendre reference for the same Lagrange basis mode. Both columns use the barycentric formula in the table builder: `raw` means the old unnormalized reciprocal-product first-kind barycentric weights, while `scaled` means this PR's log-normalized first-kind barycentric weights. The high-q stress cases use small source-box extents, where raw first-kind weights scale like `extent^(1-q)`.

`Duffy regular/radial orders` and `tensor ref order/axis` are different quadrature families, so the order numbers are not directly comparable. The tensor reference is an independent product Gauss rule with that many nodes per coordinate axis; it is not the same as the Duffy regular/radial split used by the table builder.

| q | source level | extent | Duffy regular/radial orders | tensor ref order/axis | raw weights finite? | raw weights abs err | scaled weights finite? | scaled weights abs err |
|---:|---:|---:|---:|---:|:---:|---:|:---:|---:|
| 16 | 4 | 6.25e-02 | 128 / 320 | 320 | yes | 2.03e-18 | yes | 2.04e-18 |
| 48 | 16 | 1.53e-05 | 384 / 960 | 760 | yes | 1.20e-25 | yes | 1.19e-25 |
| 64 | 16 | 1.53e-05 | 512 / 1280 | 900 | no | NaN | yes | 4.75e-20 |

The q16/q48 rows show no low/mid-order regression in the table builder. The q64 row shows the high-order failure mode: raw unscaled weights overflow during table construction and produce `NaN`, while scaled weights keep the table entry finite and near the tensor-reference floor.

## Verification

- `rtk uv run python -m compileall volumential/lagrange.py volumential/nearfield_potential_table.py volumential/volume_fmm.py volumential/expansion_wrangler_fpnd.py`
- `rtk uv run pytest test/test_import.py test/test_version.py test/test_lagrange.py`
- `rtk git diff --check`
- Raw-vs-scaled no-CL helper comparison script via `rtk uv run python`
- Nearfield table-build accuracy benchmark on `ipa` using NVIDIA H200 OpenCL, sampled fused Duffy entries, and tensor Gauss-Legendre references

Local Ruff is unavailable because `uv run ruff` cannot spawn `ruff`. Local pytest collection for the nearfield/volume modules is blocked by missing OpenCL platform discovery; the pure paths added there were verified by direct Python checks and should be covered by CI.
