### PR TITLE
feat: generate ORBIT reconstruction metadata

### DIFF
--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -18,20 +18,27 @@ Orbit canonicalization
 Online reconstruction modes
 ---------------------------
 
-Scalar full-symmetry kernels use the arithmetic path.
+Scalar full-symmetry kernels and axis-preserving derivative kernels use the
+arithmetic path.
 
 - ``case_orbit_ranks`` is stored as ``uint16[n_cases]``.
 - ``case_axis_perm``, ``case_axis_sign``, and ``case_axis_group`` are packed as
   ``uint8``/``int8`` arrays and passed as read-only List 1 kernel inputs.
+- Axis source/target derivatives additionally pass ``axis_sign_power`` so the
+  evaluator computes derivative signs analytically from the applied signed
+  permutation.
 - The evaluator decodes tensor-product source/target indices, applies the
   per-case signed permutation, resolves zero-axis flips locally, and uses a
   fixed compare-exchange sorting network for equal-absolute-value case axes.
 - The table layout is ``(canonical_case_orbit, canonical_source,
   canonical_target)`` with target index fastest. This intentionally stores some
   unused scalar layout rows to remove representative hash lookups and keep GPU
-  table accesses arithmetic and coalescing-friendly.
+  table accesses arithmetic and coalescing-friendly. Axis derivatives use the
+  same target-fastest layout and pre-apply any row-level representative sign
+  convention while packing the table values.
 
-Constrained or sign-changing kernels use the generated descriptor fallback.
+Other constrained or sign-changing kernels use the generated descriptor
+fallback.
 
 - ``transform_qpoint_map[transform, qpoint]`` and
   ``transform_case_map[transform, case]`` encode the allowed signed
@@ -53,10 +60,25 @@ preparation validates generated representative IDs and generated signs against
 ``table_entry_ids`` / ``table_entry_scales`` before the generated descriptor is
 used.
 
+GPU scheduling
+--------------
+
+The List 1 evaluator maps target boxes to a global hardware axis. The target
+point loop has a launch-known ``n_q_points`` bound and guards inactive lanes with
+``tid < n_box_targets`` so Loopy can legally schedule target work without
+data-dependent parallel bounds.
+
+``list1_target_batch_size`` controls optional target-lane batching. The default
+is ``1`` because H200 OpenCL benchmarks for 3D Laplace target derivatives showed
+one target lane per workgroup faster than a 32-lane target batch for the tested
+``q=2`` and ``q=3`` cases. Setting ``list1_target_batch_size=32`` remains useful
+for subgroup/warp experiments and keeps output bitwise identical in the covered
+benchmarks.
+
 For scalar 3D Laplace at ``q=3``, the dense online reconstruction maps contain
 ``101331`` full entries and occupy ``1215972`` bytes as ``int32`` IDs plus
 ``float64`` scales. Scalar arithmetic reconstruction reduces transferred
-metadata to less than ``2000`` bytes in the CPU descriptor test. It uses a
+metadata to ``1532`` bytes in the CPU descriptor test. It uses a
 canonical-case table layout rather than the minimal representative-only layout,
 so value bytes increase relative to ``2510`` representatives while eliminating
 the transform scan and representative hash lookup in the scalar online kernel.
@@ -65,13 +87,28 @@ Derivative kernels
 ------------------
 
 For derivative kernels, symmetry transforms can introduce sign changes.
-Volumential stores a per-entry scale map (typically ``+1`` or ``-1``) so that
-runtime reconstruction is sign-correct.
+Axis source/target derivatives, mixed axis derivatives, and axis-aligned
+directional source derivatives whose symmetry subgroup fixes the derivative axes
+use signed arithmetic reconstruction rather than a sparse sign lookup. The
+runtime sign is the product of the applied flips on derivative axes with odd
+derivative order.
 
-This applies to target-derivative kernels represented with
-``AxisTargetDerivative`` wrappers. Directional source derivatives are handled
-with sign-aware vector transforms when a fixed source direction is provided as
-``symmetry_source_direction`` on the table.
+This applies to target- and source-derivative kernels represented with
+``AxisTargetDerivative`` and ``AxisSourceDerivative`` wrappers. Directional
+source derivatives are handled with sign-aware vector transforms when a fixed
+source direction is provided as ``symmetry_source_direction`` on the table.
+Axis-aligned directional source derivatives use signed arithmetic reconstruction.
+Non-axis directional subgroups currently keep using the generated descriptor
+fallback because their allowed transforms depend on the runtime direction vector
+geometry.
+
+Odd derivative entries can be invariant under a sign-changing self-transform,
+for example when the derivative-axis case offset and both derivative-axis
+source/target coordinates are centered. These entries are mathematically zero;
+the dense signed-union oracle has an arbitrary sign convention for them. The
+signed arithmetic path counts these convention-only conflicts during payload
+preparation and keeps a deterministic arithmetic convention without sending a
+sparse sign-correction table to the device.
 
 For example, for a directional source derivative kernel:
 

--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -8,9 +8,44 @@ Orbit canonicalization
 ----------------------
 
 - A full table entry is mapped to a canonical representative entry.
-- Runtime list1 evaluation uses an index map from full entry IDs to canonical
-  entry IDs.
-- This keeps table lookup O(1) while avoiding duplicated near-field entries.
+- The dense compatibility path uses an index map from full entry IDs to
+  canonical entry IDs.
+- Generated ORBIT reconstruction avoids sending that full-entry map to the GPU
+  for symmetry-reduced tables. The List 1 evaluator instead scans the compact
+  signed-permutation descriptor, computes the representative full-entry ID in
+  registers, then resolves it through a small representative hash table.
+
+Generated online reconstruction
+-------------------------------
+
+The generated path is the intended online representation for
+symmetry-reduced tables.
+
+- ``transform_qpoint_map[transform, qpoint]`` and
+  ``transform_case_map[transform, case]`` encode the allowed signed
+  permutation group for the kernel.
+- The evaluator forms all transformed ``(source_mode, target_point, case)``
+  candidates with a fixed-size reduction and chooses the smallest
+  representative full-entry ID. Ties prefer positive transform signs and then
+  transform ID, so the rule is deterministic and warp-uniform.
+- ``representative_lookup`` maps representative full-entry IDs to compact table
+  rows. This lookup is an open-addressed hash sized during payload preparation;
+  the generated kernel uses a fixed probe count from the descriptor.
+- ``sign_lookup`` is normally empty. It is a sparse correction table for
+  derivative kernels whose stabilizer contains sign-conflicting transforms but
+  whose dense signed-union oracle has an existing convention that must be
+  preserved for bitwise metadata equivalence.
+
+The dense maps remain the construction-time oracle and fallback. Payload
+preparation validates generated representative IDs and generated signs against
+``table_entry_ids`` / ``table_entry_scales`` before the generated descriptor is
+used.
+
+For scalar 3D Laplace at ``q=3``, the dense online reconstruction maps contain
+``101331`` full entries and occupy ``1215972`` bytes as ``int32`` IDs plus
+``float64`` scales. Generated reconstruction keeps the representative values at
+``2510 * 8`` bytes and reduces reconstruction metadata to less than ``100000``
+bytes in the CPU descriptor test.
 
 Derivative kernels
 ------------------

--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -18,8 +18,8 @@ Orbit canonicalization
 Online reconstruction modes
 ---------------------------
 
-Scalar full-symmetry kernels and axis-preserving derivative kernels use the
-arithmetic path.
+Scalar full-symmetry kernels and supported axis-preserving derivative subgroups
+use the arithmetic path.
 
 - ``case_orbit_ranks`` is stored as ``uint16[n_cases]``.
 - ``case_axis_perm``, ``case_axis_sign``, and ``case_axis_group`` are packed as
@@ -27,6 +27,9 @@ arithmetic path.
 - Axis source/target derivatives additionally pass ``axis_sign_power`` so the
   evaluator computes derivative signs analytically from the applied signed
   permutation.
+- Equal-magnitude directional source derivative subgroups additionally pass the
+  source direction signs and one representative sign axis so the evaluator
+  applies the collinearity sign analytically.
 - The evaluator decodes tensor-product source/target indices, applies the
   per-case signed permutation, resolves zero-axis flips locally, and uses a
   fixed compare-exchange sorting network for equal-absolute-value case axes.
@@ -87,20 +90,21 @@ Derivative kernels
 ------------------
 
 For derivative kernels, symmetry transforms can introduce sign changes.
-Axis source/target derivatives, mixed axis derivatives, and axis-aligned
-directional source derivatives whose symmetry subgroup fixes the derivative axes
-use signed arithmetic reconstruction rather than a sparse sign lookup. The
-runtime sign is the product of the applied flips on derivative axes with odd
-derivative order.
+Axis source/target derivatives, mixed axis derivatives, axis-aligned directional
+source derivatives, and equal-magnitude directional source derivatives use
+signed arithmetic reconstruction rather than a sparse sign lookup. The runtime
+sign is the product of the applied flips on derivative axes with odd derivative
+order and, for directional source derivatives, the sign needed to keep the fixed
+source direction collinear with ``d`` or ``-d``.
 
 This applies to target- and source-derivative kernels represented with
 ``AxisTargetDerivative`` and ``AxisSourceDerivative`` wrappers. Directional
 source derivatives are handled with sign-aware vector transforms when a fixed
 source direction is provided as ``symmetry_source_direction`` on the table.
-Axis-aligned directional source derivatives use signed arithmetic reconstruction.
-Non-axis directional subgroups currently keep using the generated descriptor
-fallback because their allowed transforms depend on the runtime direction vector
-geometry.
+Axis-aligned directions and non-axis directions whose active components have
+equal magnitude use signed arithmetic reconstruction. Other non-axis directional
+subgroups keep using the generated descriptor fallback because their allowed
+transforms depend on the runtime direction vector geometry.
 
 Odd derivative entries can be invariant under a sign-changing self-transform,
 for example when the derivative-axis case offset and both derivative-axis

--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -27,9 +27,9 @@ use the arithmetic path.
 - Axis source/target derivatives additionally pass ``axis_sign_power`` so the
   evaluator computes derivative signs analytically from the applied signed
   permutation.
-- Equal-magnitude directional source derivative subgroups additionally pass the
-  source direction signs and one representative sign axis so the evaluator
-  applies the collinearity sign analytically.
+- Directional source derivative subgroups additionally pass the source direction
+  signs and, for odd directional derivative order, one representative sign axis
+  so the evaluator applies the collinearity sign analytically.
 - The evaluator decodes tensor-product source/target indices, applies the
   per-case signed permutation, resolves zero-axis flips locally, and uses a
   fixed compare-exchange sorting network for equal-absolute-value case axes.
@@ -40,7 +40,7 @@ use the arithmetic path.
   same target-fastest layout and pre-apply any row-level representative sign
   convention while packing the table values.
 
-Other constrained or sign-changing kernels use the generated descriptor
+Unsupported constrained or sign-changing kernels use the generated descriptor
 fallback.
 
 - ``transform_qpoint_map[transform, qpoint]`` and
@@ -90,21 +90,24 @@ Derivative kernels
 ------------------
 
 For derivative kernels, symmetry transforms can introduce sign changes.
-Axis source/target derivatives, mixed axis derivatives, axis-aligned directional
-source derivatives, and equal-magnitude directional source derivatives use
-signed arithmetic reconstruction rather than a sparse sign lookup. The runtime
-sign is the product of the applied flips on derivative axes with odd derivative
-order and, for directional source derivatives, the sign needed to keep the fixed
-source direction collinear with ``d`` or ``-d``.
+Axis source/target derivatives, mixed axis derivatives, fixed-direction
+directional source derivatives, and mixed axis-plus-directional derivatives use
+arithmetic reconstruction rather than a sparse sign lookup. The runtime sign is
+the product of the applied flips on derivative axes with odd derivative order
+and, for odd directional source derivative order, the sign needed to keep the
+fixed source direction collinear with ``d`` or ``-d``.
 
 This applies to target- and source-derivative kernels represented with
 ``AxisTargetDerivative`` and ``AxisSourceDerivative`` wrappers. Directional
 source derivatives are handled with sign-aware vector transforms when a fixed
-source direction is provided as ``symmetry_source_direction`` on the table.
-Axis-aligned directions and non-axis directions whose active components have
-equal magnitude use signed arithmetic reconstruction. Other non-axis directional
-subgroups keep using the generated descriptor fallback because their allowed
-transforms depend on the runtime direction vector geometry.
+source direction is provided as ``symmetry_source_direction`` on the table. Active
+direction axes are grouped by equal absolute direction magnitude; inactive axes
+keep scalar-style signed permutation freedom. Repeated directional wrappers using
+the same fixed direction are supported by parity: even directional order needs no
+collinearity sign, odd directional order does.
+
+Directional source derivatives without fixed direction metadata, or with multiple
+nonmatching fixed directions, keep using the generated descriptor fallback.
 
 Odd derivative entries can be invariant under a sign-changing self-transform,
 for example when the derivative-axis case offset and both derivative-axis

--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -10,16 +10,28 @@ Orbit canonicalization
 - A full table entry is mapped to a canonical representative entry.
 - The dense compatibility path uses an index map from full entry IDs to
   canonical entry IDs.
-- Generated ORBIT reconstruction avoids sending that full-entry map to the GPU
-  for symmetry-reduced tables. The List 1 evaluator instead scans the compact
-  signed-permutation descriptor, computes the representative full-entry ID in
-  registers, then resolves it through a small representative hash table.
+- Scalar arithmetic ORBIT reconstruction avoids sending that full-entry map to
+  the GPU for full-symmetry scalar tables. The List 1 evaluator canonicalizes
+  ``(source_mode, target_point, case)`` with packed per-case descriptors and
+  computes the target-fastest table row directly.
 
-Generated online reconstruction
--------------------------------
+Online reconstruction modes
+---------------------------
 
-The generated path is the intended online representation for
-symmetry-reduced tables.
+Scalar full-symmetry kernels use the arithmetic path.
+
+- ``case_orbit_ranks`` is stored as ``uint16[n_cases]``.
+- ``case_axis_perm``, ``case_axis_sign``, and ``case_axis_group`` are packed as
+  ``uint8``/``int8`` arrays and passed as read-only List 1 kernel inputs.
+- The evaluator decodes tensor-product source/target indices, applies the
+  per-case signed permutation, resolves zero-axis flips locally, and uses a
+  fixed compare-exchange sorting network for equal-absolute-value case axes.
+- The table layout is ``(canonical_case_orbit, canonical_source,
+  canonical_target)`` with target index fastest. This intentionally stores some
+  unused scalar layout rows to remove representative hash lookups and keep GPU
+  table accesses arithmetic and coalescing-friendly.
+
+Constrained or sign-changing kernels use the generated descriptor fallback.
 
 - ``transform_qpoint_map[transform, qpoint]`` and
   ``transform_case_map[transform, case]`` encode the allowed signed
@@ -43,9 +55,11 @@ used.
 
 For scalar 3D Laplace at ``q=3``, the dense online reconstruction maps contain
 ``101331`` full entries and occupy ``1215972`` bytes as ``int32`` IDs plus
-``float64`` scales. Generated reconstruction keeps the representative values at
-``2510 * 8`` bytes and reduces reconstruction metadata to less than ``100000``
-bytes in the CPU descriptor test.
+``float64`` scales. Scalar arithmetic reconstruction reduces transferred
+metadata to less than ``2000`` bytes in the CPU descriptor test. It uses a
+canonical-case table layout rather than the minimal representative-only layout,
+so value bytes increase relative to ``2510`` representatives while eliminating
+the transform scan and representative hash lookup in the scalar online kernel.
 
 Derivative kernels
 ------------------

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2211,6 +2211,7 @@ def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
         "target-derivative",
         "source-derivative",
         "directional-axis-source-derivative",
+        "directional-diagonal-source-derivative",
         "mixed-source-target-derivative",
     ],
 )
@@ -2223,7 +2224,7 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
     )
 
     from volumential.expansion_wrangler_fpnd import (
-        _entry_has_odd_axis_stabilizer,
+        _entry_has_odd_reconstruction_stabilizer,
         _evaluate_arithmetic_orbit_entry,
         _evaluate_scalar_arithmetic_entry,
         _prepare_table_data_and_entry_map,
@@ -2241,6 +2242,9 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
     elif kernel_case == "directional-axis-source-derivative":
         sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec")
         symmetry_source_direction = np.array([1.0, 0.0, 0.0])
+    elif kernel_case == "directional-diagonal-source-derivative":
+        sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec")
+        symmetry_source_direction = np.array([1.0, 1.0, 0.0])
     else:
         sumpy_kernel = AxisTargetDerivative(
             0,
@@ -2310,6 +2314,7 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
         assert reconstruction_info["metadata_bytes"] < 2000
 
         dense_convention_mismatches = 0
+        reconstruction_maps = table._get_orbit_reconstruction_maps()
         for full_entry_id in range(table.n_cases * table.n_pairs):
             case_id = full_entry_id // table.n_pairs
             pair_id = full_entry_id % table.n_pairs
@@ -2324,6 +2329,8 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
                 case_axis_sign=reconstruction_info["case_axis_sign"],
                 case_axis_group=reconstruction_info["case_axis_group"],
                 axis_sign_power=reconstruction_info["axis_sign_power"],
+                axis_direction_signs=reconstruction_info["axis_direction_signs"],
+                direction_sign_axis=reconstruction_info["direction_sign_axis"],
                 q_order=table.quad_order,
                 dim=table.dim,
             )
@@ -2334,13 +2341,11 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
             )
 
             if arithmetic_value != dense_value:
-                assert _entry_has_odd_axis_stabilizer(
-                    table.interaction_case_vecs[case_id],
+                assert _entry_has_odd_reconstruction_stabilizer(
+                    case_id,
                     source_mode_id,
                     target_point_id,
-                    axis_sign_power=reconstruction_info["axis_sign_power"],
-                    q_order=table.quad_order,
-                    dim=table.dim,
+                    reconstruction_maps,
                 )
                 dense_convention_mismatches += 1
 
@@ -2350,7 +2355,7 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
         assert dense_convention_mismatches > 0
 
 
-def test_non_axis_directional_source_derivative_uses_generated_fallback():
+def test_unequal_non_axis_directional_source_derivative_uses_generated_fallback():
     from sumpy.kernel import DirectionalSourceDerivative, LaplaceKernel
 
     from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map
@@ -2365,7 +2370,7 @@ def test_non_axis_directional_source_derivative_uses_generated_fallback():
         kernel_type="inv_power",
         sumpy_kernel=DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec"),
         derive_kernel_func=False,
-        symmetry_source_direction=np.array([1.0, 1.0, 0.0]),
+        symmetry_source_direction=np.array([1.0, 2.0, 0.0]),
         progress_bar=False,
         precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
     )

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2212,7 +2212,11 @@ def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
         "source-derivative",
         "directional-axis-source-derivative",
         "directional-diagonal-source-derivative",
+        "directional-unequal-source-derivative",
+        "directional-magnitude-group-source-derivative",
+        "repeated-directional-source-derivative",
         "mixed-source-target-derivative",
+        "mixed-directional-target-derivative",
     ],
 )
 def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
@@ -2245,11 +2249,29 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
     elif kernel_case == "directional-diagonal-source-derivative":
         sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec")
         symmetry_source_direction = np.array([1.0, 1.0, 0.0])
-    else:
+    elif kernel_case == "directional-unequal-source-derivative":
+        sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec")
+        symmetry_source_direction = np.array([1.0, 2.0, 0.0])
+    elif kernel_case == "directional-magnitude-group-source-derivative":
+        sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec")
+        symmetry_source_direction = np.array([1.0, 2.0, 2.0])
+    elif kernel_case == "repeated-directional-source-derivative":
+        sumpy_kernel = DirectionalSourceDerivative(
+            DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec"),
+            "dir_vec",
+        )
+        symmetry_source_direction = np.array([1.0, 2.0, 0.0])
+    elif kernel_case == "mixed-source-target-derivative":
         sumpy_kernel = AxisTargetDerivative(
             0,
             AxisSourceDerivative(1, LaplaceKernel(dim)),
         )
+    else:
+        sumpy_kernel = AxisTargetDerivative(
+            0,
+            DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec"),
+        )
+        symmetry_source_direction = np.array([1.0, 2.0, 0.0])
 
     table = npt.NearFieldInteractionTable(
         quad_order=q_order,
@@ -2284,8 +2306,11 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
     dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
     assert reconstruction_info["metadata_bytes"] < dense_metadata_bytes
 
-    if kernel_case == "scalar-laplace":
-        assert reconstruction_info["kind"] == "scalar-arithmetic-orbit"
+    if reconstruction_info["kind"] == "scalar-arithmetic-orbit":
+        assert kernel_case in {
+            "scalar-laplace",
+            "repeated-directional-source-derivative",
+        }
         assert table_data_combined.shape[1] > len(entry_ids)
         assert reconstruction_info["metadata_bytes"] < 2000
 
@@ -2352,15 +2377,23 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
         assert dense_convention_mismatches == reconstruction_info[
             "sign_convention_conflict_count"
         ]
-        assert dense_convention_mismatches > 0
+        if kernel_case in {
+            "target-derivative",
+            "source-derivative",
+            "directional-axis-source-derivative",
+            "directional-diagonal-source-derivative",
+            "directional-unequal-source-derivative",
+            "mixed-source-target-derivative",
+        }:
+            assert dense_convention_mismatches > 0
 
 
-def test_unequal_non_axis_directional_source_derivative_uses_generated_fallback():
+def test_directional_source_derivative_without_direction_uses_generated_fallback():
     from sumpy.kernel import DirectionalSourceDerivative, LaplaceKernel
 
     from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map
 
-    q_order = 3
+    q_order = 2
     dim = 3
     table = npt.NearFieldInteractionTable(
         quad_order=q_order,
@@ -2370,7 +2403,6 @@ def test_unequal_non_axis_directional_source_derivative_uses_generated_fallback(
         kernel_type="inv_power",
         sumpy_kernel=DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec"),
         derive_kernel_func=False,
-        symmetry_source_direction=np.array([1.0, 2.0, 0.0]),
         progress_bar=False,
         precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
     )

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2412,7 +2412,8 @@ def test_directional_source_derivative_without_direction_uses_generated_fallback
     table.data[entry_ids] = np.arange(1, len(entry_ids) + 1, dtype=table.dtype)
     table.table_data_is_symmetry_reduced = True
 
-    _, _, _, _, _, reconstruction_info = _prepare_table_data_and_entry_map([table])
+    with pytest.warns(RuntimeWarning, match="generated-orbit fallback"):
+        _, _, _, _, _, reconstruction_info = _prepare_table_data_and_entry_map([table])
 
     assert reconstruction_info["kind"] == "generated-orbit"
     assert "lookup_keys" in reconstruction_info

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2206,23 +2206,46 @@ def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
 
 @pytest.mark.parametrize(
     "kernel_case",
-    ["scalar-laplace", "target-derivative"],
+    [
+        "scalar-laplace",
+        "target-derivative",
+        "source-derivative",
+        "directional-axis-source-derivative",
+        "mixed-source-target-derivative",
+    ],
 )
-def test_generated_orbit_reconstruction_matches_dense_oracle(kernel_case):
-    from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
+def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
+    from sumpy.kernel import (
+        AxisSourceDerivative,
+        AxisTargetDerivative,
+        DirectionalSourceDerivative,
+        LaplaceKernel,
+    )
 
     from volumential.expansion_wrangler_fpnd import (
-        _evaluate_generated_orbit_reconstruction,
+        _entry_has_odd_axis_stabilizer,
+        _evaluate_arithmetic_orbit_entry,
         _evaluate_scalar_arithmetic_entry,
         _prepare_table_data_and_entry_map,
     )
 
     q_order = 3
     dim = 3
+    symmetry_source_direction = None
     if kernel_case == "scalar-laplace":
         sumpy_kernel = LaplaceKernel(dim)
-    else:
+    elif kernel_case == "target-derivative":
         sumpy_kernel = AxisTargetDerivative(0, LaplaceKernel(dim))
+    elif kernel_case == "source-derivative":
+        sumpy_kernel = AxisSourceDerivative(0, LaplaceKernel(dim))
+    elif kernel_case == "directional-axis-source-derivative":
+        sumpy_kernel = DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec")
+        symmetry_source_direction = np.array([1.0, 0.0, 0.0])
+    else:
+        sumpy_kernel = AxisTargetDerivative(
+            0,
+            AxisSourceDerivative(1, LaplaceKernel(dim)),
+        )
 
     table = npt.NearFieldInteractionTable(
         quad_order=q_order,
@@ -2232,6 +2255,7 @@ def test_generated_orbit_reconstruction_matches_dense_oracle(kernel_case):
         kernel_type="inv_power",
         sumpy_kernel=sumpy_kernel,
         derive_kernel_func=False,
+        symmetry_source_direction=symmetry_source_direction,
         progress_bar=False,
         precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
     )
@@ -2280,38 +2304,85 @@ def test_generated_orbit_reconstruction_matches_dense_oracle(kernel_case):
             dense_value = table.data[expected_entry_ids[full_entry_id]]
             assert table_data_combined[0, arithmetic_row] == dense_value
     else:
-        assert reconstruction_info["kind"] == "generated-orbit"
-        assert table_data_combined.shape == (1, len(entry_ids))
+        assert reconstruction_info["kind"] == "signed-arithmetic-orbit"
+        assert "lookup_keys" not in reconstruction_info
+        assert "sign_lookup_keys" not in reconstruction_info
+        assert reconstruction_info["metadata_bytes"] < 2000
 
-        reconstruction_maps = table._get_orbit_reconstruction_maps()
-        generated_entry_ids, generated_scales = (
-            _evaluate_generated_orbit_reconstruction(
-                reconstruction_maps["transform_qpoint_map"],
-                reconstruction_maps["transform_case_map"],
-                reconstruction_maps["transform_signs"],
-                n_cases=table.n_cases,
-                n_q_points=table.n_q_points,
+        dense_convention_mismatches = 0
+        for full_entry_id in range(table.n_cases * table.n_pairs):
+            case_id = full_entry_id // table.n_pairs
+            pair_id = full_entry_id % table.n_pairs
+            source_mode_id = pair_id // table.n_q_points
+            target_point_id = pair_id % table.n_q_points
+            arithmetic_row, arithmetic_sign = _evaluate_arithmetic_orbit_entry(
+                case_id,
+                source_mode_id,
+                target_point_id,
+                case_orbit_ranks=reconstruction_info["case_orbit_ranks"],
+                case_axis_perm=reconstruction_info["case_axis_perm"],
+                case_axis_sign=reconstruction_info["case_axis_sign"],
+                case_axis_group=reconstruction_info["case_axis_group"],
+                axis_sign_power=reconstruction_info["axis_sign_power"],
+                q_order=table.quad_order,
+                dim=table.dim,
             )
-        )
-        np.testing.assert_array_equal(generated_entry_ids, expected_entry_ids)
+            arithmetic_value = table_data_combined[0, arithmetic_row] * arithmetic_sign
+            dense_value = (
+                table.data[expected_entry_ids[full_entry_id]]
+                * expected_scales[full_entry_id]
+            )
 
-        sign_keys = reconstruction_info["sign_lookup_keys"]
-        sign_values = reconstruction_info["sign_lookup_values"]
-        sign_probe_count = reconstruction_info["sign_lookup_max_probe_count"]
-        corrected_scales = generated_scales.copy()
-        for full_entry_id in range(len(corrected_scales)):
-            slot0 = (full_entry_id * 33) & (len(sign_keys) - 1)
-            for probe in range(sign_probe_count):
-                slot = (slot0 + probe) & (len(sign_keys) - 1)
-                if sign_keys[slot] == full_entry_id:
-                    corrected_scales[full_entry_id] *= sign_values[slot]
-                    break
+            if arithmetic_value != dense_value:
+                assert _entry_has_odd_axis_stabilizer(
+                    table.interaction_case_vecs[case_id],
+                    source_mode_id,
+                    target_point_id,
+                    axis_sign_power=reconstruction_info["axis_sign_power"],
+                    q_order=table.quad_order,
+                    dim=table.dim,
+                )
+                dense_convention_mismatches += 1
 
-        np.testing.assert_array_equal(corrected_scales, expected_scales)
-        assert reconstruction_info["sign_correction_count"] > 0
+        assert dense_convention_mismatches == reconstruction_info[
+            "sign_convention_conflict_count"
+        ]
+        assert dense_convention_mismatches > 0
 
 
-def test_generated_orbit_reconstruction_q3_payload_diagnostic_row():
+def test_non_axis_directional_source_derivative_uses_generated_fallback():
+    from sumpy.kernel import DirectionalSourceDerivative, LaplaceKernel
+
+    from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map
+
+    q_order = 3
+    dim = 3
+    table = npt.NearFieldInteractionTable(
+        quad_order=q_order,
+        dim=dim,
+        build_method="DuffyRadial",
+        kernel_func=npt.constant_one,
+        kernel_type="inv_power",
+        sumpy_kernel=DirectionalSourceDerivative(LaplaceKernel(dim), "dir_vec"),
+        derive_kernel_func=False,
+        symmetry_source_direction=np.array([1.0, 1.0, 0.0]),
+        progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
+    )
+    orbit_info = table._get_orbit_canonical_info()
+    entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+    table.data.fill(np.nan)
+    table.data[entry_ids] = np.arange(1, len(entry_ids) + 1, dtype=table.dtype)
+    table.table_data_is_symmetry_reduced = True
+
+    _, _, _, _, _, reconstruction_info = _prepare_table_data_and_entry_map([table])
+
+    assert reconstruction_info["kind"] == "generated-orbit"
+    assert "lookup_keys" in reconstruction_info
+    assert "sign_lookup_keys" in reconstruction_info
+
+
+def test_arithmetic_orbit_reconstruction_q3_payload_diagnostic_row():
     from sumpy.kernel import LaplaceKernel
 
     from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2204,6 +2204,31 @@ def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
     assert reconstruction_info["kind"] == "dense"
 
 
+def test_arithmetic_orbit_reconstruction_sorts_nonadjacent_group_axes():
+    from volumential.expansion_wrangler_fpnd import _evaluate_arithmetic_orbit_entry
+
+    q_order = 3
+    n_q_points = q_order**3
+    source_mode_id = 2 * q_order * q_order
+    target_point_id = 2 * q_order * q_order
+
+    arithmetic_row, arithmetic_sign = _evaluate_arithmetic_orbit_entry(
+        0,
+        source_mode_id,
+        target_point_id,
+        case_orbit_ranks=np.array([0], dtype=np.uint16),
+        case_axis_perm=np.array([[0, 1, 2]], dtype=np.uint8),
+        case_axis_sign=np.array([[1, 1, 1]], dtype=np.int8),
+        case_axis_group=np.array([[1, 0, 1]], dtype=np.uint8),
+        q_order=q_order,
+        dim=3,
+    )
+
+    expected_mode_id = 2
+    assert arithmetic_row == expected_mode_id * n_q_points + expected_mode_id
+    assert arithmetic_sign == 1
+
+
 @pytest.mark.parametrize(
     "kernel_case",
     [

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2213,6 +2213,7 @@ def test_generated_orbit_reconstruction_matches_dense_oracle(kernel_case):
 
     from volumential.expansion_wrangler_fpnd import (
         _evaluate_generated_orbit_reconstruction,
+        _evaluate_scalar_arithmetic_entry,
         _prepare_table_data_and_entry_map,
     )
 
@@ -2249,41 +2250,64 @@ def test_generated_orbit_reconstruction_matches_dense_oracle(kernel_case):
         reconstruction_info,
     ) = _prepare_table_data_and_entry_map([table])
 
-    assert reconstruction_info["kind"] == "generated-orbit"
-    assert table_data_combined.shape == (1, len(entry_ids))
-
-    reconstruction_maps = table._get_orbit_reconstruction_maps()
-    generated_entry_ids, generated_scales = _evaluate_generated_orbit_reconstruction(
-        reconstruction_maps["transform_qpoint_map"],
-        reconstruction_maps["transform_case_map"],
-        reconstruction_maps["transform_signs"],
-        n_cases=table.n_cases,
-        n_q_points=table.n_q_points,
-    )
-
     expected_entry_ids = entry_ids[table_entry_ids]
     expected_scales = np.real(table_entry_scales).astype(np.int8)
-    np.testing.assert_array_equal(generated_entry_ids, expected_entry_ids)
-
-    sign_keys = reconstruction_info["sign_lookup_keys"]
-    sign_values = reconstruction_info["sign_lookup_values"]
-    sign_probe_count = reconstruction_info["sign_lookup_max_probe_count"]
-    corrected_scales = generated_scales.copy()
-    for full_entry_id in range(len(corrected_scales)):
-        slot0 = (full_entry_id * 33) & (len(sign_keys) - 1)
-        for probe in range(sign_probe_count):
-            slot = (slot0 + probe) & (len(sign_keys) - 1)
-            if sign_keys[slot] == full_entry_id:
-                corrected_scales[full_entry_id] *= sign_values[slot]
-                break
-
-    np.testing.assert_array_equal(corrected_scales, expected_scales)
 
     dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
     assert reconstruction_info["metadata_bytes"] < dense_metadata_bytes
+
     if kernel_case == "scalar-laplace":
-        assert reconstruction_info["sign_correction_count"] == 0
+        assert reconstruction_info["kind"] == "scalar-arithmetic-orbit"
+        assert table_data_combined.shape[1] > len(entry_ids)
+        assert reconstruction_info["metadata_bytes"] < 2000
+
+        for full_entry_id in range(table.n_cases * table.n_pairs):
+            case_id = full_entry_id // table.n_pairs
+            pair_id = full_entry_id % table.n_pairs
+            source_mode_id = pair_id // table.n_q_points
+            target_point_id = pair_id % table.n_q_points
+            arithmetic_row = _evaluate_scalar_arithmetic_entry(
+                case_id,
+                source_mode_id,
+                target_point_id,
+                case_orbit_ranks=reconstruction_info["case_orbit_ranks"],
+                case_axis_perm=reconstruction_info["case_axis_perm"],
+                case_axis_sign=reconstruction_info["case_axis_sign"],
+                case_axis_group=reconstruction_info["case_axis_group"],
+                q_order=table.quad_order,
+                dim=table.dim,
+            )
+            dense_value = table.data[expected_entry_ids[full_entry_id]]
+            assert table_data_combined[0, arithmetic_row] == dense_value
     else:
+        assert reconstruction_info["kind"] == "generated-orbit"
+        assert table_data_combined.shape == (1, len(entry_ids))
+
+        reconstruction_maps = table._get_orbit_reconstruction_maps()
+        generated_entry_ids, generated_scales = (
+            _evaluate_generated_orbit_reconstruction(
+                reconstruction_maps["transform_qpoint_map"],
+                reconstruction_maps["transform_case_map"],
+                reconstruction_maps["transform_signs"],
+                n_cases=table.n_cases,
+                n_q_points=table.n_q_points,
+            )
+        )
+        np.testing.assert_array_equal(generated_entry_ids, expected_entry_ids)
+
+        sign_keys = reconstruction_info["sign_lookup_keys"]
+        sign_values = reconstruction_info["sign_lookup_values"]
+        sign_probe_count = reconstruction_info["sign_lookup_max_probe_count"]
+        corrected_scales = generated_scales.copy()
+        for full_entry_id in range(len(corrected_scales)):
+            slot0 = (full_entry_id * 33) & (len(sign_keys) - 1)
+            for probe in range(sign_probe_count):
+                slot = (slot0 + probe) & (len(sign_keys) - 1)
+                if sign_keys[slot] == full_entry_id:
+                    corrected_scales[full_entry_id] *= sign_values[slot]
+                    break
+
+        np.testing.assert_array_equal(corrected_scales, expected_scales)
         assert reconstruction_info["sign_correction_count"] > 0
 
 
@@ -2316,9 +2340,10 @@ def test_generated_orbit_reconstruction_q3_payload_diagnostic_row():
     )
 
     dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
-    assert table_data_combined.nbytes == len(entry_ids) * np.dtype(table.dtype).itemsize
+    assert recon["kind"] == "scalar-arithmetic-orbit"
+    assert table_data_combined.nbytes > len(entry_ids) * np.dtype(table.dtype).itemsize
     assert dense_metadata_bytes == 1215972
-    assert recon["metadata_bytes"] < 100000
+    assert recon["metadata_bytes"] < 2000
 
 
 def test_table_payload_serialization_excludes_nan_sentinels_for_reduced_tables():

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -88,6 +88,22 @@ def _make_legendre_table_without_cl(q_order, dim):
     return table
 
 
+def _precomputed_legendre_q_points(q_order, dim):
+    nodes = np.polynomial.legendre.leggauss(q_order)[0]
+    nodes = 0.5 * (nodes + 1.0)
+
+    if dim == 1:
+        q_points = [(x,) for x in nodes]
+    elif dim == 2:
+        q_points = [(x, y) for x in nodes for y in nodes]
+    elif dim == 3:
+        q_points = [(x, y, z) for x in nodes for y in nodes for z in nodes]
+    else:
+        raise NotImplementedError("dimension %d not supported" % dim)
+
+    return np.asarray(q_points, dtype=np.float64)
+
+
 def test_const_order_1():
     queue = _make_build_queue_or_skip()
     table = npt.NearFieldInteractionTable(
@@ -2046,6 +2062,7 @@ def test_prepare_table_data_and_entry_map_accepts_finite_full_entries():
         exterior_mode_nmlz_combined,
         table_entry_ids,
         table_entry_scales,
+        reconstruction_info,
     ) = _prepare_table_data_and_entry_map([table0, table1])
 
     assert table_data_combined.shape == (2, 3)
@@ -2058,6 +2075,7 @@ def test_prepare_table_data_and_entry_map_accepts_finite_full_entries():
     np.testing.assert_allclose(
         exterior_mode_nmlz_combined[0], table0.kernel_exterior_normalizers
     )
+    assert reconstruction_info["kind"] == "dense"
 
 
 def test_prepare_table_data_and_entry_map_rejects_nonfinite_full_entries():
@@ -2128,6 +2146,7 @@ def test_prepare_table_data_and_entry_map_accepts_consistent_reduced_masks():
         _,
         table_entry_ids,
         table_entry_scales,
+        reconstruction_info,
     ) = _prepare_table_data_and_entry_map([table0, table1])
 
     assert table_data_combined.shape == (2, 2)
@@ -2137,6 +2156,7 @@ def test_prepare_table_data_and_entry_map_accepts_consistent_reduced_masks():
     np.testing.assert_allclose(table_entry_scales, np.array([1.0, 1.0, 1.0]))
     np.testing.assert_allclose(mode_nmlz_combined[0], table0.mode_normalizers)
     np.testing.assert_allclose(mode_nmlz_combined[1], table1.mode_normalizers)
+    assert reconstruction_info["kind"] == "dense"
 
 
 def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
@@ -2171,6 +2191,7 @@ def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
         _,
         table_entry_ids,
         table_entry_scales,
+        reconstruction_info,
     ) = _prepare_table_data_and_entry_map([table0, table1])
 
     assert table_data_combined.shape == (2, 2)
@@ -2180,6 +2201,124 @@ def test_prepare_table_data_and_entry_map_uses_orbit_canonical_mapping():
     np.testing.assert_allclose(table_entry_scales, np.array([1.0, -1.0, 1.0]))
     np.testing.assert_allclose(mode_nmlz_combined[0], table0.mode_normalizers)
     np.testing.assert_allclose(mode_nmlz_combined[1], table1.mode_normalizers)
+    assert reconstruction_info["kind"] == "dense"
+
+
+@pytest.mark.parametrize(
+    "kernel_case",
+    ["scalar-laplace", "target-derivative"],
+)
+def test_generated_orbit_reconstruction_matches_dense_oracle(kernel_case):
+    from sumpy.kernel import AxisTargetDerivative, LaplaceKernel
+
+    from volumential.expansion_wrangler_fpnd import (
+        _evaluate_generated_orbit_reconstruction,
+        _prepare_table_data_and_entry_map,
+    )
+
+    q_order = 3
+    dim = 3
+    if kernel_case == "scalar-laplace":
+        sumpy_kernel = LaplaceKernel(dim)
+    else:
+        sumpy_kernel = AxisTargetDerivative(0, LaplaceKernel(dim))
+
+    table = npt.NearFieldInteractionTable(
+        quad_order=q_order,
+        dim=dim,
+        build_method="DuffyRadial",
+        kernel_func=npt.constant_one,
+        kernel_type="inv_power",
+        sumpy_kernel=sumpy_kernel,
+        derive_kernel_func=False,
+        progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
+    )
+    orbit_info = table._get_orbit_canonical_info()
+    entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+    table.data.fill(np.nan)
+    table.data[entry_ids] = np.arange(1, len(entry_ids) + 1, dtype=table.dtype)
+    table.table_data_is_symmetry_reduced = True
+
+    (
+        table_data_combined,
+        _,
+        _,
+        table_entry_ids,
+        table_entry_scales,
+        reconstruction_info,
+    ) = _prepare_table_data_and_entry_map([table])
+
+    assert reconstruction_info["kind"] == "generated-orbit"
+    assert table_data_combined.shape == (1, len(entry_ids))
+
+    reconstruction_maps = table._get_orbit_reconstruction_maps()
+    generated_entry_ids, generated_scales = _evaluate_generated_orbit_reconstruction(
+        reconstruction_maps["transform_qpoint_map"],
+        reconstruction_maps["transform_case_map"],
+        reconstruction_maps["transform_signs"],
+        n_cases=table.n_cases,
+        n_q_points=table.n_q_points,
+    )
+
+    expected_entry_ids = entry_ids[table_entry_ids]
+    expected_scales = np.real(table_entry_scales).astype(np.int8)
+    np.testing.assert_array_equal(generated_entry_ids, expected_entry_ids)
+
+    sign_keys = reconstruction_info["sign_lookup_keys"]
+    sign_values = reconstruction_info["sign_lookup_values"]
+    sign_probe_count = reconstruction_info["sign_lookup_max_probe_count"]
+    corrected_scales = generated_scales.copy()
+    for full_entry_id in range(len(corrected_scales)):
+        slot0 = (full_entry_id * 33) & (len(sign_keys) - 1)
+        for probe in range(sign_probe_count):
+            slot = (slot0 + probe) & (len(sign_keys) - 1)
+            if sign_keys[slot] == full_entry_id:
+                corrected_scales[full_entry_id] *= sign_values[slot]
+                break
+
+    np.testing.assert_array_equal(corrected_scales, expected_scales)
+
+    dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
+    assert reconstruction_info["metadata_bytes"] < dense_metadata_bytes
+    if kernel_case == "scalar-laplace":
+        assert reconstruction_info["sign_correction_count"] == 0
+    else:
+        assert reconstruction_info["sign_correction_count"] > 0
+
+
+def test_generated_orbit_reconstruction_q3_payload_diagnostic_row():
+    from sumpy.kernel import LaplaceKernel
+
+    from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map
+
+    q_order = 3
+    dim = 3
+    table = npt.NearFieldInteractionTable(
+        quad_order=q_order,
+        dim=dim,
+        build_method="DuffyRadial",
+        kernel_func=npt.constant_one,
+        kernel_type="inv_power",
+        sumpy_kernel=LaplaceKernel(dim),
+        derive_kernel_func=False,
+        progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
+    )
+    orbit_info = table._get_orbit_canonical_info()
+    entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+    table.data.fill(np.nan)
+    table.data[entry_ids] = np.arange(1, len(entry_ids) + 1, dtype=table.dtype)
+    table.table_data_is_symmetry_reduced = True
+
+    table_data_combined, _, _, table_entry_ids, table_entry_scales, recon = (
+        _prepare_table_data_and_entry_map([table])
+    )
+
+    dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
+    assert table_data_combined.nbytes == len(entry_ids) * np.dtype(table.dtype).itemsize
+    assert dense_metadata_bytes == 1215972
+    assert recon["metadata_bytes"] < 100000
 
 
 def test_table_payload_serialization_excludes_nan_sentinels_for_reduced_tables():

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -4993,7 +4993,7 @@ def test_volume_fmm_2d_helmholtz_split_directional_source_derivative_tracks_dire
     q_order = 4
     wave_number = 8.0
     nlevels = 3
-    source_direction = np.array([1.0, 0.0], dtype=np.float64)
+    source_direction = np.array([1.0, 0.5], dtype=np.float64)
     split_table = _build_laplace_output_table(
         queue,
         2,

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -3770,6 +3770,68 @@ def test_source_kernel_derivation_preserves_source_derivatives():
     )
     assert source_knl_no_source_deriv == base_knl
 
+    source_knls = _derive_source_kernels_from_target_kernels(
+        [
+            AxisTargetDerivative(2, base_knl),
+            AxisTargetDerivative(1, AxisSourceDerivative(0, base_knl)),
+        ],
+        require_single=False,
+    )
+    assert len(source_knls) == 2
+    assert source_knls[0] == base_knl
+    assert isinstance(source_knls[1], AxisSourceDerivative)
+    assert source_knls[1].axis == 0
+    assert source_knls[1].inner_kernel == base_knl
+
+    with pytest.raises(ValueError, match="share a single source-side kernel"):
+        _derive_source_kernels_from_target_kernels(
+            [base_knl, AxisSourceDerivative(1, base_knl)]
+        )
+
+
+def test_list1_generated_orbit_sign_correction_codegen_uses_distinct_inames():
+    import loopy as lp
+    from sumpy.kernel import LaplaceKernel
+
+    from volumential.list1 import NearFieldFromCSR
+
+    near_field = NearFieldFromCSR(
+        LaplaceKernel(2),
+        {
+            "n_tables": 1,
+            "n_q_points": 1,
+            "n_cases": 1,
+            "n_table_entries": 1,
+            "reconstruction_kind": "generated-orbit",
+            "n_reconstruction_transforms": 1,
+            "n_reconstruction_lookup_entries": 1,
+            "n_reconstruction_lookup_probes": 1,
+            "n_reconstruction_sign_lookup_entries": 1,
+            "n_reconstruction_sign_lookup_probes": 1,
+        },
+        potential_kind=1,
+    )
+
+    knl = lp.add_dtypes(
+        near_field.get_optimized_kernel(),
+        {
+            "target_boxes": np.int32,
+            "box_target_starts": np.int32,
+            "neighbor_source_boxes_starts": np.int32,
+            "source_boxes": np.int32,
+            "box_levels": np.int32,
+            "case_indices": np.int32,
+            "box_source_starts": np.int32,
+            "source_coefs": np.float64,
+            "result": np.float64,
+            "root_extent": np.float64,
+            "encoding_shift": np.float64,
+            "box_centers": np.float64,
+        },
+    )
+
+    lp.generate_code_v2(knl)
+
 
 def test_helmholtz_split_policy_rejects_mixed_source_target_derivative_chain():
     from sumpy.kernel import (

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -32,6 +32,7 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.array
 from boxtree.pyfmmlib_integration import FMMLibExpansionWrangler
+from pytools import memoize_method
 from pytools.obj_array import new_1d as obj_array_1d
 from sumpy.array_context import PyOpenCLArrayContext
 from sumpy.fmm import (
@@ -1554,10 +1555,13 @@ class FPNDSumpyTreeIndependentDataForWrangler(
         strength_usage=None,
         source_kernels=None,
     ):
-        if source_kernels is None and not _target_kernels_include_source_derivatives(
-            target_kernels
-        ):
-            source_kernels = _derive_source_kernels_from_target_kernels(target_kernels)
+        expansion_source_kernels = source_kernels
+        if source_kernels is None:
+            expansion_source_kernels = _derive_source_kernels_from_target_kernels(
+                target_kernels
+            )
+            if not _target_kernels_include_source_derivatives(target_kernels):
+                source_kernels = expansion_source_kernels
 
         queue = cl.CommandQueue(cl_context)
         actx = PyOpenCLArrayContext(queue)
@@ -1576,6 +1580,7 @@ class FPNDSumpyTreeIndependentDataForWrangler(
             local_expansion_factory,
             **super_kwargs,
         )
+        self.expansion_source_kernels = expansion_source_kernels
 
     def _for_queue(self, queue):
         setup_queue = getattr(self._setup_actx, "queue", None)
@@ -1626,6 +1631,28 @@ class FPNDSumpyTreeIndependentDataForWrangler(
             kernel_extra_kwargs=kernel_extra_kwargs,
             self_extra_kwargs=self_extra_kwargs,
             **kwargs,
+        )
+
+    @memoize_method
+    def p2m(self, tgt_order):
+        from sumpy.p2e import P2EFromSingleBox
+
+        return P2EFromSingleBox(
+            kernels=self.expansion_source_kernels,
+            expansion=self.multipole_expansion(tgt_order),
+            strength_usage=self.strength_usage,
+            name="p2m",
+        )
+
+    @memoize_method
+    def p2l(self, tgt_order):
+        from sumpy.p2e import P2EFromCSR
+
+        return P2EFromCSR(
+            kernels=self.expansion_source_kernels,
+            expansion=self.local_expansion(tgt_order),
+            strength_usage=self.strength_usage,
+            name="p2l",
         )
 
     def opencl_fft_app(self, shape, dtype, inverse):

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -872,15 +872,29 @@ _ARITHMETIC_RECONSTRUCTION_KINDS = {
 }
 
 
-def _case_arithmetic_axis_descriptors(case_vec, fixed_axes=()):
+def _case_arithmetic_axis_descriptors(
+    case_vec,
+    *,
+    axis_groups=None,
+    direction_signs=None,
+):
     case_vec = [int(val) for val in case_vec]
     dim = len(case_vec)
-    fixed_axes = frozenset(int(axis) for axis in fixed_axes)
+    if axis_groups is None:
+        axis_group_specs = (tuple(range(dim)),)
+    else:
+        axis_group_specs = axis_groups
+    axis_group_specs = tuple(
+        tuple(int(axis) for axis in group) for group in axis_group_specs
+    )
+    direction_signs = np.zeros(dim, dtype=np.int8) if direction_signs is None else (
+        np.asarray(direction_signs, dtype=np.int8)
+    )
 
     axis_perm = np.empty(dim, dtype=np.uint8)
     axis_signs = np.empty(dim, dtype=np.int8)
-    axis_groups = np.empty(dim, dtype=np.uint8)
-    group_id = 0
+    axis_group_ids = np.empty(dim, dtype=np.uint8)
+    next_runtime_group = 0
 
     def sign_to_negative(value):
         value = int(value)
@@ -890,31 +904,66 @@ def _case_arithmetic_axis_descriptors(case_vec, fixed_axes=()):
             return 1
         return 0
 
-    for iaxis in sorted(fixed_axes):
-        axis_perm[iaxis] = iaxis
-        axis_signs[iaxis] = sign_to_negative(case_vec[iaxis])
-        axis_groups[iaxis] = group_id
-        group_id += 1
+    for group in axis_group_specs:
+        out_axes = tuple(sorted(group))
+        active_direction_axes = [axis for axis in out_axes if direction_signs[axis] != 0]
 
-    free_axes = [iaxis for iaxis in range(dim) if iaxis not in fixed_axes]
-    free_order = sorted(
-        free_axes,
-        key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis),
-    )
+        if active_direction_axes:
+            best_key = None
+            best_perm = None
+            best_line_sign = None
+            from itertools import permutations
 
-    last_abs = None
-    current_group = group_id - 1
-    for out_axis, in_axis in zip(free_axes, free_order, strict=True):
-        value = int(case_vec[in_axis])
-        abs_value = abs(value)
-        if last_abs != abs_value:
-            current_group += 1
-            last_abs = abs_value
-        axis_perm[out_axis] = in_axis
-        axis_signs[out_axis] = sign_to_negative(value)
-        axis_groups[out_axis] = current_group
+            for permuted_axes in permutations(out_axes):
+                for line_sign in (-1, 1):
+                    values = []
+                    for out_axis, in_axis in zip(out_axes, permuted_axes, strict=True):
+                        sign = (
+                            line_sign
+                            * int(direction_signs[out_axis])
+                            * int(direction_signs[in_axis])
+                        )
+                        values.append(int(case_vec[in_axis]) * sign)
 
-    return axis_perm, axis_signs, axis_groups
+                    key = (tuple(values), tuple(int(axis) for axis in permuted_axes))
+                    if best_key is None or key < best_key:
+                        best_key = key
+                        best_perm = tuple(int(axis) for axis in permuted_axes)
+                        best_line_sign = int(line_sign)
+
+            for out_axis, in_axis in zip(out_axes, best_perm, strict=True):
+                axis_perm[out_axis] = in_axis
+                axis_signs[out_axis] = (
+                    best_line_sign
+                    * int(direction_signs[out_axis])
+                    * int(direction_signs[in_axis])
+                )
+                # Avoid over-canonicalizing directional stabilizers: source/target
+                # flips in an active directional group are tied by one line sign.
+                axis_group_ids[out_axis] = next_runtime_group
+                next_runtime_group += 1
+            continue
+
+        free_order = sorted(
+            out_axes,
+            key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis),
+        )
+
+        last_abs = None
+        current_runtime_group = next_runtime_group - 1
+        for out_axis, in_axis in zip(out_axes, free_order, strict=True):
+            value = int(case_vec[in_axis])
+            abs_value = abs(value)
+            if last_abs != abs_value:
+                current_runtime_group += 1
+                last_abs = abs_value
+            axis_perm[out_axis] = in_axis
+            axis_signs[out_axis] = sign_to_negative(value)
+            axis_group_ids[out_axis] = current_runtime_group
+
+        next_runtime_group = current_runtime_group + 1
+
+    return axis_perm, axis_signs, axis_group_ids
 
 
 def _canonical_case_from_axis_descriptors(case_vec, axis_perm, axis_sign):
@@ -931,11 +980,16 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
     dim = int(table.dim)
     fixed_axes = set()
     axis_sign_power = np.zeros(dim, dtype=np.uint8)
+    direction_signs = np.zeros(dim, dtype=np.int8)
+    direction_sign_axis = -1
+    directional_groups = None
 
     kernel = table.integral_knl
     while kernel is not None:
         cls_name = kernel.__class__.__name__
         if cls_name in {"AxisTargetDerivative", "AxisSourceDerivative"}:
+            if directional_groups is not None:
+                return None
             axis = int(kernel.axis)
             if axis < 0 or axis >= dim:
                 return None
@@ -945,6 +999,8 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
             continue
 
         if cls_name == "DirectionalSourceDerivative":
+            if np.any(axis_sign_power) or directional_groups is not None:
+                return None
             source_direction = getattr(kernel, "_volumential_source_direction", None)
             if source_direction is None:
                 return None
@@ -954,11 +1010,24 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
             axis_candidates = np.flatnonzero(
                 np.abs(source_direction) > 100 * np.finfo(np.float64).eps
             )
-            if len(axis_candidates) != 1:
+            if len(axis_candidates) == 0:
                 return None
-            axis = int(axis_candidates[0])
-            fixed_axes.add(axis)
-            axis_sign_power[axis] ^= np.uint8(1)
+            active_abs_values = np.abs(source_direction[axis_candidates])
+            if not np.allclose(active_abs_values, active_abs_values[0]):
+                return None
+
+            active_axes = tuple(sorted(int(axis) for axis in axis_candidates))
+            inactive_axes = tuple(
+                axis for axis in range(dim) if axis not in set(active_axes)
+            )
+            directional_groups = (active_axes,)
+            if inactive_axes:
+                directional_groups += (inactive_axes,)
+            active_axis_list = list(active_axes)
+            direction_signs[active_axis_list] = np.sign(
+                source_direction[active_axis_list]
+            ).astype(np.int8)
+            direction_sign_axis = int(active_axes[0])
             kernel = kernel.inner_kernel
             continue
 
@@ -970,16 +1039,50 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
 
     from itertools import permutations, product
 
+    if directional_groups is None:
+        free_axes = tuple(axis for axis in range(dim) if axis not in fixed_axes)
+        axis_groups = tuple((axis,) for axis in sorted(fixed_axes))
+        if free_axes:
+            axis_groups += (free_axes,)
+    else:
+        axis_groups = directional_groups
+
     expected = set()
     for sign_tuple in product([-1, 1], repeat=dim):
         for perm_tuple in permutations(range(dim)):
-            if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
-                continue
+            line_sign = 1
+            if directional_groups is None:
+                if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
+                    continue
+            else:
+                line_sign = None
+                valid = True
+                for out_axis in range(dim):
+                    in_axis = int(perm_tuple[out_axis])
+                    out_dir = int(direction_signs[out_axis])
+                    in_dir = int(direction_signs[in_axis])
+                    if out_dir == 0 or in_dir == 0:
+                        if out_dir != in_dir:
+                            valid = False
+                            break
+                        continue
+
+                    candidate = int(sign_tuple[in_axis]) * out_dir * in_dir
+                    if line_sign is None:
+                        line_sign = candidate
+                    elif candidate != line_sign:
+                        valid = False
+                        break
+
+                if not valid or line_sign is None:
+                    continue
 
             transform_sign = 1
             for axis in range(dim):
                 if int(axis_sign_power[axis]):
                     transform_sign *= int(sign_tuple[axis])
+            if directional_groups is not None:
+                transform_sign *= int(line_sign)
 
             expected.add(
                 (
@@ -1013,8 +1116,10 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
         return None
 
     return {
-        "fixed_axes": tuple(sorted(int(axis) for axis in fixed_axes)),
+        "axis_groups": axis_groups,
         "axis_sign_power": axis_sign_power,
+        "axis_direction_signs": direction_signs,
+        "direction_sign_axis": int(direction_sign_axis),
     }
 
 
@@ -1028,11 +1133,15 @@ def _evaluate_arithmetic_orbit_entry(
     case_axis_sign,
     case_axis_group,
     axis_sign_power=None,
+    axis_direction_signs=None,
+    direction_sign_axis=-1,
     q_order,
     dim,
 ):
     if axis_sign_power is None:
         axis_sign_power = np.zeros(int(dim), dtype=np.uint8)
+    if axis_direction_signs is None:
+        axis_direction_signs = np.zeros(int(dim), dtype=np.int8)
 
     source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
     target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
@@ -1062,6 +1171,12 @@ def _evaluate_arithmetic_orbit_entry(
 
         if int(axis_sign_power[in_axis]):
             entry_sign *= applied_axis_sign
+        if int(direction_sign_axis) == out_axis:
+            entry_sign *= (
+                applied_axis_sign
+                * int(axis_direction_signs[in_axis])
+                * int(axis_direction_signs[out_axis])
+            )
 
         source_axes.append(source_axis)
         target_axes.append(target_axis)
@@ -1154,6 +1269,34 @@ def _entry_has_odd_axis_stabilizer(
     return False
 
 
+def _entry_has_odd_reconstruction_stabilizer(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    reconstruction_maps,
+):
+    transform_case_map = np.asarray(reconstruction_maps["transform_case_map"])
+    transform_qpoint_map = np.asarray(reconstruction_maps["transform_qpoint_map"])
+    transform_signs = np.asarray(reconstruction_maps["transform_signs"])
+
+    for transform_id, transform_sign in enumerate(transform_signs):
+        if int(transform_sign) >= 0:
+            continue
+        if int(transform_case_map[transform_id, case_id]) != int(case_id):
+            continue
+        if int(transform_qpoint_map[transform_id, source_mode_id]) != int(
+            source_mode_id
+        ):
+            continue
+        if int(transform_qpoint_map[transform_id, target_point_id]) != int(
+            target_point_id
+        ):
+            continue
+        return True
+
+    return False
+
+
 def _build_arithmetic_orbit_reconstruction(
     table,
     table_entry_ids,
@@ -1174,8 +1317,10 @@ def _build_arithmetic_orbit_reconstruction(
     if arithmetic_symmetry is None:
         return None
 
-    fixed_axes = arithmetic_symmetry["fixed_axes"]
     axis_sign_power = arithmetic_symmetry["axis_sign_power"]
+    axis_groups = arithmetic_symmetry["axis_groups"]
+    axis_direction_signs = arithmetic_symmetry["axis_direction_signs"]
+    direction_sign_axis = arithmetic_symmetry["direction_sign_axis"]
     if table.n_q_points > np.iinfo(np.uint16).max:
         return None
 
@@ -1188,7 +1333,8 @@ def _build_arithmetic_orbit_reconstruction(
     for case_id, case_vec in enumerate(case_vecs):
         axis_perm, axis_sign, axis_group = _case_arithmetic_axis_descriptors(
             case_vec,
-            fixed_axes=fixed_axes,
+            axis_groups=axis_groups,
+            direction_signs=axis_direction_signs,
         )
         canonical_vec = _canonical_case_from_axis_descriptors(
             case_vec,
@@ -1241,6 +1387,8 @@ def _build_arithmetic_orbit_reconstruction(
             case_axis_sign=case_axis_sign,
             case_axis_group=case_axis_group,
             axis_sign_power=axis_sign_power,
+            axis_direction_signs=axis_direction_signs,
+            direction_sign_axis=direction_sign_axis,
             q_order=table.quad_order,
             dim=table.dim,
         )
@@ -1252,13 +1400,11 @@ def _build_arithmetic_orbit_reconstruction(
         if existing >= 0 and existing != representative_full_id:
             raise RuntimeError("arithmetic ORBIT row layout is inconsistent")
         if existing >= 0 and int(layout_entry_scales[arithmetic_row]) != layout_scale:
-            if _entry_has_odd_axis_stabilizer(
-                case_vecs[case_id],
+            if _entry_has_odd_reconstruction_stabilizer(
+                case_id,
                 source_mode_id,
                 target_point_id,
-                axis_sign_power=axis_sign_power,
-                q_order=table.quad_order,
-                dim=table.dim,
+                reconstruction_maps,
             ):
                 sign_convention_conflict_count += 1
                 continue
@@ -1273,9 +1419,11 @@ def _build_arithmetic_orbit_reconstruction(
         case_axis_group,
         axis_sign_power,
     )
+    if direction_sign_axis >= 0:
+        metadata_arrays += (axis_direction_signs,)
     kind = (
         "signed-arithmetic-orbit"
-        if np.any(axis_sign_power)
+        if np.any(axis_sign_power) or direction_sign_axis >= 0
         else "scalar-arithmetic-orbit"
     )
 
@@ -1286,6 +1434,8 @@ def _build_arithmetic_orbit_reconstruction(
         "case_axis_sign": case_axis_sign,
         "case_axis_group": case_axis_group,
         "axis_sign_power": axis_sign_power,
+        "axis_direction_signs": axis_direction_signs,
+        "direction_sign_axis": int(direction_sign_axis),
         "layout_entry_ids": layout_entry_ids,
         "layout_entry_scales": layout_entry_scales,
         "n_case_orbits": int(len(unique_canonical_case_ids)),
@@ -2538,6 +2688,12 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                     "arithmetic_axis_sign_power_dev": cl.array.to_device(
                         queue, reconstruction_info["axis_sign_power"]
                     ),
+                    "arithmetic_axis_direction_signs_dev": cl.array.to_device(
+                        queue, reconstruction_info["axis_direction_signs"]
+                    ),
+                    "arithmetic_direction_sign_axis": int(
+                        reconstruction_info["direction_sign_axis"]
+                    ),
                 }
             )
         elif reconstruction_kind == "generated-orbit":
@@ -2778,6 +2934,12 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 ],
                 "arithmetic_axis_sign_power": payload[
                     "arithmetic_axis_sign_power_dev"
+                ],
+                "arithmetic_axis_direction_signs": payload[
+                    "arithmetic_axis_direction_signs_dev"
+                ],
+                "arithmetic_direction_sign_axis": payload[
+                    "arithmetic_direction_sign_axis"
                 ],
             }
         elif reconstruction_kind == "generated-orbit":
@@ -5432,6 +5594,12 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 "arithmetic_axis_sign_power": payload[
                     "arithmetic_axis_sign_power_dev"
                 ],
+                "arithmetic_axis_direction_signs": payload[
+                    "arithmetic_axis_direction_signs_dev"
+                ],
+                "arithmetic_direction_sign_axis": payload[
+                    "arithmetic_direction_sign_axis"
+                ],
             }
         elif reconstruction_kind == "generated-orbit":
             reconstruction_kwargs = {
@@ -5670,6 +5838,12 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                     ),
                     "arithmetic_axis_sign_power_dev": cl.array.to_device(
                         queue, reconstruction_info["axis_sign_power"]
+                    ),
+                    "arithmetic_axis_direction_signs_dev": cl.array.to_device(
+                        queue, reconstruction_info["axis_direction_signs"]
+                    ),
+                    "arithmetic_direction_sign_axis": int(
+                        reconstruction_info["direction_sign_axis"]
                     ),
                 }
             )

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -709,8 +709,7 @@ def _extract_symmetry_source_direction(out_kernel, source_extra_kwargs, queue):
     return np.asarray(comps, dtype=np.float64)
 
 
-def _derive_source_kernels_from_target_kernels(target_kernels):
-    from pytools import single_valued
+def _derive_source_kernels_from_target_kernels(target_kernels, *, require_single=True):
     from sumpy.kernel import TargetTransformationRemover
 
     txr = TargetTransformationRemover()
@@ -718,9 +717,15 @@ def _derive_source_kernels_from_target_kernels(target_kernels):
     if not target_kernels:
         return None
 
+    source_kernels = tuple(txr(knl) for knl in target_kernels)
+    if not require_single:
+        return source_kernels
+
+    from pytools import single_valued
+
     try:
-        source_knl = single_valued(txr(knl) for knl in target_kernels)
-    except ValueError as exc:
+        source_knl = single_valued(source_kernels)
+    except (AssertionError, ValueError) as exc:
         raise ValueError(
             "target kernels must share a single source-side kernel "
             "after removing target derivatives"
@@ -1757,12 +1762,16 @@ class FPNDSumpyTreeIndependentDataForWrangler(
         strength_usage=None,
         source_kernels=None,
     ):
+        target_has_source_derivatives = _target_kernels_include_source_derivatives(
+            target_kernels
+        )
         expansion_source_kernels = source_kernels
         if source_kernels is None:
             expansion_source_kernels = _derive_source_kernels_from_target_kernels(
-                target_kernels
+                target_kernels,
+                require_single=not target_has_source_derivatives,
             )
-            if not _target_kernels_include_source_derivatives(target_kernels):
+            if not target_has_source_derivatives:
                 source_kernels = expansion_source_kernels
 
         queue = cl.CommandQueue(cl_context)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -24,6 +24,7 @@ import json
 import logging
 import hashlib
 import math
+import warnings
 from collections import OrderedDict
 from dataclasses import dataclass
 
@@ -1659,6 +1660,15 @@ def _prepare_table_data_and_entry_map(table_levels):
             table_entry_ids,
             table_entry_scales,
         )
+        if reconstruction_info is not None:
+            warnings.warn(
+                "using generated-orbit fallback for near-field table "
+                "reconstruction; this compact fallback is correct but not "
+                "GPU-ideal because it still uses transform scans and lookup "
+                f"tables (kernel={table0.integral_knl!r})",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     if reconstruction_info is None:
         reconstruction_info = {

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -865,34 +865,159 @@ def _evaluate_generated_orbit_reconstruction(
     return representative_entry_ids, representative_scales
 
 
-def _case_arithmetic_axis_descriptors(case_vec):
+_ARITHMETIC_RECONSTRUCTION_KINDS = {
+    "scalar-arithmetic-orbit",
+    "signed-arithmetic-orbit",
+}
+
+
+def _case_arithmetic_axis_descriptors(case_vec, fixed_axes=()):
     case_vec = [int(val) for val in case_vec]
-    order = sorted(
-        range(len(case_vec)), key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis)
+    dim = len(case_vec)
+    fixed_axes = frozenset(int(axis) for axis in fixed_axes)
+
+    axis_perm = np.empty(dim, dtype=np.uint8)
+    axis_signs = np.empty(dim, dtype=np.int8)
+    axis_groups = np.empty(dim, dtype=np.uint8)
+    group_id = 0
+
+    def sign_to_negative(value):
+        value = int(value)
+        if value > 0:
+            return -1
+        if value < 0:
+            return 1
+        return 0
+
+    for iaxis in sorted(fixed_axes):
+        axis_perm[iaxis] = iaxis
+        axis_signs[iaxis] = sign_to_negative(case_vec[iaxis])
+        axis_groups[iaxis] = group_id
+        group_id += 1
+
+    free_axes = [iaxis for iaxis in range(dim) if iaxis not in fixed_axes]
+    free_order = sorted(
+        free_axes,
+        key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis),
     )
 
-    axis_signs = []
-    axis_groups = []
     last_abs = None
-    group_id = -1
-    for iaxis in order:
-        value = int(case_vec[iaxis])
+    current_group = group_id - 1
+    for out_axis, in_axis in zip(free_axes, free_order, strict=True):
+        value = int(case_vec[in_axis])
         abs_value = abs(value)
         if last_abs != abs_value:
-            group_id += 1
+            current_group += 1
             last_abs = abs_value
-        axis_groups.append(group_id)
-        if value > 0:
-            axis_signs.append(-1)
-        elif value < 0:
-            axis_signs.append(1)
-        else:
-            axis_signs.append(0)
+        axis_perm[out_axis] = in_axis
+        axis_signs[out_axis] = sign_to_negative(value)
+        axis_groups[out_axis] = current_group
 
-    return order, axis_signs, axis_groups
+    return axis_perm, axis_signs, axis_groups
 
 
-def _evaluate_scalar_arithmetic_entry(
+def _canonical_case_from_axis_descriptors(case_vec, axis_perm, axis_sign):
+    canonical = []
+    for in_axis, sign in zip(axis_perm, axis_sign, strict=True):
+        value = int(case_vec[int(in_axis)])
+        sign = int(sign)
+        canonical.append(0 if sign == 0 else value * sign)
+
+    return canonical
+
+
+def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
+    dim = int(table.dim)
+    fixed_axes = set()
+    axis_sign_power = np.zeros(dim, dtype=np.uint8)
+
+    kernel = table.integral_knl
+    while kernel is not None:
+        cls_name = kernel.__class__.__name__
+        if cls_name in {"AxisTargetDerivative", "AxisSourceDerivative"}:
+            axis = int(kernel.axis)
+            if axis < 0 or axis >= dim:
+                return None
+            fixed_axes.add(axis)
+            axis_sign_power[axis] ^= np.uint8(1)
+            kernel = kernel.inner_kernel
+            continue
+
+        if cls_name == "DirectionalSourceDerivative":
+            source_direction = getattr(kernel, "_volumential_source_direction", None)
+            if source_direction is None:
+                return None
+            source_direction = np.asarray(source_direction, dtype=np.float64).ravel()
+            if source_direction.shape != (dim,):
+                return None
+            axis_candidates = np.flatnonzero(
+                np.abs(source_direction) > 100 * np.finfo(np.float64).eps
+            )
+            if len(axis_candidates) != 1:
+                return None
+            axis = int(axis_candidates[0])
+            fixed_axes.add(axis)
+            axis_sign_power[axis] ^= np.uint8(1)
+            kernel = kernel.inner_kernel
+            continue
+
+        if hasattr(kernel, "inner_kernel"):
+            kernel = kernel.inner_kernel
+            continue
+
+        break
+
+    from itertools import permutations, product
+
+    expected = set()
+    for sign_tuple in product([-1, 1], repeat=dim):
+        for perm_tuple in permutations(range(dim)):
+            if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
+                continue
+
+            transform_sign = 1
+            for axis in range(dim):
+                if int(axis_sign_power[axis]):
+                    transform_sign *= int(sign_tuple[axis])
+
+            expected.add(
+                (
+                    tuple(int(val) for val in sign_tuple),
+                    tuple(int(val) for val in perm_tuple),
+                    int(transform_sign),
+                )
+            )
+
+    signatures = reconstruction_maps.get("transform_signatures")
+    if signatures is None:
+        return None
+
+    actual = {
+        (
+            tuple(int(val) for val in sign_tuple),
+            tuple(int(val) for val in perm_tuple),
+            int(transform_sign),
+        )
+        for (sign_tuple, perm_tuple), transform_sign in zip(
+            signatures,
+            np.asarray(reconstruction_maps["transform_signs"], dtype=np.int8),
+            strict=True,
+        )
+    }
+
+    if actual != expected:
+        return None
+
+    if len(actual) != len(signatures):
+        return None
+
+    return {
+        "fixed_axes": tuple(sorted(int(axis) for axis in fixed_axes)),
+        "axis_sign_power": axis_sign_power,
+    }
+
+
+def _evaluate_arithmetic_orbit_entry(
     case_id,
     source_mode_id,
     target_point_id,
@@ -901,30 +1026,41 @@ def _evaluate_scalar_arithmetic_entry(
     case_axis_perm,
     case_axis_sign,
     case_axis_group,
+    axis_sign_power=None,
     q_order,
     dim,
 ):
+    if axis_sign_power is None:
+        axis_sign_power = np.zeros(int(dim), dtype=np.uint8)
+
     source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
     target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
 
     source_axes = []
     target_axes = []
     groups = []
+    entry_sign = 1
     for out_axis in range(int(dim)):
         in_axis = int(case_axis_perm[case_id, out_axis])
         axis_sign = int(case_axis_sign[case_id, out_axis])
         source_axis = source_axes_raw[in_axis]
         target_axis = target_axes_raw[in_axis]
+        applied_axis_sign = 1
 
         if axis_sign < 0:
             source_axis = int(q_order) - 1 - source_axis
             target_axis = int(q_order) - 1 - target_axis
+            applied_axis_sign = -1
         elif axis_sign == 0:
             flipped_source = int(q_order) - 1 - source_axis
             flipped_target = int(q_order) - 1 - target_axis
             if (flipped_source, flipped_target) < (source_axis, target_axis):
                 source_axis = flipped_source
                 target_axis = flipped_target
+                applied_axis_sign = -1
+
+        if int(axis_sign_power[in_axis]):
+            entry_sign *= applied_axis_sign
 
         source_axes.append(source_axis)
         target_axes.append(target_axis)
@@ -958,14 +1094,66 @@ def _evaluate_scalar_arithmetic_entry(
     canonical_source = _encode_mode_axes(source_axes, q_order)
     canonical_target = _encode_mode_axes(target_axes, q_order)
     n_q_points = int(q_order) ** int(dim)
-    return (
+    entry_id = (
         int(case_orbit_ranks[case_id]) * n_q_points * n_q_points
         + canonical_source * n_q_points
         + canonical_target
     )
+    return int(entry_id), int(entry_sign)
 
 
-def _build_scalar_arithmetic_orbit_reconstruction(
+def _evaluate_scalar_arithmetic_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    q_order,
+    dim,
+):
+    entry_id, _ = _evaluate_arithmetic_orbit_entry(
+        case_id,
+        source_mode_id,
+        target_point_id,
+        case_orbit_ranks=case_orbit_ranks,
+        case_axis_perm=case_axis_perm,
+        case_axis_sign=case_axis_sign,
+        case_axis_group=case_axis_group,
+        q_order=q_order,
+        dim=dim,
+    )
+    return entry_id
+
+
+def _entry_has_odd_axis_stabilizer(
+    case_vec,
+    source_mode_id,
+    target_point_id,
+    *,
+    axis_sign_power,
+    q_order,
+    dim,
+):
+    source_axes = _decode_mode_axes(source_mode_id, q_order, dim)
+    target_axes = _decode_mode_axes(target_point_id, q_order, dim)
+    for axis in range(int(dim)):
+        if not int(axis_sign_power[axis]):
+            continue
+        if int(case_vec[axis]) != 0:
+            continue
+        if source_axes[axis] != int(q_order) - 1 - source_axes[axis]:
+            continue
+        if target_axes[axis] != int(q_order) - 1 - target_axes[axis]:
+            continue
+        return True
+
+    return False
+
+
+def _build_arithmetic_orbit_reconstruction(
     table,
     table_entry_ids,
     table_entry_scales,
@@ -978,26 +1166,40 @@ def _build_scalar_arithmetic_orbit_reconstruction(
         return None
 
     reconstruction_maps = table._get_orbit_reconstruction_maps()
-    transform_signs = np.asarray(reconstruction_maps["transform_signs"], dtype=np.int8)
-    expected_transform_count = (2 ** int(table.dim)) * math.factorial(int(table.dim))
-    if len(transform_signs) != expected_transform_count:
-        return None
-    if not np.all(transform_signs == 1):
-        return None
-    if table.n_q_points > np.iinfo(np.uint16).max:
+    arithmetic_symmetry = _kernel_axis_preserving_arithmetic_symmetry(
+        table,
+        reconstruction_maps,
+    )
+    if arithmetic_symmetry is None:
         return None
 
-    table_entry_scales_real = np.real(np.asarray(table_entry_scales))
-    if not np.all(table_entry_scales_real == 1):
+    fixed_axes = arithmetic_symmetry["fixed_axes"]
+    axis_sign_power = arithmetic_symmetry["axis_sign_power"]
+    if table.n_q_points > np.iinfo(np.uint16).max:
         return None
 
     case_vecs = np.asarray(table.interaction_case_vecs, dtype=np.int32)
     canonical_case_ids = np.empty(table.n_cases, dtype=np.int32)
+    case_axis_perm = np.empty((table.n_cases, table.dim), dtype=np.uint8)
+    case_axis_sign = np.empty((table.n_cases, table.dim), dtype=np.int8)
+    case_axis_group = np.empty((table.n_cases, table.dim), dtype=np.uint8)
+
     for case_id, case_vec in enumerate(case_vecs):
-        canonical_vec = [-int(val) for val in sorted(np.abs(case_vec), reverse=True)]
+        axis_perm, axis_sign, axis_group = _case_arithmetic_axis_descriptors(
+            case_vec,
+            fixed_axes=fixed_axes,
+        )
+        canonical_vec = _canonical_case_from_axis_descriptors(
+            case_vec,
+            axis_perm,
+            axis_sign,
+        )
         canonical_case_ids[case_id] = int(
             table.case_indices[table.case_encode(canonical_vec)]
         )
+        case_axis_perm[case_id, :] = axis_perm
+        case_axis_sign[case_id, :] = axis_sign
+        case_axis_group[case_id, :] = axis_group
 
     unique_canonical_case_ids = np.unique(canonical_case_ids)
     if len(unique_canonical_case_ids) > np.iinfo(np.uint16).max:
@@ -1007,32 +1209,29 @@ def _build_scalar_arithmetic_orbit_reconstruction(
         int(case_id): rank for rank, case_id in enumerate(unique_canonical_case_ids)
     }
     case_orbit_ranks = np.empty(table.n_cases, dtype=np.uint16)
-    case_axis_perm = np.empty((table.n_cases, table.dim), dtype=np.uint8)
-    case_axis_sign = np.empty((table.n_cases, table.dim), dtype=np.int8)
-    case_axis_group = np.empty((table.n_cases, table.dim), dtype=np.uint8)
 
-    for case_id, case_vec in enumerate(case_vecs):
+    for case_id in range(table.n_cases):
         case_orbit_ranks[case_id] = canonical_case_rank_by_id[
             int(canonical_case_ids[case_id])
         ]
-        axis_perm, axis_sign, axis_group = _case_arithmetic_axis_descriptors(case_vec)
-        case_axis_perm[case_id, :] = axis_perm
-        case_axis_sign[case_id, :] = axis_sign
-        case_axis_group[case_id, :] = axis_group
 
     n_arithmetic_entries = len(unique_canonical_case_ids) * table.n_pairs
     layout_entry_ids = np.full(n_arithmetic_entries, -1, dtype=np.int64)
+    layout_entry_scales = np.ones(n_arithmetic_entries, dtype=np.int8)
+    sign_convention_conflict_count = 0
     full_entry_count = table.n_cases * table.n_pairs
     representative_entry_ids = np.asarray(
         table._get_orbit_canonical_info()["entry_ids"], dtype=np.int64
     )
+    table_entry_ids = np.asarray(table_entry_ids, dtype=np.int32)
+    expected_scales = np.real(np.asarray(table_entry_scales)).astype(np.int8)
 
     for full_entry_id in range(full_entry_count):
         case_id = full_entry_id // table.n_pairs
         pair_id = full_entry_id % table.n_pairs
         source_mode_id = pair_id // table.n_q_points
         target_point_id = pair_id % table.n_q_points
-        arithmetic_row = _evaluate_scalar_arithmetic_entry(
+        arithmetic_row, arithmetic_sign = _evaluate_arithmetic_orbit_entry(
             case_id,
             source_mode_id,
             target_point_id,
@@ -1040,35 +1239,71 @@ def _build_scalar_arithmetic_orbit_reconstruction(
             case_axis_perm=case_axis_perm,
             case_axis_sign=case_axis_sign,
             case_axis_group=case_axis_group,
+            axis_sign_power=axis_sign_power,
             q_order=table.quad_order,
             dim=table.dim,
         )
         representative_full_id = int(
             representative_entry_ids[table_entry_ids[full_entry_id]]
         )
+        layout_scale = int(expected_scales[full_entry_id]) * int(arithmetic_sign)
         existing = int(layout_entry_ids[arithmetic_row])
         if existing >= 0 and existing != representative_full_id:
             raise RuntimeError("arithmetic ORBIT row layout is inconsistent")
+        if existing >= 0 and int(layout_entry_scales[arithmetic_row]) != layout_scale:
+            if _entry_has_odd_axis_stabilizer(
+                case_vecs[case_id],
+                source_mode_id,
+                target_point_id,
+                axis_sign_power=axis_sign_power,
+                q_order=table.quad_order,
+                dim=table.dim,
+            ):
+                sign_convention_conflict_count += 1
+                continue
+            raise RuntimeError("arithmetic ORBIT row sign layout is inconsistent")
         layout_entry_ids[arithmetic_row] = representative_full_id
+        layout_entry_scales[arithmetic_row] = layout_scale
 
     metadata_arrays = (
         case_orbit_ranks,
         case_axis_perm,
         case_axis_sign,
         case_axis_group,
+        axis_sign_power,
+    )
+    kind = (
+        "signed-arithmetic-orbit"
+        if np.any(axis_sign_power)
+        else "scalar-arithmetic-orbit"
     )
 
     return {
-        "kind": "scalar-arithmetic-orbit",
+        "kind": kind,
         "case_orbit_ranks": case_orbit_ranks,
         "case_axis_perm": case_axis_perm,
         "case_axis_sign": case_axis_sign,
         "case_axis_group": case_axis_group,
+        "axis_sign_power": axis_sign_power,
         "layout_entry_ids": layout_entry_ids,
+        "layout_entry_scales": layout_entry_scales,
         "n_case_orbits": int(len(unique_canonical_case_ids)),
         "metadata_bytes": int(sum(arr.nbytes for arr in metadata_arrays)),
         "unused_layout_entry_count": int(np.count_nonzero(layout_entry_ids < 0)),
+        "sign_convention_conflict_count": int(sign_convention_conflict_count),
     }
+
+
+def _build_scalar_arithmetic_orbit_reconstruction(
+    table,
+    table_entry_ids,
+    table_entry_scales,
+):
+    return _build_arithmetic_orbit_reconstruction(
+        table,
+        table_entry_ids,
+        table_entry_scales,
+    )
 
 
 def _build_generated_orbit_reconstruction(table, table_entry_ids, table_entry_scales):
@@ -1241,8 +1476,17 @@ def _prepare_table_data_and_entry_map(table_levels):
 
     layout_entry_ids = reconstruction_info.get("layout_entry_ids", kept_entry_ids)
     layout_entry_ids = np.asarray(layout_entry_ids, dtype=np.int64)
+    layout_entry_scales = reconstruction_info.get("layout_entry_scales")
+    if layout_entry_scales is None:
+        layout_entry_scales = np.ones(len(layout_entry_ids), dtype=table0.data.dtype)
+    else:
+        layout_entry_scales = np.asarray(layout_entry_scales, dtype=table0.data.dtype)
+    if layout_entry_scales.shape != layout_entry_ids.shape:
+        raise RuntimeError("reconstruction layout entry scales have incompatible shape")
+
     used_layout_mask = layout_entry_ids >= 0
     used_layout_entry_ids = layout_entry_ids[used_layout_mask]
+    used_layout_scales = layout_entry_scales[used_layout_mask]
     if len(used_layout_entry_ids) == 0:
         raise RuntimeError("near-field reconstruction layout contains no entries")
     if not np.all(np.isfinite(table0.data[used_layout_entry_ids])):
@@ -1267,7 +1511,9 @@ def _prepare_table_data_and_entry_map(table_levels):
     )
 
     for lev, table in enumerate(table_levels):
-        table_data_combined[lev, used_layout_mask] = table.data[used_layout_entry_ids]
+        table_data_combined[lev, used_layout_mask] = (
+            table.data[used_layout_entry_ids] * used_layout_scales
+        )
         mode_nmlz_combined[lev, :] = table.mode_normalizers
         exterior_mode_nmlz_combined[lev, :] = table.kernel_exterior_normalizers
 
@@ -2187,7 +2433,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             "n_table_entries": table_data_combined.shape[1],
             "reconstruction_kind": reconstruction_kind,
         }
-        if reconstruction_kind == "scalar-arithmetic-orbit":
+        if reconstruction_kind in _ARITHMETIC_RECONSTRUCTION_KINDS:
             table_data_shapes.update(
                 {
                     "n_arithmetic_case_orbits": int(
@@ -2226,6 +2472,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             "generated_sign_correction_count": int(
                 reconstruction_info.get("sign_correction_count", 0)
             ),
+            "sign_convention_conflict_count": int(
+                reconstruction_info.get("sign_convention_conflict_count", 0)
+            ),
             "unused_arithmetic_layout_entries": int(
                 reconstruction_info.get("unused_layout_entry_count", 0)
             ),
@@ -2244,7 +2493,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             "reconstruction_diagnostics": reconstruction_diagnostics,
         }
 
-        if reconstruction_kind == "scalar-arithmetic-orbit":
+        if reconstruction_kind in _ARITHMETIC_RECONSTRUCTION_KINDS:
             payload.update(
                 {
                     "arithmetic_case_orbit_ranks_dev": cl.array.to_device(
@@ -2258,6 +2507,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                     ),
                     "arithmetic_case_axis_group_dev": cl.array.to_device(
                         queue, reconstruction_info["case_axis_group"]
+                    ),
+                    "arithmetic_axis_sign_power_dev": cl.array.to_device(
+                        queue, reconstruction_info["axis_sign_power"]
                     ),
                 }
             )
@@ -2483,7 +2735,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         table_data_combined = payload["table_data_dev"]
         mode_nmlz_combined = payload["mode_nmlz_dev"]
         exterior_mode_nmlz_combined = payload["exterior_mode_nmlz_dev"]
-        if reconstruction_kind == "scalar-arithmetic-orbit":
+        if reconstruction_kind in _ARITHMETIC_RECONSTRUCTION_KINDS:
             reconstruction_kwargs = {
                 "arithmetic_case_orbit_ranks": payload[
                     "arithmetic_case_orbit_ranks_dev"
@@ -2496,6 +2748,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 ],
                 "arithmetic_case_axis_group": payload[
                     "arithmetic_case_axis_group_dev"
+                ],
+                "arithmetic_axis_sign_power": payload[
+                    "arithmetic_axis_sign_power_dev"
                 ],
             }
         elif reconstruction_kind == "generated-orbit":
@@ -5133,7 +5388,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         table_data_combined = payload["table_data_dev"]
         mode_nmlz_combined = payload["mode_nmlz_dev"]
         exterior_mode_nmlz_combined = payload["exterior_mode_nmlz_dev"]
-        if reconstruction_kind == "scalar-arithmetic-orbit":
+        if reconstruction_kind in _ARITHMETIC_RECONSTRUCTION_KINDS:
             reconstruction_kwargs = {
                 "arithmetic_case_orbit_ranks": payload[
                     "arithmetic_case_orbit_ranks_dev"
@@ -5146,6 +5401,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 ],
                 "arithmetic_case_axis_group": payload[
                     "arithmetic_case_axis_group_dev"
+                ],
+                "arithmetic_axis_sign_power": payload[
+                    "arithmetic_axis_sign_power_dev"
                 ],
             }
         elif reconstruction_kind == "generated-orbit":
@@ -5308,7 +5566,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             "n_table_entries": table_data_combined.shape[1],
             "reconstruction_kind": reconstruction_kind,
         }
-        if reconstruction_kind == "scalar-arithmetic-orbit":
+        if reconstruction_kind in _ARITHMETIC_RECONSTRUCTION_KINDS:
             table_data_shapes.update(
                 {
                     "n_arithmetic_case_orbits": int(
@@ -5347,6 +5605,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             "generated_sign_correction_count": int(
                 reconstruction_info.get("sign_correction_count", 0)
             ),
+            "sign_convention_conflict_count": int(
+                reconstruction_info.get("sign_convention_conflict_count", 0)
+            ),
             "unused_arithmetic_layout_entries": int(
                 reconstruction_info.get("unused_layout_entry_count", 0)
             ),
@@ -5365,7 +5626,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             "reconstruction_diagnostics": reconstruction_diagnostics,
         }
 
-        if reconstruction_kind == "scalar-arithmetic-orbit":
+        if reconstruction_kind in _ARITHMETIC_RECONSTRUCTION_KINDS:
             payload.update(
                 {
                     "arithmetic_case_orbit_ranks_dev": cl.array.to_device(
@@ -5379,6 +5640,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                     ),
                     "arithmetic_case_axis_group_dev": cl.array.to_device(
                         queue, reconstruction_info["case_axis_group"]
+                    ),
+                    "arithmetic_axis_sign_power_dev": cl.array.to_device(
+                        queue, reconstruction_info["axis_sign_power"]
                     ),
                 }
             )

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -59,6 +59,9 @@ from volumential.nearfield_potential_table import NearFieldInteractionTable
 logger = logging.getLogger(__name__)
 
 
+_ORBIT_RECONSTRUCTION_HASH_MULTIPLIER = 33
+
+
 @dataclass(frozen=True)
 class HelmholtzSplitCacheAccounting:
     split_enabled: bool
@@ -722,6 +725,206 @@ def _target_kernels_include_source_derivatives(target_kernels):
     return False
 
 
+def _build_open_addressed_int_lookup(
+    keys, *, max_load_factor=0.5, target_max_probe_count=16
+):
+    keys = np.asarray(keys, dtype=np.int64)
+    if keys.ndim != 1:
+        raise ValueError("lookup keys must be one-dimensional")
+    if len(keys) == 0:
+        raise ValueError("lookup keys cannot be empty")
+    if np.any(keys < 0) or np.any(keys > np.iinfo(np.int32).max):
+        raise ValueError("lookup keys must fit in nonnegative int32")
+
+    size = 1
+    min_size = int(math.ceil(len(keys) / float(max_load_factor)))
+    while size < min_size:
+        size *= 2
+
+    while True:
+        lookup_keys = np.full(size, -1, dtype=np.int32)
+        lookup_values = np.full(size, -1, dtype=np.int32)
+        max_probe_count = 0
+        mask = size - 1
+
+        for value, key64 in enumerate(keys.tolist()):
+            key = int(key64)
+            slot = (key * _ORBIT_RECONSTRUCTION_HASH_MULTIPLIER) & mask
+            probe_count = 1
+            while lookup_keys[slot] != -1:
+                if int(lookup_keys[slot]) == key:
+                    raise ValueError("lookup keys must be unique")
+                slot = (slot + 1) & mask
+                probe_count += 1
+            lookup_keys[slot] = key
+            lookup_values[slot] = value
+            max_probe_count = max(max_probe_count, probe_count)
+
+        if max_probe_count <= target_max_probe_count or size >= 64 * len(keys):
+            return lookup_keys, lookup_values, max_probe_count
+
+        size *= 2
+
+
+def _build_sparse_sign_lookup(keys, values):
+    keys = np.asarray(keys, dtype=np.int64)
+    values = np.asarray(values, dtype=np.int8)
+    if keys.shape != values.shape:
+        raise ValueError("sign lookup keys and values must have the same shape")
+
+    if len(keys) == 0:
+        return (
+            np.full(1, -1, dtype=np.int32),
+            np.ones(1, dtype=np.int8),
+            1,
+        )
+
+    lookup_keys, lookup_values_i32, max_probe_count = _build_open_addressed_int_lookup(
+        keys,
+        max_load_factor=0.5,
+    )
+    lookup_values = np.ones(lookup_values_i32.shape, dtype=np.int8)
+    occupied = lookup_values_i32 >= 0
+    lookup_values[occupied] = values[lookup_values_i32[occupied]]
+    return lookup_keys, lookup_values, max_probe_count
+
+
+def _evaluate_generated_orbit_reconstruction(
+    transform_qpoint_map,
+    transform_case_map,
+    transform_signs,
+    *,
+    n_cases,
+    n_q_points,
+):
+    transform_qpoint_map = np.asarray(transform_qpoint_map, dtype=np.int64)
+    transform_case_map = np.asarray(transform_case_map, dtype=np.int64)
+    transform_signs = np.asarray(transform_signs, dtype=np.int8)
+
+    if transform_qpoint_map.ndim != 2:
+        raise ValueError("transform_qpoint_map must be two-dimensional")
+    if transform_case_map.ndim != 2:
+        raise ValueError("transform_case_map must be two-dimensional")
+    if transform_qpoint_map.shape[0] != transform_case_map.shape[0]:
+        raise ValueError("transform maps disagree on transform count")
+    if transform_signs.shape != (transform_qpoint_map.shape[0],):
+        raise ValueError("transform_signs disagrees with transform maps")
+
+    n_transforms = int(transform_qpoint_map.shape[0])
+    n_pairs = int(n_q_points) * int(n_q_points)
+    n_entries = int(n_cases) * n_pairs
+    transform_ids = np.arange(n_transforms, dtype=np.int64)
+    sign_tie_breakers = np.where(transform_signs > 0, 0, 1).astype(np.int64)
+
+    representative_entry_ids = np.empty(n_entries, dtype=np.int64)
+    representative_scales = np.empty(n_entries, dtype=np.int8)
+
+    for case_id in range(int(n_cases)):
+        transformed_cases = transform_case_map[:, case_id]
+        for source_mode_id in range(int(n_q_points)):
+            transformed_sources = transform_qpoint_map[:, source_mode_id]
+            row = case_id * n_pairs + source_mode_id * int(n_q_points)
+            for target_point_id in range(int(n_q_points)):
+                transformed_targets = transform_qpoint_map[:, target_point_id]
+                candidates = (
+                    transformed_cases * n_pairs
+                    + transformed_sources * int(n_q_points)
+                    + transformed_targets
+                )
+                # Prefer positive stabilizer signs, then transform id. This matches
+                # the dense oracle's convention that a representative scales itself
+                # by +1 even if an odd stabilizer transform also fixes the entry.
+                best_key = int(
+                    np.min(
+                        candidates * (2 * n_transforms)
+                        + sign_tie_breakers * n_transforms
+                        + transform_ids
+                    )
+                )
+                best_transform = best_key % n_transforms
+                entry_id = row + target_point_id
+                representative_entry_ids[entry_id] = best_key // (2 * n_transforms)
+                representative_scales[entry_id] = transform_signs[best_transform]
+
+    return representative_entry_ids, representative_scales
+
+
+def _build_generated_orbit_reconstruction(table, table_entry_ids, table_entry_scales):
+    if not hasattr(table, "_get_orbit_reconstruction_maps"):
+        return None
+    if not bool(getattr(table, "table_data_is_symmetry_reduced", False)):
+        return None
+
+    orbit_info = table._get_orbit_canonical_info()
+    representative_entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
+    if len(representative_entry_ids) == 0:
+        return None
+
+    reconstruction_maps = table._get_orbit_reconstruction_maps()
+    transform_qpoint_map = np.asarray(
+        reconstruction_maps["transform_qpoint_map"], dtype=np.int32
+    )
+    transform_case_map = np.asarray(
+        reconstruction_maps["transform_case_map"], dtype=np.int32
+    )
+    transform_signs = np.asarray(reconstruction_maps["transform_signs"], dtype=np.int8)
+
+    generated_entry_ids, generated_scales = _evaluate_generated_orbit_reconstruction(
+        transform_qpoint_map,
+        transform_case_map,
+        transform_signs,
+        n_cases=table.n_cases,
+        n_q_points=table.n_q_points,
+    )
+
+    table_entry_ids = np.asarray(table_entry_ids, dtype=np.int32)
+    table_entry_scales = np.asarray(table_entry_scales)
+    expected_entry_ids = representative_entry_ids[table_entry_ids]
+    expected_scales = np.real(table_entry_scales).astype(np.int8)
+
+    if not np.array_equal(generated_entry_ids, expected_entry_ids):
+        raise RuntimeError("generated ORBIT representative ids disagree with dense map")
+
+    sign_correction_entry_ids = np.flatnonzero(generated_scales != expected_scales)
+    sign_corrections = (
+        expected_scales[sign_correction_entry_ids]
+        // generated_scales[sign_correction_entry_ids]
+    ).astype(np.int8)
+
+    lookup_keys, lookup_values, max_probe_count = _build_open_addressed_int_lookup(
+        representative_entry_ids
+    )
+    sign_lookup_keys, sign_lookup_values, sign_lookup_max_probe_count = (
+        _build_sparse_sign_lookup(sign_correction_entry_ids, sign_corrections)
+    )
+
+    metadata_arrays = (
+        transform_qpoint_map,
+        transform_case_map,
+        transform_signs,
+        lookup_keys,
+        lookup_values,
+        sign_lookup_keys,
+        sign_lookup_values,
+    )
+
+    return {
+        "kind": "generated-orbit",
+        "transform_qpoint_map": np.ascontiguousarray(transform_qpoint_map),
+        "transform_case_map": np.ascontiguousarray(transform_case_map),
+        "transform_signs": np.ascontiguousarray(transform_signs),
+        "lookup_keys": lookup_keys,
+        "lookup_values": lookup_values,
+        "lookup_max_probe_count": int(max_probe_count),
+        "sign_lookup_keys": sign_lookup_keys,
+        "sign_lookup_values": sign_lookup_values,
+        "sign_lookup_max_probe_count": int(sign_lookup_max_probe_count),
+        "sign_correction_count": int(len(sign_correction_entry_ids)),
+        "metadata_bytes": int(sum(arr.nbytes for arr in metadata_arrays)),
+        "representative_entry_ids": representative_entry_ids,
+    }
+
+
 def _prepare_table_data_and_entry_map(table_levels):
     if not table_levels:
         raise ValueError("table_levels cannot be empty")
@@ -796,6 +999,17 @@ def _prepare_table_data_and_entry_map(table_levels):
         table_entry_ids[kept_entry_ids] = np.arange(len(kept_entry_ids), dtype=np.int32)
         table_entry_scales = np.ones(n_full_entries, dtype=table0.data.dtype)
 
+    reconstruction_info = _build_generated_orbit_reconstruction(
+        table0,
+        table_entry_ids,
+        table_entry_scales,
+    )
+    if reconstruction_info is None:
+        reconstruction_info = {
+            "kind": "dense",
+            "metadata_bytes": int(table_entry_ids.nbytes + table_entry_scales.nbytes),
+        }
+
     table_data_combined = np.zeros(
         (len(table_levels), len(kept_entry_ids)),
         dtype=table0.data.dtype,
@@ -820,6 +1034,7 @@ def _prepare_table_data_and_entry_map(table_levels):
         exterior_mode_nmlz_combined,
         table_entry_ids,
         table_entry_scales,
+        reconstruction_info,
     )
 
 
@@ -1683,26 +1898,19 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         base = len(range(min(distinct_numbers), max(distinct_numbers) + 1))
         shift = -min(distinct_numbers)
 
-        case_indices_dev = cl.array.to_device(queue, table0.case_indices)
-        symmetry_maps = table0._get_online_symmetry_maps()
-        mode_qpoint_map_dev = cl.array.to_device(
-            queue, symmetry_maps["mode_qpoint_map"]
-        )
-        mode_case_map_dev = cl.array.to_device(queue, symmetry_maps["mode_case_map"])
-        mode_case_scale = symmetry_maps.get("mode_case_scale")
-        if mode_case_scale is None:
-            mode_case_scale = np.ones(
-                (table0.n_q_points, table0.n_cases),
-                dtype=np.int8,
-            )
-
         (
             table_data_combined,
             mode_nmlz_combined,
             exterior_mode_nmlz_combined,
             table_entry_ids,
             table_entry_scales,
+            reconstruction_info,
         ) = _prepare_table_data_and_entry_map(near_field_tables)
+
+        case_indices_dev = cl.array.to_device(queue, table0.case_indices)
+        reconstruction_kind = reconstruction_info["kind"]
+        dense_id_bytes = int(table_entry_ids.nbytes)
+        dense_scale_bytes = int(table_entry_scales.size * np.dtype(eval_dtype).itemsize)
 
         if table_data_combined.dtype != eval_dtype:
             table_data_combined = table_data_combined.astype(eval_dtype)
@@ -1710,34 +1918,115 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             mode_nmlz_combined = mode_nmlz_combined.astype(eval_dtype)
         if exterior_mode_nmlz_combined.dtype != eval_dtype:
             exterior_mode_nmlz_combined = exterior_mode_nmlz_combined.astype(eval_dtype)
-        if table_entry_scales.dtype != eval_dtype:
-            table_entry_scales = table_entry_scales.astype(eval_dtype)
-        if mode_case_scale.dtype != eval_dtype:
-            mode_case_scale = mode_case_scale.astype(eval_dtype)
+
+        if reconstruction_kind == "dense":
+            symmetry_maps = table0._get_online_symmetry_maps()
+            mode_qpoint_map_dev = cl.array.to_device(
+                queue, symmetry_maps["mode_qpoint_map"]
+            )
+            mode_case_map_dev = cl.array.to_device(queue, symmetry_maps["mode_case_map"])
+            mode_case_scale = symmetry_maps.get("mode_case_scale")
+            if mode_case_scale is None:
+                mode_case_scale = np.ones(
+                    (table0.n_q_points, table0.n_cases),
+                    dtype=np.int8,
+                )
+            if table_entry_scales.dtype != eval_dtype:
+                table_entry_scales = table_entry_scales.astype(eval_dtype)
+            if mode_case_scale.dtype != eval_dtype:
+                mode_case_scale = mode_case_scale.astype(eval_dtype)
 
         table_data_shapes = {
             "n_tables": len(near_field_tables),
             "n_q_points": table0.n_q_points,
             "n_cases": table0.n_cases,
             "n_table_entries": table_data_combined.shape[1],
+            "reconstruction_kind": reconstruction_kind,
+        }
+        if reconstruction_kind == "generated-orbit":
+            table_data_shapes.update(
+                {
+                    "n_reconstruction_transforms": reconstruction_info[
+                        "transform_signs"
+                    ].shape[0],
+                    "n_reconstruction_lookup_entries": reconstruction_info[
+                        "lookup_keys"
+                    ].shape[0],
+                    "n_reconstruction_lookup_probes": int(
+                        reconstruction_info["lookup_max_probe_count"]
+                    ),
+                    "n_reconstruction_sign_lookup_entries": reconstruction_info[
+                        "sign_lookup_keys"
+                    ].shape[0],
+                    "n_reconstruction_sign_lookup_probes": int(
+                        reconstruction_info["sign_lookup_max_probe_count"]
+                    ),
+                }
+            )
+
+        reconstruction_diagnostics = {
+            "kind": reconstruction_kind,
+            "representative_value_bytes": int(table_data_combined.nbytes),
+            "dense_entry_id_bytes": dense_id_bytes,
+            "dense_entry_scale_bytes": dense_scale_bytes,
+            "dense_metadata_bytes": int(dense_id_bytes + dense_scale_bytes),
+            "generated_metadata_bytes": int(reconstruction_info["metadata_bytes"]),
+            "generated_sign_correction_count": int(
+                reconstruction_info.get("sign_correction_count", 0)
+            ),
         }
 
         payload = {
             "base": base,
             "shift": shift,
             "case_indices_dev": case_indices_dev,
-            "mode_qpoint_map_dev": mode_qpoint_map_dev,
-            "mode_case_map_dev": mode_case_map_dev,
-            "mode_case_scale_dev": cl.array.to_device(queue, mode_case_scale),
             "table_data_dev": cl.array.to_device(queue, table_data_combined),
             "mode_nmlz_dev": cl.array.to_device(queue, mode_nmlz_combined),
             "exterior_mode_nmlz_dev": cl.array.to_device(
                 queue, exterior_mode_nmlz_combined
             ),
-            "table_entry_ids_dev": cl.array.to_device(queue, table_entry_ids),
-            "table_entry_scales_dev": cl.array.to_device(queue, table_entry_scales),
             "table_data_shapes": table_data_shapes,
+            "reconstruction_diagnostics": reconstruction_diagnostics,
         }
+
+        if reconstruction_kind == "generated-orbit":
+            payload.update(
+                {
+                    "reconstruction_qpoint_map_dev": cl.array.to_device(
+                        queue, reconstruction_info["transform_qpoint_map"]
+                    ),
+                    "reconstruction_case_map_dev": cl.array.to_device(
+                        queue, reconstruction_info["transform_case_map"]
+                    ),
+                    "reconstruction_signs_dev": cl.array.to_device(
+                        queue, reconstruction_info["transform_signs"]
+                    ),
+                    "reconstruction_lookup_keys_dev": cl.array.to_device(
+                        queue, reconstruction_info["lookup_keys"]
+                    ),
+                    "reconstruction_lookup_values_dev": cl.array.to_device(
+                        queue, reconstruction_info["lookup_values"]
+                    ),
+                    "reconstruction_sign_lookup_keys_dev": cl.array.to_device(
+                        queue, reconstruction_info["sign_lookup_keys"]
+                    ),
+                    "reconstruction_sign_lookup_values_dev": cl.array.to_device(
+                        queue, reconstruction_info["sign_lookup_values"]
+                    ),
+                }
+            )
+        else:
+            payload.update(
+                {
+                    "mode_qpoint_map_dev": mode_qpoint_map_dev,
+                    "mode_case_map_dev": mode_case_map_dev,
+                    "mode_case_scale_dev": cl.array.to_device(queue, mode_case_scale),
+                    "table_entry_ids_dev": cl.array.to_device(queue, table_entry_ids),
+                    "table_entry_scales_dev": cl.array.to_device(
+                        queue, table_entry_scales
+                    ),
+                }
+            )
         self._nearfield_device_payload_cache[cache_key] = payload
         while (
             len(self._nearfield_device_payload_cache)
@@ -1906,11 +2195,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         base = payload["base"]
         shift = payload["shift"]
         case_indices_dev = payload["case_indices_dev"]
-        mode_qpoint_map_dev = payload["mode_qpoint_map_dev"]
-        mode_case_map_dev = payload["mode_case_map_dev"]
-        mode_case_scale_dev = payload["mode_case_scale_dev"]
         table_data_shapes = payload["table_data_shapes"]
         assert table_data_shapes["n_q_points"] == len(table0.mode_normalizers)
+        reconstruction_kind = table_data_shapes.get("reconstruction_kind", "dense")
 
         from volumential.list1 import NearFieldFromCSR
 
@@ -1924,8 +2211,34 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         table_data_combined = payload["table_data_dev"]
         mode_nmlz_combined = payload["mode_nmlz_dev"]
         exterior_mode_nmlz_combined = payload["exterior_mode_nmlz_dev"]
-        table_entry_ids = payload["table_entry_ids_dev"]
-        table_entry_scales = payload["table_entry_scales_dev"]
+        if reconstruction_kind == "generated-orbit":
+            reconstruction_kwargs = {
+                "reconstruction_qpoint_map": payload[
+                    "reconstruction_qpoint_map_dev"
+                ],
+                "reconstruction_case_map": payload["reconstruction_case_map_dev"],
+                "reconstruction_signs": payload["reconstruction_signs_dev"],
+                "reconstruction_lookup_keys": payload[
+                    "reconstruction_lookup_keys_dev"
+                ],
+                "reconstruction_lookup_values": payload[
+                    "reconstruction_lookup_values_dev"
+                ],
+                "reconstruction_sign_lookup_keys": payload[
+                    "reconstruction_sign_lookup_keys_dev"
+                ],
+                "reconstruction_sign_lookup_values": payload[
+                    "reconstruction_sign_lookup_values_dev"
+                ],
+            }
+        else:
+            reconstruction_kwargs = {
+                "mode_qpoint_map": payload["mode_qpoint_map_dev"],
+                "mode_case_map": payload["mode_case_map_dev"],
+                "mode_case_scale": payload["mode_case_scale_dev"],
+                "table_entry_ids": payload["table_entry_ids_dev"],
+                "table_entry_scales": payload["table_entry_scales_dev"],
+            }
         particle_local_ids = _compute_box_local_ids(queue, self.tree, table0.n_q_points)
 
         _validate_table_box_particle_layout_cached(
@@ -1962,15 +2275,10 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             box_target_counts_nonchild=target_counts_nonchild,
             box_target_starts=self.tree.box_target_starts,
             case_indices=case_indices_dev,
-            mode_qpoint_map=mode_qpoint_map_dev,
-            mode_case_map=mode_case_map_dev,
-            mode_case_scale=mode_case_scale_dev,
             encoding_base=base,
             encoding_shift=shift,
             mode_nmlz_combined=mode_nmlz_combined,
             exterior_mode_nmlz_combined=exterior_mode_nmlz_combined,
-            table_entry_ids=table_entry_ids,
-            table_entry_scales=table_entry_scales,
             neighbor_source_boxes_starts=neighbor_source_boxes_starts,
             root_extent=self.tree.root_extent,
             neighbor_source_boxes_lists=neighbor_source_boxes_lists,
@@ -1981,6 +2289,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             target_point_ids=particle_local_ids,
             table_root_extent=table_root_extent,
             table_starting_level=table_starting_level,
+            **reconstruction_kwargs,
         )
 
         # print(near_field.get_kernel())
@@ -4519,12 +4828,11 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         base = payload["base"]
         shift = payload["shift"]
         case_indices_dev = payload["case_indices_dev"]
-        mode_qpoint_map_dev = payload["mode_qpoint_map_dev"]
-        mode_case_map_dev = payload["mode_case_map_dev"]
         table_data_shapes = payload["table_data_shapes"]
         assert table_data_shapes["n_q_points"] == len(
             self.near_field_table[kname][0].mode_normalizers
         )
+        reconstruction_kind = table_data_shapes.get("reconstruction_kind", "dense")
 
         from volumential.list1 import NearFieldFromCSR
 
@@ -4538,8 +4846,34 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         table_data_combined = payload["table_data_dev"]
         mode_nmlz_combined = payload["mode_nmlz_dev"]
         exterior_mode_nmlz_combined = payload["exterior_mode_nmlz_dev"]
-        table_entry_ids = payload["table_entry_ids_dev"]
-        table_entry_scales = payload["table_entry_scales_dev"]
+        if reconstruction_kind == "generated-orbit":
+            reconstruction_kwargs = {
+                "reconstruction_qpoint_map": payload[
+                    "reconstruction_qpoint_map_dev"
+                ],
+                "reconstruction_case_map": payload["reconstruction_case_map_dev"],
+                "reconstruction_signs": payload["reconstruction_signs_dev"],
+                "reconstruction_lookup_keys": payload[
+                    "reconstruction_lookup_keys_dev"
+                ],
+                "reconstruction_lookup_values": payload[
+                    "reconstruction_lookup_values_dev"
+                ],
+                "reconstruction_sign_lookup_keys": payload[
+                    "reconstruction_sign_lookup_keys_dev"
+                ],
+                "reconstruction_sign_lookup_values": payload[
+                    "reconstruction_sign_lookup_values_dev"
+                ],
+            }
+        else:
+            reconstruction_kwargs = {
+                "mode_qpoint_map": payload["mode_qpoint_map_dev"],
+                "mode_case_map": payload["mode_case_map_dev"],
+                "mode_case_scale": payload["mode_case_scale_dev"],
+                "table_entry_ids": payload["table_entry_ids_dev"],
+                "table_entry_scales": payload["table_entry_scales_dev"],
+            }
         particle_local_ids = _compute_box_local_ids(
             self.queue, self.tree, self.near_field_table[kname][0].n_q_points
         )
@@ -4575,15 +4909,10 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             box_target_counts_nonchild=target_counts_nonchild,
             box_target_starts=self.tree.box_target_starts,
             case_indices=case_indices_dev,
-            mode_qpoint_map=mode_qpoint_map_dev,
-            mode_case_map=mode_case_map_dev,
-            mode_case_scale=payload["mode_case_scale_dev"],
             encoding_base=base,
             encoding_shift=shift,
             mode_nmlz_combined=mode_nmlz_combined,
             exterior_mode_nmlz_combined=exterior_mode_nmlz_combined,
-            table_entry_ids=table_entry_ids,
-            table_entry_scales=table_entry_scales,
             neighbor_source_boxes_starts=neighbor_source_boxes_starts,
             root_extent=self.tree.root_extent,
             neighbor_source_boxes_lists=neighbor_source_boxes_lists,
@@ -4594,6 +4923,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             target_point_ids=particle_local_ids,
             table_root_extent=self.root_table_source_box_extent,
             table_starting_level=self.table_starting_level,
+            **reconstruction_kwargs,
         )
 
         if isinstance(out_pot, cl.array.Array):
@@ -4630,26 +4960,19 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         base = len(range(min(distinct_numbers), max(distinct_numbers) + 1))
         shift = -min(distinct_numbers)
 
-        case_indices_dev = cl.array.to_device(queue, table0.case_indices)
-        symmetry_maps = table0._get_online_symmetry_maps()
-        mode_qpoint_map_dev = cl.array.to_device(
-            queue, symmetry_maps["mode_qpoint_map"]
-        )
-        mode_case_map_dev = cl.array.to_device(queue, symmetry_maps["mode_case_map"])
-        mode_case_scale = symmetry_maps.get("mode_case_scale")
-        if mode_case_scale is None:
-            mode_case_scale = np.ones(
-                (table0.n_q_points, table0.n_cases),
-                dtype=np.int8,
-            )
-
         (
             table_data_combined,
             mode_nmlz_combined,
             exterior_mode_nmlz_combined,
             table_entry_ids,
             table_entry_scales,
+            reconstruction_info,
         ) = _prepare_table_data_and_entry_map(near_field_tables)
+
+        case_indices_dev = cl.array.to_device(queue, table0.case_indices)
+        reconstruction_kind = reconstruction_info["kind"]
+        dense_id_bytes = int(table_entry_ids.nbytes)
+        dense_scale_bytes = int(table_entry_scales.size * np.dtype(eval_dtype).itemsize)
 
         if table_data_combined.dtype != eval_dtype:
             table_data_combined = table_data_combined.astype(eval_dtype)
@@ -4657,34 +4980,115 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             mode_nmlz_combined = mode_nmlz_combined.astype(eval_dtype)
         if exterior_mode_nmlz_combined.dtype != eval_dtype:
             exterior_mode_nmlz_combined = exterior_mode_nmlz_combined.astype(eval_dtype)
-        if table_entry_scales.dtype != eval_dtype:
-            table_entry_scales = table_entry_scales.astype(eval_dtype)
-        if mode_case_scale.dtype != eval_dtype:
-            mode_case_scale = mode_case_scale.astype(eval_dtype)
+
+        if reconstruction_kind == "dense":
+            symmetry_maps = table0._get_online_symmetry_maps()
+            mode_qpoint_map_dev = cl.array.to_device(
+                queue, symmetry_maps["mode_qpoint_map"]
+            )
+            mode_case_map_dev = cl.array.to_device(queue, symmetry_maps["mode_case_map"])
+            mode_case_scale = symmetry_maps.get("mode_case_scale")
+            if mode_case_scale is None:
+                mode_case_scale = np.ones(
+                    (table0.n_q_points, table0.n_cases),
+                    dtype=np.int8,
+                )
+            if table_entry_scales.dtype != eval_dtype:
+                table_entry_scales = table_entry_scales.astype(eval_dtype)
+            if mode_case_scale.dtype != eval_dtype:
+                mode_case_scale = mode_case_scale.astype(eval_dtype)
 
         table_data_shapes = {
             "n_tables": len(near_field_tables),
             "n_q_points": table0.n_q_points,
             "n_cases": table0.n_cases,
             "n_table_entries": table_data_combined.shape[1],
+            "reconstruction_kind": reconstruction_kind,
+        }
+        if reconstruction_kind == "generated-orbit":
+            table_data_shapes.update(
+                {
+                    "n_reconstruction_transforms": reconstruction_info[
+                        "transform_signs"
+                    ].shape[0],
+                    "n_reconstruction_lookup_entries": reconstruction_info[
+                        "lookup_keys"
+                    ].shape[0],
+                    "n_reconstruction_lookup_probes": int(
+                        reconstruction_info["lookup_max_probe_count"]
+                    ),
+                    "n_reconstruction_sign_lookup_entries": reconstruction_info[
+                        "sign_lookup_keys"
+                    ].shape[0],
+                    "n_reconstruction_sign_lookup_probes": int(
+                        reconstruction_info["sign_lookup_max_probe_count"]
+                    ),
+                }
+            )
+
+        reconstruction_diagnostics = {
+            "kind": reconstruction_kind,
+            "representative_value_bytes": int(table_data_combined.nbytes),
+            "dense_entry_id_bytes": dense_id_bytes,
+            "dense_entry_scale_bytes": dense_scale_bytes,
+            "dense_metadata_bytes": int(dense_id_bytes + dense_scale_bytes),
+            "generated_metadata_bytes": int(reconstruction_info["metadata_bytes"]),
+            "generated_sign_correction_count": int(
+                reconstruction_info.get("sign_correction_count", 0)
+            ),
         }
 
         payload = {
             "base": base,
             "shift": shift,
             "case_indices_dev": case_indices_dev,
-            "mode_qpoint_map_dev": mode_qpoint_map_dev,
-            "mode_case_map_dev": mode_case_map_dev,
-            "mode_case_scale_dev": cl.array.to_device(queue, mode_case_scale),
             "table_data_dev": cl.array.to_device(queue, table_data_combined),
             "mode_nmlz_dev": cl.array.to_device(queue, mode_nmlz_combined),
             "exterior_mode_nmlz_dev": cl.array.to_device(
                 queue, exterior_mode_nmlz_combined
             ),
-            "table_entry_ids_dev": cl.array.to_device(queue, table_entry_ids),
-            "table_entry_scales_dev": cl.array.to_device(queue, table_entry_scales),
             "table_data_shapes": table_data_shapes,
+            "reconstruction_diagnostics": reconstruction_diagnostics,
         }
+
+        if reconstruction_kind == "generated-orbit":
+            payload.update(
+                {
+                    "reconstruction_qpoint_map_dev": cl.array.to_device(
+                        queue, reconstruction_info["transform_qpoint_map"]
+                    ),
+                    "reconstruction_case_map_dev": cl.array.to_device(
+                        queue, reconstruction_info["transform_case_map"]
+                    ),
+                    "reconstruction_signs_dev": cl.array.to_device(
+                        queue, reconstruction_info["transform_signs"]
+                    ),
+                    "reconstruction_lookup_keys_dev": cl.array.to_device(
+                        queue, reconstruction_info["lookup_keys"]
+                    ),
+                    "reconstruction_lookup_values_dev": cl.array.to_device(
+                        queue, reconstruction_info["lookup_values"]
+                    ),
+                    "reconstruction_sign_lookup_keys_dev": cl.array.to_device(
+                        queue, reconstruction_info["sign_lookup_keys"]
+                    ),
+                    "reconstruction_sign_lookup_values_dev": cl.array.to_device(
+                        queue, reconstruction_info["sign_lookup_values"]
+                    ),
+                }
+            )
+        else:
+            payload.update(
+                {
+                    "mode_qpoint_map_dev": mode_qpoint_map_dev,
+                    "mode_case_map_dev": mode_case_map_dev,
+                    "mode_case_scale_dev": cl.array.to_device(queue, mode_case_scale),
+                    "table_entry_ids_dev": cl.array.to_device(queue, table_entry_ids),
+                    "table_entry_scales_dev": cl.array.to_device(
+                        queue, table_entry_scales
+                    ),
+                }
+            )
         self._nearfield_device_payload_cache[cache_key] = payload
         while (
             len(self._nearfield_device_payload_cache)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -62,6 +62,22 @@ logger = logging.getLogger(__name__)
 _ORBIT_RECONSTRUCTION_HASH_MULTIPLIER = 33
 
 
+def _encode_mode_axes(axes, q_order):
+    result = 0
+    for axis_value in axes:
+        result = result * int(q_order) + int(axis_value)
+    return int(result)
+
+
+def _decode_mode_axes(mode_id, q_order, dim):
+    axes = [0] * int(dim)
+    residual = int(mode_id)
+    for iaxis in range(int(dim) - 1, -1, -1):
+        axes[iaxis] = residual % int(q_order)
+        residual //= int(q_order)
+    return axes
+
+
 @dataclass(frozen=True)
 class HelmholtzSplitCacheAccounting:
     split_enabled: bool
@@ -849,6 +865,212 @@ def _evaluate_generated_orbit_reconstruction(
     return representative_entry_ids, representative_scales
 
 
+def _case_arithmetic_axis_descriptors(case_vec):
+    case_vec = [int(val) for val in case_vec]
+    order = sorted(
+        range(len(case_vec)), key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis)
+    )
+
+    axis_signs = []
+    axis_groups = []
+    last_abs = None
+    group_id = -1
+    for iaxis in order:
+        value = int(case_vec[iaxis])
+        abs_value = abs(value)
+        if last_abs != abs_value:
+            group_id += 1
+            last_abs = abs_value
+        axis_groups.append(group_id)
+        if value > 0:
+            axis_signs.append(-1)
+        elif value < 0:
+            axis_signs.append(1)
+        else:
+            axis_signs.append(0)
+
+    return order, axis_signs, axis_groups
+
+
+def _evaluate_scalar_arithmetic_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    q_order,
+    dim,
+):
+    source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
+    target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
+
+    source_axes = []
+    target_axes = []
+    groups = []
+    for out_axis in range(int(dim)):
+        in_axis = int(case_axis_perm[case_id, out_axis])
+        axis_sign = int(case_axis_sign[case_id, out_axis])
+        source_axis = source_axes_raw[in_axis]
+        target_axis = target_axes_raw[in_axis]
+
+        if axis_sign < 0:
+            source_axis = int(q_order) - 1 - source_axis
+            target_axis = int(q_order) - 1 - target_axis
+        elif axis_sign == 0:
+            flipped_source = int(q_order) - 1 - source_axis
+            flipped_target = int(q_order) - 1 - target_axis
+            if (flipped_source, flipped_target) < (source_axis, target_axis):
+                source_axis = flipped_source
+                target_axis = flipped_target
+
+        source_axes.append(source_axis)
+        target_axes.append(target_axis)
+        groups.append(int(case_axis_group[case_id, out_axis]))
+
+    def compare_swap(iaxis, jaxis):
+        if groups[iaxis] != groups[jaxis]:
+            return
+        if (source_axes[jaxis], target_axes[jaxis]) < (
+            source_axes[iaxis],
+            target_axes[iaxis],
+        ):
+            source_axes[iaxis], source_axes[jaxis] = (
+                source_axes[jaxis],
+                source_axes[iaxis],
+            )
+            target_axes[iaxis], target_axes[jaxis] = (
+                target_axes[jaxis],
+                target_axes[iaxis],
+            )
+
+    if int(dim) == 2:
+        compare_swap(0, 1)
+    elif int(dim) == 3:
+        compare_swap(0, 1)
+        compare_swap(1, 2)
+        compare_swap(0, 1)
+    else:
+        raise NotImplementedError("scalar arithmetic ORBIT supports dim 2 or 3")
+
+    canonical_source = _encode_mode_axes(source_axes, q_order)
+    canonical_target = _encode_mode_axes(target_axes, q_order)
+    n_q_points = int(q_order) ** int(dim)
+    return (
+        int(case_orbit_ranks[case_id]) * n_q_points * n_q_points
+        + canonical_source * n_q_points
+        + canonical_target
+    )
+
+
+def _build_scalar_arithmetic_orbit_reconstruction(
+    table,
+    table_entry_ids,
+    table_entry_scales,
+):
+    if not hasattr(table, "_get_orbit_reconstruction_maps"):
+        return None
+    if not bool(getattr(table, "table_data_is_symmetry_reduced", False)):
+        return None
+    if table.dim not in (2, 3):
+        return None
+
+    reconstruction_maps = table._get_orbit_reconstruction_maps()
+    transform_signs = np.asarray(reconstruction_maps["transform_signs"], dtype=np.int8)
+    expected_transform_count = (2 ** int(table.dim)) * math.factorial(int(table.dim))
+    if len(transform_signs) != expected_transform_count:
+        return None
+    if not np.all(transform_signs == 1):
+        return None
+    if table.n_q_points > np.iinfo(np.uint16).max:
+        return None
+
+    table_entry_scales_real = np.real(np.asarray(table_entry_scales))
+    if not np.all(table_entry_scales_real == 1):
+        return None
+
+    case_vecs = np.asarray(table.interaction_case_vecs, dtype=np.int32)
+    canonical_case_ids = np.empty(table.n_cases, dtype=np.int32)
+    for case_id, case_vec in enumerate(case_vecs):
+        canonical_vec = [-int(val) for val in sorted(np.abs(case_vec), reverse=True)]
+        canonical_case_ids[case_id] = int(
+            table.case_indices[table.case_encode(canonical_vec)]
+        )
+
+    unique_canonical_case_ids = np.unique(canonical_case_ids)
+    if len(unique_canonical_case_ids) > np.iinfo(np.uint16).max:
+        return None
+
+    canonical_case_rank_by_id = {
+        int(case_id): rank for rank, case_id in enumerate(unique_canonical_case_ids)
+    }
+    case_orbit_ranks = np.empty(table.n_cases, dtype=np.uint16)
+    case_axis_perm = np.empty((table.n_cases, table.dim), dtype=np.uint8)
+    case_axis_sign = np.empty((table.n_cases, table.dim), dtype=np.int8)
+    case_axis_group = np.empty((table.n_cases, table.dim), dtype=np.uint8)
+
+    for case_id, case_vec in enumerate(case_vecs):
+        case_orbit_ranks[case_id] = canonical_case_rank_by_id[
+            int(canonical_case_ids[case_id])
+        ]
+        axis_perm, axis_sign, axis_group = _case_arithmetic_axis_descriptors(case_vec)
+        case_axis_perm[case_id, :] = axis_perm
+        case_axis_sign[case_id, :] = axis_sign
+        case_axis_group[case_id, :] = axis_group
+
+    n_arithmetic_entries = len(unique_canonical_case_ids) * table.n_pairs
+    layout_entry_ids = np.full(n_arithmetic_entries, -1, dtype=np.int64)
+    full_entry_count = table.n_cases * table.n_pairs
+    representative_entry_ids = np.asarray(
+        table._get_orbit_canonical_info()["entry_ids"], dtype=np.int64
+    )
+
+    for full_entry_id in range(full_entry_count):
+        case_id = full_entry_id // table.n_pairs
+        pair_id = full_entry_id % table.n_pairs
+        source_mode_id = pair_id // table.n_q_points
+        target_point_id = pair_id % table.n_q_points
+        arithmetic_row = _evaluate_scalar_arithmetic_entry(
+            case_id,
+            source_mode_id,
+            target_point_id,
+            case_orbit_ranks=case_orbit_ranks,
+            case_axis_perm=case_axis_perm,
+            case_axis_sign=case_axis_sign,
+            case_axis_group=case_axis_group,
+            q_order=table.quad_order,
+            dim=table.dim,
+        )
+        representative_full_id = int(
+            representative_entry_ids[table_entry_ids[full_entry_id]]
+        )
+        existing = int(layout_entry_ids[arithmetic_row])
+        if existing >= 0 and existing != representative_full_id:
+            raise RuntimeError("arithmetic ORBIT row layout is inconsistent")
+        layout_entry_ids[arithmetic_row] = representative_full_id
+
+    metadata_arrays = (
+        case_orbit_ranks,
+        case_axis_perm,
+        case_axis_sign,
+        case_axis_group,
+    )
+
+    return {
+        "kind": "scalar-arithmetic-orbit",
+        "case_orbit_ranks": case_orbit_ranks,
+        "case_axis_perm": case_axis_perm,
+        "case_axis_sign": case_axis_sign,
+        "case_axis_group": case_axis_group,
+        "layout_entry_ids": layout_entry_ids,
+        "n_case_orbits": int(len(unique_canonical_case_ids)),
+        "metadata_bytes": int(sum(arr.nbytes for arr in metadata_arrays)),
+        "unused_layout_entry_count": int(np.count_nonzero(layout_entry_ids < 0)),
+    }
+
+
 def _build_generated_orbit_reconstruction(table, table_entry_ids, table_entry_scales):
     if not hasattr(table, "_get_orbit_reconstruction_maps"):
         return None
@@ -999,19 +1221,40 @@ def _prepare_table_data_and_entry_map(table_levels):
         table_entry_ids[kept_entry_ids] = np.arange(len(kept_entry_ids), dtype=np.int32)
         table_entry_scales = np.ones(n_full_entries, dtype=table0.data.dtype)
 
-    reconstruction_info = _build_generated_orbit_reconstruction(
+    reconstruction_info = _build_scalar_arithmetic_orbit_reconstruction(
         table0,
         table_entry_ids,
         table_entry_scales,
     )
+    if reconstruction_info is None:
+        reconstruction_info = _build_generated_orbit_reconstruction(
+            table0,
+            table_entry_ids,
+            table_entry_scales,
+        )
+
     if reconstruction_info is None:
         reconstruction_info = {
             "kind": "dense",
             "metadata_bytes": int(table_entry_ids.nbytes + table_entry_scales.nbytes),
         }
 
+    layout_entry_ids = reconstruction_info.get("layout_entry_ids", kept_entry_ids)
+    layout_entry_ids = np.asarray(layout_entry_ids, dtype=np.int64)
+    used_layout_mask = layout_entry_ids >= 0
+    used_layout_entry_ids = layout_entry_ids[used_layout_mask]
+    if len(used_layout_entry_ids) == 0:
+        raise RuntimeError("near-field reconstruction layout contains no entries")
+    if not np.all(np.isfinite(table0.data[used_layout_entry_ids])):
+        raise RuntimeError("near-field reconstruction layout references missing data")
+    for table in table_levels[1:]:
+        if not np.all(np.isfinite(table.data[used_layout_entry_ids])):
+            raise RuntimeError(
+                "near-field levels disagree on reconstruction layout availability"
+            )
+
     table_data_combined = np.zeros(
-        (len(table_levels), len(kept_entry_ids)),
+        (len(table_levels), len(layout_entry_ids)),
         dtype=table0.data.dtype,
     )
     mode_nmlz_combined = np.zeros(
@@ -1024,7 +1267,7 @@ def _prepare_table_data_and_entry_map(table_levels):
     )
 
     for lev, table in enumerate(table_levels):
-        table_data_combined[lev, :] = table.data[kept_entry_ids]
+        table_data_combined[lev, used_layout_mask] = table.data[used_layout_entry_ids]
         mode_nmlz_combined[lev, :] = table.mode_normalizers
         exterior_mode_nmlz_combined[lev, :] = table.kernel_exterior_normalizers
 
@@ -1938,12 +2181,21 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
         table_data_shapes = {
             "n_tables": len(near_field_tables),
+            "quad_order": table0.quad_order,
             "n_q_points": table0.n_q_points,
             "n_cases": table0.n_cases,
             "n_table_entries": table_data_combined.shape[1],
             "reconstruction_kind": reconstruction_kind,
         }
-        if reconstruction_kind == "generated-orbit":
+        if reconstruction_kind == "scalar-arithmetic-orbit":
+            table_data_shapes.update(
+                {
+                    "n_arithmetic_case_orbits": int(
+                        reconstruction_info["n_case_orbits"]
+                    ),
+                }
+            )
+        elif reconstruction_kind == "generated-orbit":
             table_data_shapes.update(
                 {
                     "n_reconstruction_transforms": reconstruction_info[
@@ -1974,6 +2226,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             "generated_sign_correction_count": int(
                 reconstruction_info.get("sign_correction_count", 0)
             ),
+            "unused_arithmetic_layout_entries": int(
+                reconstruction_info.get("unused_layout_entry_count", 0)
+            ),
         }
 
         payload = {
@@ -1989,7 +2244,24 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
             "reconstruction_diagnostics": reconstruction_diagnostics,
         }
 
-        if reconstruction_kind == "generated-orbit":
+        if reconstruction_kind == "scalar-arithmetic-orbit":
+            payload.update(
+                {
+                    "arithmetic_case_orbit_ranks_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_orbit_ranks"]
+                    ),
+                    "arithmetic_case_axis_perm_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_axis_perm"]
+                    ),
+                    "arithmetic_case_axis_sign_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_axis_sign"]
+                    ),
+                    "arithmetic_case_axis_group_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_axis_group"]
+                    ),
+                }
+            )
+        elif reconstruction_kind == "generated-orbit":
             payload.update(
                 {
                     "reconstruction_qpoint_map_dev": cl.array.to_device(
@@ -2211,7 +2483,22 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
         table_data_combined = payload["table_data_dev"]
         mode_nmlz_combined = payload["mode_nmlz_dev"]
         exterior_mode_nmlz_combined = payload["exterior_mode_nmlz_dev"]
-        if reconstruction_kind == "generated-orbit":
+        if reconstruction_kind == "scalar-arithmetic-orbit":
+            reconstruction_kwargs = {
+                "arithmetic_case_orbit_ranks": payload[
+                    "arithmetic_case_orbit_ranks_dev"
+                ],
+                "arithmetic_case_axis_perm": payload[
+                    "arithmetic_case_axis_perm_dev"
+                ],
+                "arithmetic_case_axis_sign": payload[
+                    "arithmetic_case_axis_sign_dev"
+                ],
+                "arithmetic_case_axis_group": payload[
+                    "arithmetic_case_axis_group_dev"
+                ],
+            }
+        elif reconstruction_kind == "generated-orbit":
             reconstruction_kwargs = {
                 "reconstruction_qpoint_map": payload[
                     "reconstruction_qpoint_map_dev"
@@ -4846,7 +5133,22 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         table_data_combined = payload["table_data_dev"]
         mode_nmlz_combined = payload["mode_nmlz_dev"]
         exterior_mode_nmlz_combined = payload["exterior_mode_nmlz_dev"]
-        if reconstruction_kind == "generated-orbit":
+        if reconstruction_kind == "scalar-arithmetic-orbit":
+            reconstruction_kwargs = {
+                "arithmetic_case_orbit_ranks": payload[
+                    "arithmetic_case_orbit_ranks_dev"
+                ],
+                "arithmetic_case_axis_perm": payload[
+                    "arithmetic_case_axis_perm_dev"
+                ],
+                "arithmetic_case_axis_sign": payload[
+                    "arithmetic_case_axis_sign_dev"
+                ],
+                "arithmetic_case_axis_group": payload[
+                    "arithmetic_case_axis_group_dev"
+                ],
+            }
+        elif reconstruction_kind == "generated-orbit":
             reconstruction_kwargs = {
                 "reconstruction_qpoint_map": payload[
                     "reconstruction_qpoint_map_dev"
@@ -5000,12 +5302,21 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
 
         table_data_shapes = {
             "n_tables": len(near_field_tables),
+            "quad_order": table0.quad_order,
             "n_q_points": table0.n_q_points,
             "n_cases": table0.n_cases,
             "n_table_entries": table_data_combined.shape[1],
             "reconstruction_kind": reconstruction_kind,
         }
-        if reconstruction_kind == "generated-orbit":
+        if reconstruction_kind == "scalar-arithmetic-orbit":
+            table_data_shapes.update(
+                {
+                    "n_arithmetic_case_orbits": int(
+                        reconstruction_info["n_case_orbits"]
+                    ),
+                }
+            )
+        elif reconstruction_kind == "generated-orbit":
             table_data_shapes.update(
                 {
                     "n_reconstruction_transforms": reconstruction_info[
@@ -5036,6 +5347,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             "generated_sign_correction_count": int(
                 reconstruction_info.get("sign_correction_count", 0)
             ),
+            "unused_arithmetic_layout_entries": int(
+                reconstruction_info.get("unused_layout_entry_count", 0)
+            ),
         }
 
         payload = {
@@ -5051,7 +5365,24 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             "reconstruction_diagnostics": reconstruction_diagnostics,
         }
 
-        if reconstruction_kind == "generated-orbit":
+        if reconstruction_kind == "scalar-arithmetic-orbit":
+            payload.update(
+                {
+                    "arithmetic_case_orbit_ranks_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_orbit_ranks"]
+                    ),
+                    "arithmetic_case_axis_perm_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_axis_perm"]
+                    ),
+                    "arithmetic_case_axis_sign_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_axis_sign"]
+                    ),
+                    "arithmetic_case_axis_group_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_axis_group"]
+                    ),
+                }
+            )
+        elif reconstruction_kind == "generated-orbit":
             payload.update(
                 {
                     "reconstruction_qpoint_map_dev": cl.array.to_device(

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -904,46 +904,69 @@ def _case_arithmetic_axis_descriptors(
             return 1
         return 0
 
+    active_group_specs = []
+    inactive_group_specs = []
     for group in axis_group_specs:
         out_axes = tuple(sorted(group))
         active_direction_axes = [axis for axis in out_axes if direction_signs[axis] != 0]
-
         if active_direction_axes:
-            best_key = None
-            best_perm = None
-            best_line_sign = None
-            from itertools import permutations
+            if len(active_direction_axes) != len(out_axes):
+                raise ValueError("directional arithmetic groups cannot mix active axes")
+            active_group_specs.append(out_axes)
+        else:
+            inactive_group_specs.append(out_axes)
 
-            for permuted_axes in permutations(out_axes):
-                for line_sign in (-1, 1):
-                    values = []
+    if active_group_specs:
+        from itertools import permutations, product
+
+        sorted_active_axes = tuple(
+            sorted(axis for group in active_group_specs for axis in group)
+        )
+        permutation_options = [tuple(permutations(group)) for group in active_group_specs]
+        best_key = None
+        best_axis_perm = None
+        best_axis_sign = None
+
+        for line_sign in (-1, 1):
+            for permuted_groups in product(*permutation_options):
+                candidate_axis_perm = {}
+                candidate_axis_sign = {}
+                for out_axes, permuted_axes in zip(
+                    active_group_specs,
+                    permuted_groups,
+                    strict=True,
+                ):
                     for out_axis, in_axis in zip(out_axes, permuted_axes, strict=True):
                         sign = (
-                            line_sign
+                            int(line_sign)
                             * int(direction_signs[out_axis])
                             * int(direction_signs[in_axis])
                         )
-                        values.append(int(case_vec[in_axis]) * sign)
+                        candidate_axis_perm[out_axis] = int(in_axis)
+                        candidate_axis_sign[out_axis] = int(sign)
 
-                    key = (tuple(values), tuple(int(axis) for axis in permuted_axes))
-                    if best_key is None or key < best_key:
-                        best_key = key
-                        best_perm = tuple(int(axis) for axis in permuted_axes)
-                        best_line_sign = int(line_sign)
-
-            for out_axis, in_axis in zip(out_axes, best_perm, strict=True):
-                axis_perm[out_axis] = in_axis
-                axis_signs[out_axis] = (
-                    best_line_sign
-                    * int(direction_signs[out_axis])
-                    * int(direction_signs[in_axis])
+                key = (
+                    tuple(
+                        int(case_vec[candidate_axis_perm[axis]])
+                        * int(candidate_axis_sign[axis])
+                        for axis in sorted_active_axes
+                    ),
+                    tuple(candidate_axis_perm[axis] for axis in sorted_active_axes),
                 )
-                # Avoid over-canonicalizing directional stabilizers: source/target
-                # flips in an active directional group are tied by one line sign.
-                axis_group_ids[out_axis] = next_runtime_group
-                next_runtime_group += 1
-            continue
+                if best_key is None or key < best_key:
+                    best_key = key
+                    best_axis_perm = candidate_axis_perm
+                    best_axis_sign = candidate_axis_sign
 
+        for out_axis in sorted_active_axes:
+            axis_perm[out_axis] = best_axis_perm[out_axis]
+            axis_signs[out_axis] = best_axis_sign[out_axis]
+            # Avoid over-canonicalizing directional stabilizers: source/target
+            # flips in active directional groups are tied by one line sign.
+            axis_group_ids[out_axis] = next_runtime_group
+            next_runtime_group += 1
+
+    for out_axes in inactive_group_specs:
         free_order = sorted(
             out_axes,
             key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis),
@@ -982,14 +1005,15 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
     axis_sign_power = np.zeros(dim, dtype=np.uint8)
     direction_signs = np.zeros(dim, dtype=np.int8)
     direction_sign_axis = -1
-    directional_groups = None
+    direction_abs_group = np.full(dim, -1, dtype=np.int16)
+    direction_sign_power = np.uint8(0)
+    direction_vector = None
+    has_directional_source = False
 
     kernel = table.integral_knl
     while kernel is not None:
         cls_name = kernel.__class__.__name__
         if cls_name in {"AxisTargetDerivative", "AxisSourceDerivative"}:
-            if directional_groups is not None:
-                return None
             axis = int(kernel.axis)
             if axis < 0 or axis >= dim:
                 return None
@@ -999,35 +1023,44 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
             continue
 
         if cls_name == "DirectionalSourceDerivative":
-            if np.any(axis_sign_power) or directional_groups is not None:
-                return None
             source_direction = getattr(kernel, "_volumential_source_direction", None)
             if source_direction is None:
                 return None
             source_direction = np.asarray(source_direction, dtype=np.float64).ravel()
             if source_direction.shape != (dim,):
                 return None
+            direction_sign_power ^= np.uint8(1)
+            if has_directional_source:
+                if not np.allclose(source_direction, direction_vector):
+                    return None
+                kernel = kernel.inner_kernel
+                continue
+
             axis_candidates = np.flatnonzero(
                 np.abs(source_direction) > 100 * np.finfo(np.float64).eps
             )
             if len(axis_candidates) == 0:
                 return None
-            active_abs_values = np.abs(source_direction[axis_candidates])
-            if not np.allclose(active_abs_values, active_abs_values[0]):
-                return None
 
             active_axes = tuple(sorted(int(axis) for axis in axis_candidates))
-            inactive_axes = tuple(
-                axis for axis in range(dim) if axis not in set(active_axes)
-            )
-            directional_groups = (active_axes,)
-            if inactive_axes:
-                directional_groups += (inactive_axes,)
             active_axis_list = list(active_axes)
             direction_signs[active_axis_list] = np.sign(
                 source_direction[active_axis_list]
             ).astype(np.int8)
+            active_abs_groups = []
+            for axis in active_axes:
+                abs_value = abs(float(source_direction[axis]))
+                for group_id, (group_abs, group_axes) in enumerate(active_abs_groups):
+                    if np.isclose(abs_value, group_abs):
+                        group_axes.append(axis)
+                        direction_abs_group[axis] = group_id
+                        break
+                else:
+                    direction_abs_group[axis] = len(active_abs_groups)
+                    active_abs_groups.append((abs_value, [axis]))
             direction_sign_axis = int(active_axes[0])
+            direction_vector = source_direction.copy()
+            has_directional_source = True
             kernel = kernel.inner_kernel
             continue
 
@@ -1039,24 +1072,52 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
 
     from itertools import permutations, product
 
-    if directional_groups is None:
+    if not has_directional_source:
         free_axes = tuple(axis for axis in range(dim) if axis not in fixed_axes)
         axis_groups = tuple((axis,) for axis in sorted(fixed_axes))
         if free_axes:
             axis_groups += (free_axes,)
     else:
-        axis_groups = directional_groups
+        axis_groups = []
+        for group_id in sorted(
+            int(group_id) for group_id in np.unique(direction_abs_group) if group_id >= 0
+        ):
+            group_axes = tuple(
+                axis for axis in range(dim) if int(direction_abs_group[axis]) == group_id
+            )
+            fixed_group_axes = tuple(axis for axis in group_axes if axis in fixed_axes)
+            free_group_axes = tuple(axis for axis in group_axes if axis not in fixed_axes)
+            axis_groups.extend((axis,) for axis in fixed_group_axes)
+            if free_group_axes:
+                axis_groups.append(free_group_axes)
+
+        inactive_fixed_axes = tuple(
+            axis
+            for axis in sorted(fixed_axes)
+            if int(direction_abs_group[axis]) < 0
+        )
+        inactive_free_axes = tuple(
+            axis
+            for axis in range(dim)
+            if int(direction_abs_group[axis]) < 0 and axis not in fixed_axes
+        )
+        axis_groups.extend((axis,) for axis in inactive_fixed_axes)
+        if inactive_free_axes:
+            axis_groups.append(inactive_free_axes)
+        axis_groups = tuple(axis_groups)
 
     expected = set()
     for sign_tuple in product([-1, 1], repeat=dim):
         for perm_tuple in permutations(range(dim)):
             line_sign = 1
-            if directional_groups is None:
+            if not has_directional_source:
                 if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
                     continue
             else:
                 line_sign = None
                 valid = True
+                if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
+                    continue
                 for out_axis in range(dim):
                     in_axis = int(perm_tuple[out_axis])
                     out_dir = int(direction_signs[out_axis])
@@ -1066,6 +1127,11 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
                             valid = False
                             break
                         continue
+                    if int(direction_abs_group[out_axis]) != int(
+                        direction_abs_group[in_axis]
+                    ):
+                        valid = False
+                        break
 
                     candidate = int(sign_tuple[in_axis]) * out_dir * in_dir
                     if line_sign is None:
@@ -1081,7 +1147,7 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
             for axis in range(dim):
                 if int(axis_sign_power[axis]):
                     transform_sign *= int(sign_tuple[axis])
-            if directional_groups is not None:
+            if int(direction_sign_power):
                 transform_sign *= int(line_sign)
 
             expected.add(
@@ -1119,7 +1185,7 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
         "axis_groups": axis_groups,
         "axis_sign_power": axis_sign_power,
         "axis_direction_signs": direction_signs,
-        "direction_sign_axis": int(direction_sign_axis),
+        "direction_sign_axis": int(direction_sign_axis if direction_sign_power else -1),
     }
 
 
@@ -1242,31 +1308,6 @@ def _evaluate_scalar_arithmetic_entry(
         dim=dim,
     )
     return entry_id
-
-
-def _entry_has_odd_axis_stabilizer(
-    case_vec,
-    source_mode_id,
-    target_point_id,
-    *,
-    axis_sign_power,
-    q_order,
-    dim,
-):
-    source_axes = _decode_mode_axes(source_mode_id, q_order, dim)
-    target_axes = _decode_mode_axes(target_point_id, q_order, dim)
-    for axis in range(int(dim)):
-        if not int(axis_sign_power[axis]):
-            continue
-        if int(case_vec[axis]) != 0:
-            continue
-        if source_axes[axis] != int(q_order) - 1 - source_axes[axis]:
-            continue
-        if target_axes[axis] != int(q_order) - 1 - target_axes[axis]:
-            continue
-        return True
-
-    return False
 
 
 def _entry_has_odd_reconstruction_stabilizer(

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1271,6 +1271,7 @@ def _evaluate_arithmetic_orbit_entry(
         compare_swap(0, 1)
         compare_swap(1, 2)
         compare_swap(0, 1)
+        compare_swap(0, 2)
     else:
         raise NotImplementedError("scalar arithmetic ORBIT supports dim 2 or 3")
 

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -718,8 +718,16 @@ class NearFieldFromCSR(NearFieldEvalBase):
                             if zero_flip{iaxis} else tgt{iaxis}_fixed)
                         <> transform_sign{iaxis} = (-1
                             if {sign_name} < 0 or zero_flip{iaxis} else 1)
-                        <> entry_sign_factor{iaxis} = (transform_sign{iaxis}
-                            if sign_power{iaxis} != 0 else 1)
+                        <> direction_sign_factor{iaxis} = (
+                            transform_sign{iaxis}
+                            * arithmetic_axis_direction_signs[{perm_name}]
+                            * arithmetic_axis_direction_signs[{iaxis}]
+                            if arithmetic_direction_sign_axis == {iaxis}
+                            else 1)
+                        <> entry_sign_factor{iaxis} = (
+                            (transform_sign{iaxis}
+                                if sign_power{iaxis} != 0 else 1)
+                            * direction_sign_factor{iaxis})
                 """
 
             reconstruction_code = f"""
@@ -767,8 +775,17 @@ class NearFieldFromCSR(NearFieldEvalBase):
                     "dim",
                     is_input=True,
                 ),
+                loopy.GlobalArg(
+                    "arithmetic_axis_direction_signs",
+                    np.int8,
+                    "dim",
+                    is_input=True,
+                ),
             ]
-            reconstruction_value_arg_names = ", quad_order, n_arithmetic_case_orbits"
+            reconstruction_value_arg_names = (
+                ", quad_order, n_arithmetic_case_orbits, "
+                "arithmetic_direction_sign_axis"
+            )
         elif self.reconstruction_kind == "generated-orbit":
             reconstruction_domains = [
                 "{ [ tr ] : 0 <= tr < n_reconstruction_transforms }",
@@ -1074,7 +1091,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
     def get_cache_key(self):
         return (
             type(self).__name__,
-            "kernel-v12",
+            "kernel-v13",
             self.name,
             self.kname,
             "complex_kernel=" + str(self.integral_kernel.is_complex_valued),
@@ -1159,6 +1176,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 ),
                 "arithmetic_axis_sign_power": kwargs.pop(
                     "arithmetic_axis_sign_power"
+                ),
+                "arithmetic_axis_direction_signs": kwargs.pop(
+                    "arithmetic_axis_direction_signs"
+                ),
+                "arithmetic_direction_sign_axis": kwargs.pop(
+                    "arithmetic_direction_sign_axis"
                 ),
                 "quad_order": self.quad_order,
                 "n_arithmetic_case_orbits": self.n_arithmetic_case_orbits,

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -803,6 +803,8 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 "{ [ probe ] : 0 <= probe < n_reconstruction_lookup_probes }",
                 "{ [ sign_probe ] : "
                 "0 <= sign_probe < n_reconstruction_sign_lookup_probes }",
+                "{ [ sign_value_probe ] : "
+                "0 <= sign_value_probe < n_reconstruction_sign_lookup_probes }",
             ]
             reconstruction_code = """
                         <> reconstruction_full_entry_id = \
@@ -852,12 +854,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
                                 == reconstruction_full_entry_id
                             else 0)
                         <> sign_correction = (
-                            sum((sign_probe),
+                            sum((sign_value_probe),
                                 reconstruction_sign_lookup_values[
-                                    (sign_lookup_start + sign_probe)
+                                    (sign_lookup_start + sign_value_probe)
                                     % n_reconstruction_sign_lookup_entries]
                                 if reconstruction_sign_lookup_keys[
-                                    (sign_lookup_start + sign_probe)
+                                    (sign_lookup_start + sign_value_probe)
                                     % n_reconstruction_sign_lookup_entries]
                                     == reconstruction_full_entry_id
                                 else 0)

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -619,9 +619,9 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
             if self.dim == 2:
                 decode_code = """
-                        <> src_raw_0 = source_mode_id / quad_order
+                        <> src_raw_0 = source_mode_id // quad_order
                         <> src_raw_1 = source_mode_id % quad_order
-                        <> tgt_raw_0 = target_point_id / quad_order
+                        <> tgt_raw_0 = target_point_id // quad_order
                         <> tgt_raw_1 = target_point_id % quad_order
                 """
                 encode_source = "src0_s * quad_order + src1_s"
@@ -637,11 +637,11 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 """
             elif self.dim == 3:
                 decode_code = """
-                        <> src_raw_0 = source_mode_id / (quad_order * quad_order)
-                        <> src_raw_1 = (source_mode_id / quad_order) % quad_order
+                        <> src_raw_0 = source_mode_id // (quad_order * quad_order)
+                        <> src_raw_1 = (source_mode_id // quad_order) % quad_order
                         <> src_raw_2 = source_mode_id % quad_order
-                        <> tgt_raw_0 = target_point_id / (quad_order * quad_order)
-                        <> tgt_raw_1 = (target_point_id / quad_order) % quad_order
+                        <> tgt_raw_0 = target_point_id // (quad_order * quad_order)
+                        <> tgt_raw_1 = (target_point_id // quad_order) % quad_order
                         <> tgt_raw_2 = target_point_id % quad_order
                 """
                 encode_source = (
@@ -778,7 +778,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
                                 best_reconstruction_key % n_reconstruction_transforms
                         <> representative_entry_id = \
                                 best_reconstruction_key \
-                                / (2 * n_reconstruction_transforms)
+                                // (2 * n_reconstruction_transforms)
                         <> lookup_start = (representative_entry_id * 33) \
                                 % n_reconstruction_lookup_entries
                         <> lookup_match_count = sum((probe),

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -117,12 +117,29 @@ class NearFieldEvalBase(KernelCacheWrapper):
         self.n_q_points = table_data_shapes["n_q_points"]
         self.n_table_entries = table_data_shapes["n_table_entries"]
         self.n_cases = table_data_shapes.get("n_cases", 0)
+        self.reconstruction_kind = table_data_shapes.get("reconstruction_kind", "dense")
+        self.n_reconstruction_transforms = table_data_shapes.get(
+            "n_reconstruction_transforms", 0
+        )
+        self.n_reconstruction_lookup_entries = table_data_shapes.get(
+            "n_reconstruction_lookup_entries", 0
+        )
+        self.n_reconstruction_lookup_probes = table_data_shapes.get(
+            "n_reconstruction_lookup_probes", 0
+        )
+        self.n_reconstruction_sign_lookup_entries = table_data_shapes.get(
+            "n_reconstruction_sign_lookup_entries", 0
+        )
+        self.n_reconstruction_sign_lookup_probes = table_data_shapes.get(
+            "n_reconstruction_sign_lookup_probes", 0
+        )
         self.potential_kind = potential_kind
 
         assert np.isreal(self.n_tables)
         assert np.isreal(self.n_q_points)
         assert np.isreal(self.n_table_entries)
         assert np.isreal(self.n_cases)
+        assert self.reconstruction_kind in {"dense", "generated-orbit"}
 
         self.options = options
         self.name = name or self.default_name
@@ -570,13 +587,160 @@ class NearFieldFromCSR(NearFieldEvalBase):
         else:
             potential_dtype = np.float64
 
+        if self.reconstruction_kind == "generated-orbit":
+            reconstruction_domains = [
+                "{ [ tr ] : 0 <= tr < n_reconstruction_transforms }",
+                "{ [ probe ] : 0 <= probe < n_reconstruction_lookup_probes }",
+                "{ [ sign_probe ] : "
+                "0 <= sign_probe < n_reconstruction_sign_lookup_probes }",
+            ]
+            reconstruction_code = """
+                        <> reconstruction_full_entry_id = \
+                                case_id * (n_q_points * n_q_points) \
+                                + source_mode_id * n_q_points + target_point_id
+                        <> best_reconstruction_key = min((tr),
+                            (
+                                reconstruction_case_map[tr, case_id]
+                                * (n_q_points * n_q_points)
+                                + reconstruction_qpoint_map[tr, source_mode_id]
+                                * n_q_points
+                                + reconstruction_qpoint_map[tr, target_point_id]
+                            ) * (2 * n_reconstruction_transforms)
+                            + (0 if reconstruction_signs[tr] > 0 else 1)
+                            * n_reconstruction_transforms
+                            + tr)
+                        <> best_transform_id = \
+                                best_reconstruction_key % n_reconstruction_transforms
+                        <> representative_entry_id = \
+                                best_reconstruction_key \
+                                / (2 * n_reconstruction_transforms)
+                        <> lookup_start = (representative_entry_id * 33) \
+                                % n_reconstruction_lookup_entries
+                        <> lookup_match_count = sum((probe),
+                            1
+                            if reconstruction_lookup_keys[
+                                (lookup_start + probe)
+                                % n_reconstruction_lookup_entries]
+                                == representative_entry_id
+                            else 0)
+                        <> entry_id = sum((probe),
+                            reconstruction_lookup_values[
+                                (lookup_start + probe)
+                                % n_reconstruction_lookup_entries]
+                            if reconstruction_lookup_keys[
+                                (lookup_start + probe)
+                                % n_reconstruction_lookup_entries]
+                                == representative_entry_id
+                            else 0)
+                        <> sign_lookup_start = (reconstruction_full_entry_id * 33) \
+                                % n_reconstruction_sign_lookup_entries
+                        <> sign_correction_match_count = sum((sign_probe),
+                            1
+                            if reconstruction_sign_lookup_keys[
+                                (sign_lookup_start + sign_probe)
+                                % n_reconstruction_sign_lookup_entries]
+                                == reconstruction_full_entry_id
+                            else 0)
+                        <> sign_correction = (
+                            sum((sign_probe),
+                                reconstruction_sign_lookup_values[
+                                    (sign_lookup_start + sign_probe)
+                                    % n_reconstruction_sign_lookup_entries]
+                                if reconstruction_sign_lookup_keys[
+                                    (sign_lookup_start + sign_probe)
+                                    % n_reconstruction_sign_lookup_entries]
+                                    == reconstruction_full_entry_id
+                                else 0)
+                            if sign_correction_match_count > 0
+                            else 1)
+                        <> entry_sign = reconstruction_signs[best_transform_id] \
+                                * sign_correction
+                        <> has_entry = lookup_match_count > 0
+            """
+            reconstruction_args = [
+                loopy.GlobalArg(
+                    "reconstruction_qpoint_map",
+                    np.int32,
+                    "n_reconstruction_transforms, n_q_points",
+                ),
+                loopy.GlobalArg(
+                    "reconstruction_case_map",
+                    np.int32,
+                    "n_reconstruction_transforms, n_cases",
+                ),
+                loopy.GlobalArg(
+                    "reconstruction_signs",
+                    np.int8,
+                    "n_reconstruction_transforms",
+                ),
+                loopy.GlobalArg(
+                    "reconstruction_lookup_keys",
+                    np.int32,
+                    "n_reconstruction_lookup_entries",
+                ),
+                loopy.GlobalArg(
+                    "reconstruction_lookup_values",
+                    np.int32,
+                    "n_reconstruction_lookup_entries",
+                ),
+                loopy.GlobalArg(
+                    "reconstruction_sign_lookup_keys",
+                    np.int32,
+                    "n_reconstruction_sign_lookup_entries",
+                ),
+                loopy.GlobalArg(
+                    "reconstruction_sign_lookup_values",
+                    np.int8,
+                    "n_reconstruction_sign_lookup_entries",
+                ),
+            ]
+            reconstruction_value_arg_names = (
+                ", n_reconstruction_transforms, "
+                "n_reconstruction_lookup_entries, n_reconstruction_lookup_probes, "
+                "n_reconstruction_sign_lookup_entries, "
+                "n_reconstruction_sign_lookup_probes"
+            )
+        else:
+            reconstruction_domains = []
+            reconstruction_code = """
+                        <> source_mode_id_sym = mode_qpoint_map[source_mode_id, source_mode_id]
+                        <> target_point_id_sym = mode_qpoint_map[source_mode_id, target_point_id]
+                        <> case_id_sym = mode_case_map[source_mode_id, case_id]
+                        <> mode_map_sign = mode_case_scale[source_mode_id, case_id]
+                        <> pair_id = source_mode_id_sym * n_q_points + target_point_id_sym
+                        <> entry_id_full = case_id_sym * (n_q_points * n_q_points) + pair_id
+                        <> entry_id = table_entry_ids[entry_id_full]
+                        <> entry_sign = table_entry_scales[entry_id_full] * mode_map_sign
+                        <> has_entry = entry_id >= 0
+            """
+            reconstruction_args = [
+                loopy.GlobalArg(
+                    "table_entry_ids", np.int32, "n_cases*n_q_points*n_q_points"
+                ),
+                loopy.GlobalArg(
+                    "table_entry_scales",
+                    potential_dtype,
+                    "n_cases*n_q_points*n_q_points",
+                ),
+                loopy.GlobalArg("mode_qpoint_map", np.int32, "n_q_points, n_q_points"),
+                loopy.GlobalArg("mode_case_map", np.int32, "n_q_points, n_cases"),
+                loopy.GlobalArg(
+                    "mode_case_scale",
+                    potential_dtype,
+                    "n_q_points, n_cases",
+                ),
+            ]
+            reconstruction_value_arg_names = ""
+
+        kernel_domains = [
+            "{ [ tbox ] : 0 <= tbox < n_tgt_boxes }",
+            "{ [ tid, sbox ] : 0 <= tid < n_box_targets and "
+            "sbox_begin <= sbox < sbox_end }",
+            "{ [ sid ] : 0 <= sid < n_box_sources }",
+        ] + reconstruction_domains
+
         lpknl = loopy.make_kernel(
-            [
-                "{ [ tbox ] : 0 <= tbox < n_tgt_boxes }",
-                "{ [ tid, sbox ] : 0 <= tid < n_box_targets and \
-                        sbox_begin <= sbox < sbox_end }",
-                "{ [ sid ] : 0 <= sid < n_box_sources }",
-            ],
+            kernel_domains,
             """
             for tbox
                 <> target_box_id    = target_boxes[tbox]
@@ -624,15 +788,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
                         <> source_id = box_source_beg + sid
                         <> source_mode_id = source_mode_ids[source_id]
-                        <> source_mode_id_sym = mode_qpoint_map[source_mode_id, source_mode_id]
-                        <> target_point_id_sym = mode_qpoint_map[source_mode_id, target_point_id]
-                        <> case_id_sym = mode_case_map[source_mode_id, case_id]
-                        <> mode_map_sign = mode_case_scale[source_mode_id, case_id]
-                        <> pair_id = source_mode_id_sym * n_q_points + target_point_id_sym
-                        <> entry_id_full = case_id_sym * (n_q_points * n_q_points) + pair_id
-                        <> entry_id = table_entry_ids[entry_id_full]
-                        <> entry_sign = table_entry_scales[entry_id_full] * mode_map_sign
-                        <> has_entry = entry_id >= 0
+                        RECONSTRUCT_ENTRY
 
                         <> displacement = COMPUTE_DISPLACEMENT
 
@@ -669,6 +825,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 end
             end
             """.replace("COMPUTE_VEC_ID", self.codegen_vec_id())
+            .replace("RECONSTRUCT_ENTRY", reconstruction_code)
             .replace("COMPUTE_SCALING", self.codegen_compute_scaling())
             .replace("COMPUTE_DISPLACEMENT", self.codegen_compute_displacement())
             .replace("COMPUTE_TGT_SCALING", self.codegen_compute_scaling("tbox"))
@@ -693,21 +850,6 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 loopy.GlobalArg(
                     "table_data", potential_dtype, "n_tables, n_table_entries"
                 ),
-                loopy.GlobalArg(
-                    "table_entry_ids", np.int32, "n_cases*n_q_points*n_q_points"
-                ),
-                loopy.GlobalArg(
-                    "table_entry_scales",
-                    potential_dtype,
-                    "n_cases*n_q_points*n_q_points",
-                ),
-                loopy.GlobalArg("mode_qpoint_map", np.int32, "n_q_points, n_q_points"),
-                loopy.GlobalArg("mode_case_map", np.int32, "n_q_points, n_cases"),
-                loopy.GlobalArg(
-                    "mode_case_scale",
-                    potential_dtype,
-                    "n_q_points, n_cases",
-                ),
                 loopy.GlobalArg("source_boxes", np.int32, "n_source_boxes"),
                 loopy.GlobalArg("box_centers", None, "dim, aligned_nboxes"),
                 loopy.GlobalArg(
@@ -722,11 +864,14 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 loopy.ValueArg("table_root_extent", np.float64),
                 loopy.ValueArg("table_starting_level", np.int32),
                 loopy.ValueArg(
-                    "dim, n_source_boxes, n_tables, n_q_points, n_cases, n_table_entries, n_source_particles, n_target_particles",
+                    "dim, n_source_boxes, n_tables, n_q_points, n_cases, "
+                    "n_table_entries, n_source_particles, n_target_particles"
+                    + reconstruction_value_arg_names,
                     np.int32,
                 ),
                 "...",
-            ],
+            ]
+            + reconstruction_args,
             name="near_field",
             lang_version=(2018, 2),
         )
@@ -744,6 +889,16 @@ class NearFieldFromCSR(NearFieldEvalBase):
             self.kname,
             "complex_kernel=" + str(self.integral_kernel.is_complex_valued),
             "potential_kind=%d" % self.potential_kind,
+            "reconstruction_kind=" + self.reconstruction_kind,
+            "n_reconstruction_transforms=%d" % self.n_reconstruction_transforms,
+            "n_reconstruction_lookup_entries=%d"
+            % self.n_reconstruction_lookup_entries,
+            "n_reconstruction_lookup_probes=%d"
+            % self.n_reconstruction_lookup_probes,
+            "n_reconstruction_sign_lookup_entries=%d"
+            % self.n_reconstruction_sign_lookup_entries,
+            "n_reconstruction_sign_lookup_probes=%d"
+            % self.n_reconstruction_sign_lookup_probes,
             "infer_scaling=" + str(self.extra_kwargs["infer_kernel_scaling"]),
             "case_encoding_bias=" + repr(self.extra_kwargs["case_encoding_bias"]),
             "scaling_policy=" + self.codegen_compute_scaling(),
@@ -771,11 +926,43 @@ class NearFieldFromCSR(NearFieldEvalBase):
         encoding_shift = kwargs.pop("encoding_shift")
         mode_nmlz_combined = kwargs.pop("mode_nmlz_combined")
         exterior_mode_nmlz_combined = kwargs.pop("exterior_mode_nmlz_combined")
-        mode_qpoint_map = kwargs.pop("mode_qpoint_map")
-        mode_case_map = kwargs.pop("mode_case_map")
-        mode_case_scale = kwargs.pop("mode_case_scale")
-        table_entry_ids = kwargs.pop("table_entry_ids")
-        table_entry_scales = kwargs.pop("table_entry_scales")
+        if self.reconstruction_kind == "generated-orbit":
+            reconstruction_kwargs = {
+                "reconstruction_qpoint_map": kwargs.pop("reconstruction_qpoint_map"),
+                "reconstruction_case_map": kwargs.pop("reconstruction_case_map"),
+                "reconstruction_signs": kwargs.pop("reconstruction_signs"),
+                "reconstruction_lookup_keys": kwargs.pop(
+                    "reconstruction_lookup_keys"
+                ),
+                "reconstruction_lookup_values": kwargs.pop(
+                    "reconstruction_lookup_values"
+                ),
+                "reconstruction_sign_lookup_keys": kwargs.pop(
+                    "reconstruction_sign_lookup_keys"
+                ),
+                "reconstruction_sign_lookup_values": kwargs.pop(
+                    "reconstruction_sign_lookup_values"
+                ),
+                "n_reconstruction_transforms": self.n_reconstruction_transforms,
+                "n_reconstruction_lookup_entries": (
+                    self.n_reconstruction_lookup_entries
+                ),
+                "n_reconstruction_lookup_probes": self.n_reconstruction_lookup_probes,
+                "n_reconstruction_sign_lookup_entries": (
+                    self.n_reconstruction_sign_lookup_entries
+                ),
+                "n_reconstruction_sign_lookup_probes": (
+                    self.n_reconstruction_sign_lookup_probes
+                ),
+            }
+        else:
+            reconstruction_kwargs = {
+                "mode_qpoint_map": kwargs.pop("mode_qpoint_map"),
+                "mode_case_map": kwargs.pop("mode_case_map"),
+                "mode_case_scale": kwargs.pop("mode_case_scale"),
+                "table_entry_ids": kwargs.pop("table_entry_ids"),
+                "table_entry_scales": kwargs.pop("table_entry_scales"),
+            }
         root_extent = kwargs.pop("root_extent")
         table_root_extent = kwargs.pop("table_root_extent")
         table_starting_level = kwargs.pop("table_starting_level")
@@ -887,11 +1074,6 @@ class NearFieldFromCSR(NearFieldEvalBase):
             encoding_shift=encoding_shift,
             mode_nmlz=mode_nmlz_combined,
             exterior_mode_nmlz=exterior_mode_nmlz_combined,
-            table_entry_ids=table_entry_ids,
-            table_entry_scales=table_entry_scales,
-            mode_qpoint_map=mode_qpoint_map,
-            mode_case_map=mode_case_map,
-            mode_case_scale=mode_case_scale,
             n_tgt_boxes=len(target_boxes),
             neighbor_source_boxes_starts=neighbor_source_boxes_starts,
             root_extent=root_extent,
@@ -906,6 +1088,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
             n_target_particles=len(target_point_ids),
             table_root_extent=table_root_extent,
             table_starting_level=table_starting_level,
+            **reconstruction_kwargs,
             **extra_knl_args_from_init,
         )
 

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -133,13 +133,20 @@ class NearFieldEvalBase(KernelCacheWrapper):
         self.n_reconstruction_sign_lookup_probes = table_data_shapes.get(
             "n_reconstruction_sign_lookup_probes", 0
         )
+        self.n_arithmetic_case_orbits = table_data_shapes.get(
+            "n_arithmetic_case_orbits", 0
+        )
         self.potential_kind = potential_kind
 
         assert np.isreal(self.n_tables)
         assert np.isreal(self.n_q_points)
         assert np.isreal(self.n_table_entries)
         assert np.isreal(self.n_cases)
-        assert self.reconstruction_kind in {"dense", "generated-orbit"}
+        assert self.reconstruction_kind in {
+            "dense",
+            "generated-orbit",
+            "scalar-arithmetic-orbit",
+        }
 
         self.options = options
         self.name = name or self.default_name
@@ -147,6 +154,12 @@ class NearFieldEvalBase(KernelCacheWrapper):
         self.extra_kwargs = kwargs
         self.kname = self.integral_kernel.__repr__()
         self.dim = self.integral_kernel.dim
+        self.quad_order = int(
+            table_data_shapes.get(
+                "quad_order",
+                round(float(self.n_q_points) ** (1.0 / float(self.dim))),
+            )
+        )
 
         if "case_encoding_bias" not in self.extra_kwargs:
             self.extra_kwargs["case_encoding_bias"] = CASE_ENCODING_BIAS_DEFAULT
@@ -587,7 +600,159 @@ class NearFieldFromCSR(NearFieldEvalBase):
         else:
             potential_dtype = np.float64
 
-        if self.reconstruction_kind == "generated-orbit":
+        if self.reconstruction_kind == "scalar-arithmetic-orbit":
+            reconstruction_domains = []
+
+            def select_axis(prefix, perm_name):
+                if self.dim == 2:
+                    return (
+                        f"({prefix}_raw_0 if {perm_name} == 0 "
+                        f"else {prefix}_raw_1)"
+                    )
+                if self.dim == 3:
+                    return (
+                        f"({prefix}_raw_0 if {perm_name} == 0 "
+                        f"else ({prefix}_raw_1 if {perm_name} == 1 "
+                        f"else {prefix}_raw_2))"
+                    )
+                raise NotImplementedError("arithmetic ORBIT supports dim 2 or 3")
+
+            if self.dim == 2:
+                decode_code = """
+                        <> src_raw_0 = source_mode_id / quad_order
+                        <> src_raw_1 = source_mode_id % quad_order
+                        <> tgt_raw_0 = target_point_id / quad_order
+                        <> tgt_raw_1 = target_point_id % quad_order
+                """
+                encode_source = "src0_s * quad_order + src1_s"
+                encode_target = "tgt0_s * quad_order + tgt1_s"
+                sort_code = """
+                        <> swap01 = (1 if group0 == group1
+                            and (src1 < src0 or (src1 == src0 and tgt1 < tgt0))
+                            else 0)
+                        <> src0_s = (src1 if swap01 else src0)
+                        <> tgt0_s = (tgt1 if swap01 else tgt0)
+                        <> src1_s = (src0 if swap01 else src1)
+                        <> tgt1_s = (tgt0 if swap01 else tgt1)
+                """
+            elif self.dim == 3:
+                decode_code = """
+                        <> src_raw_0 = source_mode_id / (quad_order * quad_order)
+                        <> src_raw_1 = (source_mode_id / quad_order) % quad_order
+                        <> src_raw_2 = source_mode_id % quad_order
+                        <> tgt_raw_0 = target_point_id / (quad_order * quad_order)
+                        <> tgt_raw_1 = (target_point_id / quad_order) % quad_order
+                        <> tgt_raw_2 = target_point_id % quad_order
+                """
+                encode_source = (
+                    "src0_s * (quad_order * quad_order) + src1_s * quad_order + src2_s"
+                )
+                encode_target = (
+                    "tgt0_s * (quad_order * quad_order) + tgt1_s * quad_order + tgt2_s"
+                )
+                sort_code = """
+                        <> swap01_a = (1 if group0 == group1
+                            and (src1 < src0 or (src1 == src0 and tgt1 < tgt0))
+                            else 0)
+                        <> src0_a = (src1 if swap01_a else src0)
+                        <> tgt0_a = (tgt1 if swap01_a else tgt0)
+                        <> src1_a = (src0 if swap01_a else src1)
+                        <> tgt1_a = (tgt0 if swap01_a else tgt1)
+                        <> src2_a = src2
+                        <> tgt2_a = tgt2
+
+                        <> swap12_b = (1 if group1 == group2
+                            and (src2_a < src1_a
+                                or (src2_a == src1_a and tgt2_a < tgt1_a))
+                            else 0)
+                        <> src0_b = src0_a
+                        <> tgt0_b = tgt0_a
+                        <> src1_b = (src2_a if swap12_b else src1_a)
+                        <> tgt1_b = (tgt2_a if swap12_b else tgt1_a)
+                        <> src2_b = (src1_a if swap12_b else src2_a)
+                        <> tgt2_b = (tgt1_a if swap12_b else tgt2_a)
+
+                        <> swap01_c = (1 if group0 == group1
+                            and (src1_b < src0_b
+                                or (src1_b == src0_b and tgt1_b < tgt0_b))
+                            else 0)
+                        <> src0_s = (src1_b if swap01_c else src0_b)
+                        <> tgt0_s = (tgt1_b if swap01_c else tgt0_b)
+                        <> src1_s = (src0_b if swap01_c else src1_b)
+                        <> tgt1_s = (tgt0_b if swap01_c else tgt1_b)
+                        <> src2_s = src2_b
+                        <> tgt2_s = tgt2_b
+                """
+            else:
+                raise NotImplementedError("arithmetic ORBIT supports dim 2 or 3")
+
+            axis_code = ""
+            for iaxis in range(self.dim):
+                perm_name = f"perm{iaxis}"
+                sign_name = f"axis_sign{iaxis}"
+                axis_code += f"""
+                        <> {perm_name} = arithmetic_case_axis_perm[case_id, {iaxis}]
+                        <> {sign_name} = arithmetic_case_axis_sign[case_id, {iaxis}]
+                        <> group{iaxis} = arithmetic_case_axis_group[case_id, {iaxis}]
+                        <> src{iaxis}_raw_perm = {select_axis("src", perm_name)}
+                        <> tgt{iaxis}_raw_perm = {select_axis("tgt", perm_name)}
+                        <> src{iaxis}_fixed = (quad_order - 1 - src{iaxis}_raw_perm
+                            if {sign_name} < 0 else src{iaxis}_raw_perm)
+                        <> tgt{iaxis}_fixed = (quad_order - 1 - tgt{iaxis}_raw_perm
+                            if {sign_name} < 0 else tgt{iaxis}_raw_perm)
+                        <> src{iaxis}_flip = quad_order - 1 - src{iaxis}_raw_perm
+                        <> tgt{iaxis}_flip = quad_order - 1 - tgt{iaxis}_raw_perm
+                        <> zero_flip{iaxis} = (1 if {sign_name} == 0
+                            and (src{iaxis}_flip < src{iaxis}_raw_perm
+                                or (src{iaxis}_flip == src{iaxis}_raw_perm
+                                    and tgt{iaxis}_flip < tgt{iaxis}_raw_perm))
+                            else 0)
+                        <> src{iaxis} = (src{iaxis}_flip
+                            if zero_flip{iaxis} else src{iaxis}_fixed)
+                        <> tgt{iaxis} = (tgt{iaxis}_flip
+                            if zero_flip{iaxis} else tgt{iaxis}_fixed)
+                """
+
+            reconstruction_code = f"""
+                        {decode_code}
+                        {axis_code}
+                        {sort_code}
+                        <> canonical_source_id = {encode_source}
+                        <> canonical_target_id = {encode_target}
+                        <> arithmetic_case_rank = arithmetic_case_orbit_ranks[case_id]
+                        <> entry_id = arithmetic_case_rank * (n_q_points * n_q_points) \
+                                + canonical_source_id * n_q_points + canonical_target_id
+                        <> entry_sign = 1
+                        <> has_entry = 1
+            """
+            reconstruction_args = [
+                loopy.GlobalArg(
+                    "arithmetic_case_orbit_ranks",
+                    np.uint16,
+                    "n_cases",
+                    is_input=True,
+                ),
+                loopy.GlobalArg(
+                    "arithmetic_case_axis_perm",
+                    np.uint8,
+                    "n_cases, dim",
+                    is_input=True,
+                ),
+                loopy.GlobalArg(
+                    "arithmetic_case_axis_sign",
+                    np.int8,
+                    "n_cases, dim",
+                    is_input=True,
+                ),
+                loopy.GlobalArg(
+                    "arithmetic_case_axis_group",
+                    np.uint8,
+                    "n_cases, dim",
+                    is_input=True,
+                ),
+            ]
+            reconstruction_value_arg_names = ", quad_order, n_arithmetic_case_orbits"
+        elif self.reconstruction_kind == "generated-orbit":
             reconstruction_domains = [
                 "{ [ tr ] : 0 <= tr < n_reconstruction_transforms }",
                 "{ [ probe ] : 0 <= probe < n_reconstruction_lookup_probes }",
@@ -899,6 +1064,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
             % self.n_reconstruction_sign_lookup_entries,
             "n_reconstruction_sign_lookup_probes=%d"
             % self.n_reconstruction_sign_lookup_probes,
+            "n_arithmetic_case_orbits=%d" % self.n_arithmetic_case_orbits,
             "infer_scaling=" + str(self.extra_kwargs["infer_kernel_scaling"]),
             "case_encoding_bias=" + repr(self.extra_kwargs["case_encoding_bias"]),
             "scaling_policy=" + self.codegen_compute_scaling(),
@@ -926,7 +1092,24 @@ class NearFieldFromCSR(NearFieldEvalBase):
         encoding_shift = kwargs.pop("encoding_shift")
         mode_nmlz_combined = kwargs.pop("mode_nmlz_combined")
         exterior_mode_nmlz_combined = kwargs.pop("exterior_mode_nmlz_combined")
-        if self.reconstruction_kind == "generated-orbit":
+        if self.reconstruction_kind == "scalar-arithmetic-orbit":
+            reconstruction_kwargs = {
+                "arithmetic_case_orbit_ranks": kwargs.pop(
+                    "arithmetic_case_orbit_ranks"
+                ),
+                "arithmetic_case_axis_perm": kwargs.pop(
+                    "arithmetic_case_axis_perm"
+                ),
+                "arithmetic_case_axis_sign": kwargs.pop(
+                    "arithmetic_case_axis_sign"
+                ),
+                "arithmetic_case_axis_group": kwargs.pop(
+                    "arithmetic_case_axis_group"
+                ),
+                "quad_order": self.quad_order,
+                "n_arithmetic_case_orbits": self.n_arithmetic_case_orbits,
+            }
+        elif self.reconstruction_kind == "generated-orbit":
             reconstruction_kwargs = {
                 "reconstruction_qpoint_map": kwargs.pop("reconstruction_qpoint_map"),
                 "reconstruction_case_map": kwargs.pop("reconstruction_case_map"),

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -146,6 +146,7 @@ class NearFieldEvalBase(KernelCacheWrapper):
             "dense",
             "generated-orbit",
             "scalar-arithmetic-orbit",
+            "signed-arithmetic-orbit",
         }
 
         self.options = options
@@ -600,7 +601,10 @@ class NearFieldFromCSR(NearFieldEvalBase):
         else:
             potential_dtype = np.float64
 
-        if self.reconstruction_kind == "scalar-arithmetic-orbit":
+        if self.reconstruction_kind in {
+            "scalar-arithmetic-orbit",
+            "signed-arithmetic-orbit",
+        }:
             reconstruction_domains = []
 
             def select_axis(prefix, perm_name):
@@ -694,6 +698,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         <> {perm_name} = arithmetic_case_axis_perm[case_id, {iaxis}]
                         <> {sign_name} = arithmetic_case_axis_sign[case_id, {iaxis}]
                         <> group{iaxis} = arithmetic_case_axis_group[case_id, {iaxis}]
+                        <> sign_power{iaxis} = arithmetic_axis_sign_power[{perm_name}]
                         <> src{iaxis}_raw_perm = {select_axis("src", perm_name)}
                         <> tgt{iaxis}_raw_perm = {select_axis("tgt", perm_name)}
                         <> src{iaxis}_fixed = (quad_order - 1 - src{iaxis}_raw_perm
@@ -711,6 +716,10 @@ class NearFieldFromCSR(NearFieldEvalBase):
                             if zero_flip{iaxis} else src{iaxis}_fixed)
                         <> tgt{iaxis} = (tgt{iaxis}_flip
                             if zero_flip{iaxis} else tgt{iaxis}_fixed)
+                        <> transform_sign{iaxis} = (-1
+                            if {sign_name} < 0 or zero_flip{iaxis} else 1)
+                        <> entry_sign_factor{iaxis} = (transform_sign{iaxis}
+                            if sign_power{iaxis} != 0 else 1)
                 """
 
             reconstruction_code = f"""
@@ -722,7 +731,9 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         <> arithmetic_case_rank = arithmetic_case_orbit_ranks[case_id]
                         <> entry_id = arithmetic_case_rank * (n_q_points * n_q_points) \
                                 + canonical_source_id * n_q_points + canonical_target_id
-                        <> entry_sign = 1
+                        <> entry_sign = {" * ".join(
+                            f"entry_sign_factor{iaxis}" for iaxis in range(self.dim)
+                        )}
                         <> has_entry = 1
             """
             reconstruction_args = [
@@ -748,6 +759,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
                     "arithmetic_case_axis_group",
                     np.uint8,
                     "n_cases, dim",
+                    is_input=True,
+                ),
+                loopy.GlobalArg(
+                    "arithmetic_axis_sign_power",
+                    np.uint8,
+                    "dim",
                     is_input=True,
                 ),
             ]
@@ -899,8 +916,8 @@ class NearFieldFromCSR(NearFieldEvalBase):
 
         kernel_domains = [
             "{ [ tbox ] : 0 <= tbox < n_tgt_boxes }",
-            "{ [ tid, sbox ] : 0 <= tid < n_box_targets and "
-            "sbox_begin <= sbox < sbox_end }",
+            "{ [ tid ] : 0 <= tid < n_q_points }",
+            "{ [ sbox ] : sbox_begin <= sbox < sbox_end }",
             "{ [ sid ] : 0 <= sid < n_box_sources }",
         ] + reconstruction_domains
 
@@ -919,10 +936,13 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 <> tbox_extent = root_extent * (1.0 / (2**tbox_level))
 
                 for tid
+                    if tid < n_box_targets
                     <> target_id = box_target_beg + tid
+                    end
                 end
 
                 for tid, sbox
+                    if tid < n_box_targets
                     <> source_box_id  = source_boxes[sbox]
                     <> n_box_sources  = box_source_counts_nonchild[source_box_id]
                     <> box_source_beg = box_source_starts[source_box_id]
@@ -975,18 +995,22 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         #db_entry_id[target_id] = entry_id
 
                     end
+                    end
                 end
 
                 for tid
+                    if tid < n_box_targets
 
                     result[target_id] = sum((sbox, sid),
-                        coef * integ) + EXTERIOR_PART {dep=integ:coef:extnmlz}
+                        coef * integ) + EXTERIOR_PART \
+                            {id=write_result,dep=integ:coef:extnmlz}
 
                     # Try inspecting case_id if something goes wrong
                     # (like segmentation fault) and look for -1's
                     # result[target_id] = min((sbox, sid), case_id)
                     # result[target_id] = vec_id_tmp
 
+                    end
                 end
             end
             """.replace("COMPUTE_VEC_ID", self.codegen_vec_id())
@@ -1039,6 +1063,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
             + reconstruction_args,
             name="near_field",
             lang_version=(2018, 2),
+            silenced_warnings=("write_race(write_result)",),
         )
 
         # lpknl = loopy.set_options(lpknl, write_code=True)
@@ -1049,7 +1074,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
     def get_cache_key(self):
         return (
             type(self).__name__,
-            "kernel-v10",
+            "kernel-v12",
             self.name,
             self.kname,
             "complex_kernel=" + str(self.integral_kernel.is_complex_valued),
@@ -1065,6 +1090,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
             "n_reconstruction_sign_lookup_probes=%d"
             % self.n_reconstruction_sign_lookup_probes,
             "n_arithmetic_case_orbits=%d" % self.n_arithmetic_case_orbits,
+            "list1_target_batch_size=%d" % self._target_batch_size(),
             "infer_scaling=" + str(self.extra_kwargs["infer_kernel_scaling"]),
             "case_encoding_bias=" + repr(self.extra_kwargs["case_encoding_bias"]),
             "scaling_policy=" + self.codegen_compute_scaling(),
@@ -1072,8 +1098,30 @@ class NearFieldFromCSR(NearFieldEvalBase):
             "table_level_policy=" + self.codegen_get_table_level(),
         )
 
+    def _target_batch_size(self):
+        target_batch_size = int(self.extra_kwargs.get("list1_target_batch_size", 1))
+        if target_batch_size < 1:
+            raise ValueError("list1_target_batch_size must be positive")
+        return target_batch_size
+
     def get_optimized_kernel(self, ncpus=None):
         knl = self.get_kernel()
+        target_batch_size = self._target_batch_size()
+        if target_batch_size > 1:
+            # Each target row is independent; keep the source-box/source-mode
+            # reduction private to one work item while mapping neighboring target
+            # points in a box to local lanes for warp/subgroup-friendly execution.
+            knl = loopy.split_iname(
+                knl,
+                "tid",
+                inner_length=target_batch_size,
+                outer_tag="g.1",
+                inner_tag="l.0",
+                slabs=(0, 1),
+            )
+
+        knl = loopy.tag_inames(knl, {"tbox": "g.0"})
+        knl = loopy.add_inames_for_unused_hw_axes(knl)
         return knl
 
     def __call__(self, queue, **kwargs):
@@ -1092,7 +1140,10 @@ class NearFieldFromCSR(NearFieldEvalBase):
         encoding_shift = kwargs.pop("encoding_shift")
         mode_nmlz_combined = kwargs.pop("mode_nmlz_combined")
         exterior_mode_nmlz_combined = kwargs.pop("exterior_mode_nmlz_combined")
-        if self.reconstruction_kind == "scalar-arithmetic-orbit":
+        if self.reconstruction_kind in {
+            "scalar-arithmetic-orbit",
+            "signed-arithmetic-orbit",
+        }:
             reconstruction_kwargs = {
                 "arithmetic_case_orbit_ranks": kwargs.pop(
                     "arithmetic_case_orbit_ranks"
@@ -1105,6 +1156,9 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 ),
                 "arithmetic_case_axis_group": kwargs.pop(
                     "arithmetic_case_axis_group"
+                ),
+                "arithmetic_axis_sign_power": kwargs.pop(
+                    "arithmetic_axis_sign_power"
                 ),
                 "quad_order": self.quad_order,
                 "n_arithmetic_case_orbits": self.n_arithmetic_case_orbits,

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -680,12 +680,23 @@ class NearFieldFromCSR(NearFieldEvalBase):
                             and (src1_b < src0_b
                                 or (src1_b == src0_b and tgt1_b < tgt0_b))
                             else 0)
-                        <> src0_s = (src1_b if swap01_c else src0_b)
-                        <> tgt0_s = (tgt1_b if swap01_c else tgt0_b)
-                        <> src1_s = (src0_b if swap01_c else src1_b)
-                        <> tgt1_s = (tgt0_b if swap01_c else tgt1_b)
-                        <> src2_s = src2_b
-                        <> tgt2_s = tgt2_b
+                        <> src0_c = (src1_b if swap01_c else src0_b)
+                        <> tgt0_c = (tgt1_b if swap01_c else tgt0_b)
+                        <> src1_c = (src0_b if swap01_c else src1_b)
+                        <> tgt1_c = (tgt0_b if swap01_c else tgt1_b)
+                        <> src2_c = src2_b
+                        <> tgt2_c = tgt2_b
+
+                        <> swap02_d = (1 if group0 == group2
+                            and (src2_c < src0_c
+                                or (src2_c == src0_c and tgt2_c < tgt0_c))
+                            else 0)
+                        <> src0_s = (src2_c if swap02_d else src0_c)
+                        <> tgt0_s = (tgt2_c if swap02_d else tgt0_c)
+                        <> src1_s = src1_c
+                        <> tgt1_s = tgt1_c
+                        <> src2_s = (src0_c if swap02_d else src2_c)
+                        <> tgt2_s = (tgt0_c if swap02_d else tgt2_c)
                 """
             else:
                 raise NotImplementedError("arithmetic ORBIT supports dim 2 or 3")

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -1288,8 +1288,12 @@ class NearFieldInteractionTable:
         direction_key = self._symmetry_source_direction_key(symmetry_source_direction)
         return self._get_online_symmetry_maps_cached(direction_key)
 
+    def _get_orbit_reconstruction_maps(self, symmetry_source_direction=None):
+        direction_key = self._symmetry_source_direction_key(symmetry_source_direction)
+        return self._get_orbit_reconstruction_maps_cached(direction_key)
+
     @memoize_method
-    def _get_online_symmetry_maps_cached(self, symmetry_source_direction_key):
+    def _get_orbit_reconstruction_maps_cached(self, symmetry_source_direction_key):
         runtime_source_direction = None
         if symmetry_source_direction_key is not None:
             runtime_source_direction = np.asarray(
@@ -1302,10 +1306,6 @@ class NearFieldInteractionTable:
                     "symmetry_source_direction has incompatible shape "
                     f"{runtime_source_direction.shape}; expected {expected_shape}"
                 )
-
-        mode_qpoint_map = np.empty((self.n_q_points, self.n_q_points), dtype=np.int32)
-        mode_case_map = np.empty((self.n_q_points, self.n_cases), dtype=np.int32)
-        mode_case_scale = np.empty((self.n_q_points, self.n_cases), dtype=np.int8)
 
         all_mode_axes = self._get_all_mode_axes()
         case_vecs = np.asarray(self.interaction_case_vecs, dtype=np.int32)
@@ -1320,7 +1320,11 @@ class NearFieldInteractionTable:
         )
         kernel_constraint, kernel_sign_eval = _kernel_symmetry_meta(kernel)
 
-        transforms = []
+        mode_maps = []
+        case_maps = []
+        transform_signs = []
+        transform_signatures = []
+
         for sign_tuple in product([-1, 1], repeat=self.dim):
             sgn = np.asarray(sign_tuple, dtype=np.int32)
             neg_axes = sgn < 0
@@ -1338,10 +1342,9 @@ class NearFieldInteractionTable:
                         self.quad_order - 1 - mapped_axes[:, neg_axes]
                     )
                 mapped_axes = mapped_axes[:, perm]
-                transform_mode_map = np.ravel_multi_index(
-                    mapped_axes.T,
-                    multi_shape,
-                ).astype(np.int32)
+                mode_maps.append(
+                    np.ravel_multi_index(mapped_axes.T, multi_shape).astype(np.int32)
+                )
 
                 mapped_case_vecs = case_vecs * sgn
                 mapped_case_vecs = mapped_case_vecs[:, perm]
@@ -1352,7 +1355,7 @@ class NearFieldInteractionTable:
                     ],
                     dtype=np.int64,
                 )
-                transform_case_map = self.case_indices[encoded].astype(np.int32)
+                case_maps.append(self.case_indices[encoded].astype(np.int32))
 
                 transform_sign = int(kernel_sign_eval(sign_tuple, perm_tuple))
                 if transform_sign not in {-1, 1}:
@@ -1360,29 +1363,44 @@ class NearFieldInteractionTable:
                         "kernel symmetry transform sign must be +/-1, got "
                         f"{transform_sign}"
                     )
-
-                transforms.append(
+                transform_signs.append(transform_sign)
+                transform_signatures.append(
                     (
-                        transform_mode_map,
-                        transform_case_map,
-                        np.int8(transform_sign),
                         tuple(int(val) for val in sign_tuple),
                         tuple(int(val) for val in perm_tuple),
                     )
                 )
 
-        if not transforms:
-            identity_mode = np.arange(self.n_q_points, dtype=np.int32)
-            identity_case = np.arange(self.n_cases, dtype=np.int32)
-            transforms = [
-                (
-                    identity_mode,
-                    identity_case,
-                    np.int8(1),
-                    (1,) * self.dim,
-                    tuple(range(self.dim)),
-                )
-            ]
+        if not mode_maps:
+            mode_maps = [np.arange(self.n_q_points, dtype=np.int32)]
+            case_maps = [np.arange(self.n_cases, dtype=np.int32)]
+            transform_signs = [1]
+            transform_signatures = [((1,) * self.dim, tuple(range(self.dim)))]
+
+        return {
+            "transform_qpoint_map": np.ascontiguousarray(
+                np.vstack(mode_maps), dtype=np.int32
+            ),
+            "transform_case_map": np.ascontiguousarray(
+                np.vstack(case_maps), dtype=np.int32
+            ),
+            "transform_signs": np.asarray(transform_signs, dtype=np.int8),
+            "transform_signatures": tuple(transform_signatures),
+        }
+
+    @memoize_method
+    def _get_online_symmetry_maps_cached(self, symmetry_source_direction_key):
+        mode_qpoint_map = np.empty((self.n_q_points, self.n_q_points), dtype=np.int32)
+        mode_case_map = np.empty((self.n_q_points, self.n_cases), dtype=np.int32)
+        mode_case_scale = np.empty((self.n_q_points, self.n_cases), dtype=np.int8)
+
+        reconstruction_maps = self._get_orbit_reconstruction_maps_cached(
+            symmetry_source_direction_key
+        )
+        transform_qpoint_map = reconstruction_maps["transform_qpoint_map"]
+        transform_case_map = reconstruction_maps["transform_case_map"]
+        transform_signs = reconstruction_maps["transform_signs"]
+        transform_signatures = reconstruction_maps["transform_signatures"]
 
         for source_mode_index in range(self.n_q_points):
             best_score = None
@@ -1390,13 +1408,11 @@ class NearFieldInteractionTable:
             best_case_map = None
             best_sign = np.int8(1)
 
-            for (
-                transform_mode_map,
-                transform_case_map,
-                transform_sign,
-                sign_tuple,
-                perm_tuple,
-            ) in transforms:
+            for itransform in range(len(transform_signs)):
+                transform_mode_map = transform_qpoint_map[itransform]
+                transform_case_map_i = transform_case_map[itransform]
+                transform_sign = np.int8(transform_signs[itransform])
+                sign_tuple, perm_tuple = transform_signatures[itransform]
                 mapped_source_mode = int(transform_mode_map[source_mode_index])
                 score = (
                     mapped_source_mode,
@@ -1407,7 +1423,7 @@ class NearFieldInteractionTable:
                 if best_score is None or score < best_score:
                     best_score = score
                     best_mode_map = transform_mode_map
-                    best_case_map = transform_case_map
+                    best_case_map = transform_case_map_i
                     best_sign = transform_sign
 
             if best_mode_map is None or best_case_map is None:
@@ -1447,7 +1463,6 @@ class NearFieldInteractionTable:
             return cached
 
         all_mode_axes = self._get_all_mode_axes()
-        case_vecs = np.asarray(self.interaction_case_vecs, dtype=np.int32)
 
         n_entries = self.n_cases * self.n_pairs
         n_q_points_i64 = np.int64(self.n_q_points)
@@ -1457,55 +1472,10 @@ class NearFieldInteractionTable:
         rank = np.zeros(n_entries, dtype=np.int8)
         rel = np.ones(n_entries, dtype=np.int8)
 
-        from itertools import permutations, product
-
-        multi_shape = (self.quad_order,) * self.dim
-        perms = list(permutations(range(self.dim)))
-        signs = list(product([-1, 1], repeat=self.dim))
-
-        mode_maps = []
-        case_maps = []
-        transform_signs = []
-        kernel = self.integral_knl
-        self._attach_directional_symmetry_metadata(
-            kernel,
-            self.symmetry_source_direction,
-        )
-
-        kernel_constraint, kernel_sign_eval = _kernel_symmetry_meta(kernel)
-
-        for sign_tuple in signs:
-            sgn = np.asarray(sign_tuple, dtype=np.int32)
-            neg_axes = sgn < 0
-
-            for perm_tuple in perms:
-                perm = np.asarray(perm_tuple, dtype=np.int32)
-
-                if not kernel_constraint(sign_tuple, perm_tuple):
-                    continue
-
-                mapped_axes = all_mode_axes
-                if np.any(neg_axes):
-                    mapped_axes = mapped_axes.copy()
-                    mapped_axes[:, neg_axes] = (
-                        self.quad_order - 1 - mapped_axes[:, neg_axes]
-                    )
-                mapped_axes = mapped_axes[:, perm]
-                mode_maps.append(
-                    np.ravel_multi_index(mapped_axes.T, multi_shape).astype(np.int32)
-                )
-
-                mapped_case_vecs = case_vecs * sgn
-                mapped_case_vecs = mapped_case_vecs[:, perm]
-                encoded = np.array(
-                    [
-                        self.case_encode(case_vec.tolist())
-                        for case_vec in mapped_case_vecs
-                    ],
-                    dtype=np.int64,
-                )
-                case_maps.append(self.case_indices[encoded].astype(np.int32))
-                transform_signs.append(int(kernel_sign_eval(sign_tuple, perm_tuple)))
+        reconstruction_maps = self._get_orbit_reconstruction_maps()
+        mode_maps = reconstruction_maps["transform_qpoint_map"]
+        case_maps = reconstruction_maps["transform_case_map"]
+        transform_signs = reconstruction_maps["transform_signs"]
 
         for mode_map, case_map, transform_sign in zip(
             mode_maps, case_maps, transform_signs


### PR DESCRIPTION
## Summary

Implements generated and arithmetic ORBIT reconstruction paths for issue #108.

- Keeps dense `table_entry_ids` / `table_entry_scales` as the construction-time oracle and fallback.
- Adds a scalar full-symmetry arithmetic path that canonicalizes entries from packed `uint16`/`uint8`/`int8` per-case descriptors.
- Adds a signed arithmetic path for axis source/target derivatives, mixed axis derivatives, and axis-aligned directional source derivatives using per-axis analytic sign powers.
- Uses a target-fastest `(canonical_case_orbit, canonical_source, canonical_target)` table layout for scalar and signed arithmetic reconstruction.
- Schedules List 1 target boxes on a global hardware axis and exposes `list1_target_batch_size` for target-lane subgroup experiments. The default is `1` based on H200 timings; `32` is correct but slower on the measured q=2/q=3 target-derivative cases.
- Fixes source-derivative far-field expansion formation by deriving source-side kernels for P2M/P2L while preserving original output kernels for near-field/direct lookup.
- Keeps a generated descriptor fallback for other constrained/sign-changing kernels, such as non-axis directional source derivatives, using bounded lookup tables and sparse sign corrections.
- Adds payload diagnostics and CPU-only equivalence coverage.

## q=3 Payload Diagnostic

For scalar 3D Laplace at `q=3`:

- Dense reconstruction metadata: `1,215,972` bytes.
- Scalar arithmetic reconstruction metadata: `1,532` bytes.
- Scalar arithmetic table value payload: `58,320` bytes.
- The arithmetic layout intentionally uses extra scalar rows versus the `2510` minimal representatives to remove transform scans and representative hash lookups from the scalar online kernel.
- Axis source/target derivatives now use the same no-transform-scan/no-hash-lookup arithmetic kernel path: `1,532` bytes metadata and `11,664` q=3 value rows for single-axis 3D derivatives. Mixed axis derivatives use `16,038` q=3 value rows. Convention-only odd self-stabilizer sign conflicts are counted during payload packing instead of using a device sign lookup.

## Tests

- `rtk uv run python -m compileall volumential/list1.py volumential/expansion_wrangler_fpnd.py volumential/nearfield_potential_table.py test/test_nearfield_potential_table.py`
- Direct CPU calls for scalar arithmetic plus source/target/mixed derivative signed arithmetic reconstruction checks and q=3 diagnostic.
- Scalar and signed arithmetic List 1 kernel parse via `NearFieldFromCSR(...).get_kernel()`.
- On `ipa` H200 OpenCL: `python -m pytest test/test_nearfield_potential_table.py -k "arithmetic_orbit_reconstruction or non_axis_directional_source_derivative_uses_generated_fallback"`
- On `ipa` H200 OpenCL: `python -m pytest test/test_volume_fmm.py -k "source_target_derivative_antisymmetry or target_derivative_list1_preserves_odd_x_symmetry or target_derivative_matches_scalar_fd_sign"`
- `rtk uv run pytest test/test_lagrange.py`
- `rtk git diff --check`

## H200 List 1 Timing Notes

- q=2, nlevels=4 target derivative List 1 median: original `0.0607s`, `list1_target_batch_size=1` `0.0446s`, `list1_target_batch_size=32` `0.0541s`.
- q=3, nlevels=3 target derivative List 1 median: original `0.0980s`, `list1_target_batch_size=1` `0.0740s`, `list1_target_batch_size=32` `0.0888s`.
- Outputs matched the original in both timing runs.

## Local Limitations

- `ruff` is unavailable in the local `uv` environment.
- Focused `pytest test/test_nearfield_potential_table.py ...` is blocked locally during collection because PyOpenCL finds no CL platforms.

## Draft Status

This PR is draft pending CI/OpenCL validation and review of the scalar arithmetic table-layout tradeoff.
