### PR TITLE
feat: compact arithmetic orbit value layout

### DIFF
--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -33,12 +33,19 @@ use the arithmetic path.
 - The evaluator decodes tensor-product source/target indices, applies the
   per-case signed permutation, resolves zero-axis flips locally, and uses a
   fixed compare-exchange sorting network for equal-absolute-value case axes.
-- The table layout is ``(canonical_case_orbit, canonical_source,
-  canonical_target)`` with target index fastest. This intentionally stores some
-  unused scalar layout rows to remove representative hash lookups and keep GPU
-  table accesses arithmetic and coalescing-friendly. Axis derivatives use the
-  same target-fastest layout and pre-apply any row-level representative sign
-  convention while packing the table values.
+- The table layout is compact by canonical case orbit. Each case orbit stores a
+  contiguous value segment, and the evaluator computes a compact multiset rank
+  for the canonical source/target pair under that case stabilizer. This keeps
+  scalar value rows at the persisted representative-entry count while avoiding
+  representative hash lookups and full-entry maps.
+- ``case_value_offsets`` maps a canonical case-orbit rank to the beginning of
+  its compact value segment. It is the only extra arithmetic-layout metadata
+  beyond the PR #109 descriptors.
+- Axis derivatives use the same compact layout and pre-apply any row-level
+  representative sign convention while packing the table values. Directional
+  derivative subgroups whose line-sign stabilizer couples multiple axes may use
+  a small compact envelope with duplicate representative values, still without a
+  runtime hash table.
 
 Unsupported constrained or sign-changing kernels use the generated descriptor
 fallback.
@@ -81,10 +88,11 @@ benchmarks.
 For scalar 3D Laplace at ``q=3``, the dense online reconstruction maps contain
 ``101331`` full entries and occupy ``1215972`` bytes as ``int32`` IDs plus
 ``float64`` scales. Scalar arithmetic reconstruction reduces transferred
-metadata to ``1532`` bytes in the CPU descriptor test. It uses a
-canonical-case table layout rather than the minimal representative-only layout,
-so value bytes increase relative to ``2510`` representatives while eliminating
-the transform scan and representative hash lookup in the scalar online kernel.
+metadata to ``1576`` bytes in the CPU descriptor test, including the
+``case_value_offsets`` array. The compact value layout stores ``2510`` scalar
+representative rows, matching the persisted representative-entry count while
+eliminating the transform scan and representative hash lookup in the scalar
+online kernel.
 
 Derivative kernels
 ------------------

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -2254,8 +2254,7 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
 
     from volumential.expansion_wrangler_fpnd import (
         _entry_has_odd_reconstruction_stabilizer,
-        _evaluate_arithmetic_orbit_entry,
-        _evaluate_scalar_arithmetic_entry,
+        _evaluate_compact_arithmetic_orbit_entry,
         _prepare_table_data_and_entry_map,
     )
 
@@ -2336,7 +2335,17 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
             "scalar-laplace",
             "repeated-directional-source-derivative",
         }
-        assert table_data_combined.shape[1] > len(entry_ids)
+        assert table_data_combined.shape[1] == reconstruction_info[
+            "compact_value_entry_count"
+        ]
+        assert table_data_combined.shape[1] < reconstruction_info[
+            "dense_arithmetic_layout_entry_count"
+        ]
+        assert reconstruction_info["distinct_layout_entry_count"] == len(entry_ids)
+        if kernel_case == "scalar-laplace":
+            assert table_data_combined.shape[1] == len(entry_ids)
+            assert reconstruction_info["duplicate_layout_entry_count"] == 0
+            assert reconstruction_info["unused_layout_entry_count"] == 0
         assert reconstruction_info["metadata_bytes"] < 2000
 
         for full_entry_id in range(table.n_cases * table.n_pairs):
@@ -2344,11 +2353,12 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
             pair_id = full_entry_id % table.n_pairs
             source_mode_id = pair_id // table.n_q_points
             target_point_id = pair_id % table.n_q_points
-            arithmetic_row = _evaluate_scalar_arithmetic_entry(
+            arithmetic_row, arithmetic_sign = _evaluate_compact_arithmetic_orbit_entry(
                 case_id,
                 source_mode_id,
                 target_point_id,
                 case_orbit_ranks=reconstruction_info["case_orbit_ranks"],
+                case_value_offsets=reconstruction_info["case_value_offsets"],
                 case_axis_perm=reconstruction_info["case_axis_perm"],
                 case_axis_sign=reconstruction_info["case_axis_sign"],
                 case_axis_group=reconstruction_info["case_axis_group"],
@@ -2356,11 +2366,21 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
                 dim=table.dim,
             )
             dense_value = table.data[expected_entry_ids[full_entry_id]]
-            assert table_data_combined[0, arithmetic_row] == dense_value
+            assert (
+                table_data_combined[0, arithmetic_row] * arithmetic_sign
+                == dense_value
+            )
     else:
         assert reconstruction_info["kind"] == "signed-arithmetic-orbit"
         assert "lookup_keys" not in reconstruction_info
         assert "sign_lookup_keys" not in reconstruction_info
+        assert table_data_combined.shape[1] == reconstruction_info[
+            "compact_value_entry_count"
+        ]
+        assert table_data_combined.shape[1] <= reconstruction_info[
+            "dense_arithmetic_layout_entry_count"
+        ]
+        assert reconstruction_info["distinct_layout_entry_count"] == len(entry_ids)
         assert reconstruction_info["metadata_bytes"] < 2000
 
         dense_convention_mismatches = 0
@@ -2370,11 +2390,12 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
             pair_id = full_entry_id % table.n_pairs
             source_mode_id = pair_id // table.n_q_points
             target_point_id = pair_id % table.n_q_points
-            arithmetic_row, arithmetic_sign = _evaluate_arithmetic_orbit_entry(
+            arithmetic_row, arithmetic_sign = _evaluate_compact_arithmetic_orbit_entry(
                 case_id,
                 source_mode_id,
                 target_point_id,
                 case_orbit_ranks=reconstruction_info["case_orbit_ranks"],
+                case_value_offsets=reconstruction_info["case_value_offsets"],
                 case_axis_perm=reconstruction_info["case_axis_perm"],
                 case_axis_sign=reconstruction_info["case_axis_sign"],
                 case_axis_group=reconstruction_info["case_axis_group"],
@@ -2475,9 +2496,14 @@ def test_arithmetic_orbit_reconstruction_q3_payload_diagnostic_row():
 
     dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
     assert recon["kind"] == "scalar-arithmetic-orbit"
-    assert table_data_combined.nbytes > len(entry_ids) * np.dtype(table.dtype).itemsize
+    assert table_data_combined.shape[1] == len(entry_ids)
+    assert table_data_combined.nbytes == len(entry_ids) * np.dtype(table.dtype).itemsize
+    assert recon["compact_value_entry_count"] == 2510
+    assert recon["representative_entry_count"] == 2510
+    assert recon["dense_arithmetic_layout_entry_count"] == 7290
+    assert recon["unused_layout_entry_count"] == 0
     assert dense_metadata_bytes == 1215972
-    assert recon["metadata_bytes"] < 2000
+    assert recon["metadata_bytes"] == 1576
 
 
 def test_table_payload_serialization_excludes_nan_sentinels_for_reduced_tables():

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1317,6 +1317,144 @@ def _evaluate_scalar_arithmetic_entry(
     return entry_id
 
 
+def _rank_multiset(values, alphabet_size):
+    values = [int(value) for value in values]
+    alphabet_size = int(alphabet_size)
+    rank = 0
+    min_allowed = 0
+    nvalues = len(values)
+
+    for i, value in enumerate(values):
+        remaining = nvalues - i - 1
+        for candidate in range(min_allowed, value):
+            rank += math.comb(alphabet_size - candidate + remaining - 1, remaining)
+        min_allowed = value
+
+    return int(rank)
+
+
+def _compact_arithmetic_case_value_count(case_axis_sign, case_axis_group, q_order):
+    case_axis_sign = np.asarray(case_axis_sign, dtype=np.int8)
+    case_axis_group = np.asarray(case_axis_group, dtype=np.int64)
+    pair_count = int(q_order) * int(q_order)
+    folded_pair_count = (pair_count + 1) // 2
+    value_count = 1
+
+    for group_id in range(int(np.max(case_axis_group)) + 1):
+        axes = np.flatnonzero(case_axis_group == group_id)
+        if len(axes) == 0:
+            continue
+        alphabet_size = (
+            folded_pair_count
+            if np.any(case_axis_sign[axes] == 0)
+            else pair_count
+        )
+        value_count *= math.comb(int(alphabet_size) + len(axes) - 1, len(axes))
+
+    return int(value_count)
+
+
+def _evaluate_compact_arithmetic_orbit_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_value_offsets,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    axis_sign_power=None,
+    axis_direction_signs=None,
+    direction_sign_axis=-1,
+    q_order,
+    dim,
+):
+    if axis_sign_power is None:
+        axis_sign_power = np.zeros(int(dim), dtype=np.uint8)
+    if axis_direction_signs is None:
+        axis_direction_signs = np.zeros(int(dim), dtype=np.int8)
+
+    source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
+    target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
+
+    source_axes = []
+    target_axes = []
+    groups = []
+    axis_signs = []
+    entry_sign = 1
+    for out_axis in range(int(dim)):
+        in_axis = int(case_axis_perm[case_id, out_axis])
+        axis_sign = int(case_axis_sign[case_id, out_axis])
+        source_axis = source_axes_raw[in_axis]
+        target_axis = target_axes_raw[in_axis]
+        applied_axis_sign = 1
+
+        if axis_sign < 0:
+            source_axis = int(q_order) - 1 - source_axis
+            target_axis = int(q_order) - 1 - target_axis
+            applied_axis_sign = -1
+        elif axis_sign == 0:
+            flipped_source = int(q_order) - 1 - source_axis
+            flipped_target = int(q_order) - 1 - target_axis
+            if (flipped_source, flipped_target) < (source_axis, target_axis):
+                source_axis = flipped_source
+                target_axis = flipped_target
+                applied_axis_sign = -1
+
+        if int(axis_sign_power[in_axis]):
+            entry_sign *= applied_axis_sign
+        if int(direction_sign_axis) == out_axis:
+            entry_sign *= (
+                applied_axis_sign
+                * int(axis_direction_signs[in_axis])
+                * int(axis_direction_signs[out_axis])
+            )
+
+        source_axes.append(source_axis)
+        target_axes.append(target_axis)
+        groups.append(int(case_axis_group[case_id, out_axis]))
+        axis_signs.append(axis_sign)
+
+    pair_codes = [
+        int(source_axis) * int(q_order) + int(target_axis)
+        for source_axis, target_axis in zip(source_axes, target_axes, strict=True)
+    ]
+    pair_count = int(q_order) * int(q_order)
+    folded_pair_count = (pair_count + 1) // 2
+
+    group_ranks = []
+    group_value_counts = []
+    for group_id in range(max(groups) + 1):
+        axes = [axis for axis, group in enumerate(groups) if group == group_id]
+        if not axes:
+            group_ranks.append(0)
+            group_value_counts.append(1)
+            continue
+
+        alphabet_size = (
+            folded_pair_count
+            if any(axis_signs[axis] == 0 for axis in axes)
+            else pair_count
+        )
+        group_values = sorted(pair_codes[axis] for axis in axes)
+        group_ranks.append(_rank_multiset(group_values, alphabet_size))
+        group_value_counts.append(
+            math.comb(int(alphabet_size) + len(axes) - 1, len(axes))
+        )
+
+    compact_pair_rank = 0
+    for group_rank, group_value_count in zip(
+        group_ranks,
+        group_value_counts,
+        strict=True,
+    ):
+        compact_pair_rank = compact_pair_rank * int(group_value_count) + int(group_rank)
+
+    case_rank = int(case_orbit_ranks[case_id])
+    return int(case_value_offsets[case_rank]) + compact_pair_rank, int(entry_sign)
+
+
 def _entry_has_odd_reconstruction_stabilizer(
     case_id,
     source_mode_id,
@@ -1410,9 +1548,23 @@ def _build_arithmetic_orbit_reconstruction(
             int(canonical_case_ids[case_id])
         ]
 
-    n_arithmetic_entries = len(unique_canonical_case_ids) * table.n_pairs
-    layout_entry_ids = np.full(n_arithmetic_entries, -1, dtype=np.int64)
-    layout_entry_scales = np.ones(n_arithmetic_entries, dtype=np.int8)
+    case_value_counts = np.empty(len(unique_canonical_case_ids), dtype=np.int64)
+    for case_rank, canonical_case_id in enumerate(unique_canonical_case_ids):
+        case_value_counts[case_rank] = _compact_arithmetic_case_value_count(
+            case_axis_sign[canonical_case_id],
+            case_axis_group[canonical_case_id],
+            table.quad_order,
+        )
+
+    case_value_offsets_i64 = np.zeros(len(unique_canonical_case_ids) + 1, dtype=np.int64)
+    case_value_offsets_i64[1:] = np.cumsum(case_value_counts, dtype=np.int64)
+    if case_value_offsets_i64[-1] > np.iinfo(np.int32).max:
+        return None
+    case_value_offsets = case_value_offsets_i64.astype(np.int32)
+
+    n_compact_entries = int(case_value_offsets_i64[-1])
+    layout_entry_ids = np.full(n_compact_entries, -1, dtype=np.int64)
+    layout_entry_scales = np.ones(n_compact_entries, dtype=np.int8)
     sign_convention_conflict_count = 0
     full_entry_count = table.n_cases * table.n_pairs
     representative_entry_ids = np.asarray(
@@ -1426,11 +1578,12 @@ def _build_arithmetic_orbit_reconstruction(
         pair_id = full_entry_id % table.n_pairs
         source_mode_id = pair_id // table.n_q_points
         target_point_id = pair_id % table.n_q_points
-        arithmetic_row, arithmetic_sign = _evaluate_arithmetic_orbit_entry(
+        arithmetic_row, arithmetic_sign = _evaluate_compact_arithmetic_orbit_entry(
             case_id,
             source_mode_id,
             target_point_id,
             case_orbit_ranks=case_orbit_ranks,
+            case_value_offsets=case_value_offsets,
             case_axis_perm=case_axis_perm,
             case_axis_sign=case_axis_sign,
             case_axis_group=case_axis_group,
@@ -1466,6 +1619,7 @@ def _build_arithmetic_orbit_reconstruction(
         case_axis_sign,
         case_axis_group,
         axis_sign_power,
+        case_value_offsets,
     )
     if direction_sign_axis >= 0:
         metadata_arrays += (axis_direction_signs,)
@@ -1474,6 +1628,8 @@ def _build_arithmetic_orbit_reconstruction(
         if np.any(axis_sign_power) or direction_sign_axis >= 0
         else "scalar-arithmetic-orbit"
     )
+    used_layout_entry_ids = layout_entry_ids[layout_entry_ids >= 0]
+    distinct_layout_entry_count = int(len(np.unique(used_layout_entry_ids)))
 
     return {
         "kind": kind,
@@ -1481,6 +1637,7 @@ def _build_arithmetic_orbit_reconstruction(
         "case_axis_perm": case_axis_perm,
         "case_axis_sign": case_axis_sign,
         "case_axis_group": case_axis_group,
+        "case_value_offsets": case_value_offsets,
         "axis_sign_power": axis_sign_power,
         "axis_direction_signs": axis_direction_signs,
         "direction_sign_axis": int(direction_sign_axis),
@@ -1488,6 +1645,15 @@ def _build_arithmetic_orbit_reconstruction(
         "layout_entry_scales": layout_entry_scales,
         "n_case_orbits": int(len(unique_canonical_case_ids)),
         "metadata_bytes": int(sum(arr.nbytes for arr in metadata_arrays)),
+        "dense_arithmetic_layout_entry_count": int(
+            len(unique_canonical_case_ids) * table.n_pairs
+        ),
+        "compact_value_entry_count": int(n_compact_entries),
+        "representative_entry_count": int(len(representative_entry_ids)),
+        "distinct_layout_entry_count": distinct_layout_entry_count,
+        "duplicate_layout_entry_count": int(
+            len(used_layout_entry_ids) - distinct_layout_entry_count
+        ),
         "unused_layout_entry_count": int(np.count_nonzero(layout_entry_ids < 0)),
         "sign_convention_conflict_count": int(sign_convention_conflict_count),
     }
@@ -2702,7 +2868,17 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
         reconstruction_diagnostics = {
             "kind": reconstruction_kind,
+            "online_value_bytes": int(table_data_combined.nbytes),
             "representative_value_bytes": int(table_data_combined.nbytes),
+            "generated_reconstruction_metadata_bytes": int(
+                reconstruction_info["metadata_bytes"]
+            ),
+            "normalizer_auxiliary_bytes": int(
+                mode_nmlz_combined.nbytes + exterior_mode_nmlz_combined.nbytes
+            ),
+            "value_dense_block_equivalents": float(
+                table_data_combined.shape[1] / table0.n_pairs
+            ),
             "dense_entry_id_bytes": dense_id_bytes,
             "dense_entry_scale_bytes": dense_scale_bytes,
             "dense_metadata_bytes": int(dense_id_bytes + dense_scale_bytes),
@@ -2745,6 +2921,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                     ),
                     "arithmetic_case_axis_group_dev": cl.array.to_device(
                         queue, reconstruction_info["case_axis_group"]
+                    ),
+                    "arithmetic_case_value_offsets_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_value_offsets"]
                     ),
                     "arithmetic_axis_sign_power_dev": cl.array.to_device(
                         queue, reconstruction_info["axis_sign_power"]
@@ -2992,6 +3171,9 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 ],
                 "arithmetic_case_axis_group": payload[
                     "arithmetic_case_axis_group_dev"
+                ],
+                "arithmetic_case_value_offsets": payload[
+                    "arithmetic_case_value_offsets_dev"
                 ],
                 "arithmetic_axis_sign_power": payload[
                     "arithmetic_axis_sign_power_dev"
@@ -5652,6 +5834,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 "arithmetic_case_axis_group": payload[
                     "arithmetic_case_axis_group_dev"
                 ],
+                "arithmetic_case_value_offsets": payload[
+                    "arithmetic_case_value_offsets_dev"
+                ],
                 "arithmetic_axis_sign_power": payload[
                     "arithmetic_axis_sign_power_dev"
                 ],
@@ -5853,7 +6038,17 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
 
         reconstruction_diagnostics = {
             "kind": reconstruction_kind,
+            "online_value_bytes": int(table_data_combined.nbytes),
             "representative_value_bytes": int(table_data_combined.nbytes),
+            "generated_reconstruction_metadata_bytes": int(
+                reconstruction_info["metadata_bytes"]
+            ),
+            "normalizer_auxiliary_bytes": int(
+                mode_nmlz_combined.nbytes + exterior_mode_nmlz_combined.nbytes
+            ),
+            "value_dense_block_equivalents": float(
+                table_data_combined.shape[1] / table0.n_pairs
+            ),
             "dense_entry_id_bytes": dense_id_bytes,
             "dense_entry_scale_bytes": dense_scale_bytes,
             "dense_metadata_bytes": int(dense_id_bytes + dense_scale_bytes),
@@ -5896,6 +6091,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                     ),
                     "arithmetic_case_axis_group_dev": cl.array.to_device(
                         queue, reconstruction_info["case_axis_group"]
+                    ),
+                    "arithmetic_case_value_offsets_dev": cl.array.to_device(
+                        queue, reconstruction_info["case_value_offsets"]
                     ),
                     "arithmetic_axis_sign_power_dev": cl.array.to_device(
                         queue, reconstruction_info["axis_sign_power"]

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -2866,10 +2866,20 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
                 }
             )
 
+        representative_entry_count = int(
+            reconstruction_info.get(
+                "representative_entry_count",
+                table_data_combined.shape[1],
+            )
+        )
         reconstruction_diagnostics = {
             "kind": reconstruction_kind,
             "online_value_bytes": int(table_data_combined.nbytes),
-            "representative_value_bytes": int(table_data_combined.nbytes),
+            "representative_value_bytes": int(
+                representative_entry_count
+                * len(near_field_tables)
+                * np.dtype(eval_dtype).itemsize
+            ),
             "generated_reconstruction_metadata_bytes": int(
                 reconstruction_info["metadata_bytes"]
             ),
@@ -6036,10 +6046,20 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 }
             )
 
+        representative_entry_count = int(
+            reconstruction_info.get(
+                "representative_entry_count",
+                table_data_combined.shape[1],
+            )
+        )
         reconstruction_diagnostics = {
             "kind": reconstruction_kind,
             "online_value_bytes": int(table_data_combined.nbytes),
-            "representative_value_bytes": int(table_data_combined.nbytes),
+            "representative_value_bytes": int(
+                representative_entry_count
+                * len(near_field_tables)
+                * np.dtype(eval_dtype).itemsize
+            ),
             "generated_reconstruction_metadata_bytes": int(
                 reconstruction_info["metadata_bytes"]
             ),

--- a/volumential/list1.py
+++ b/volumential/list1.py
@@ -628,8 +628,6 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         <> tgt_raw_0 = target_point_id // quad_order
                         <> tgt_raw_1 = target_point_id % quad_order
                 """
-                encode_source = "src0_s * quad_order + src1_s"
-                encode_target = "tgt0_s * quad_order + tgt1_s"
                 sort_code = """
                         <> swap01 = (1 if group0 == group1
                             and (src1 < src0 or (src1 == src0 and tgt1 < tgt0))
@@ -648,12 +646,6 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         <> tgt_raw_1 = (target_point_id // quad_order) % quad_order
                         <> tgt_raw_2 = target_point_id % quad_order
                 """
-                encode_source = (
-                    "src0_s * (quad_order * quad_order) + src1_s * quad_order + src2_s"
-                )
-                encode_target = (
-                    "tgt0_s * (quad_order * quad_order) + tgt1_s * quad_order + tgt2_s"
-                )
                 sort_code = """
                         <> swap01_a = (1 if group0 == group1
                             and (src1 < src0 or (src1 == src0 and tgt1 < tgt0))
@@ -701,6 +693,110 @@ class NearFieldFromCSR(NearFieldEvalBase):
             else:
                 raise NotImplementedError("arithmetic ORBIT supports dim 2 or 3")
 
+            pair_code = ""
+            for iaxis in range(self.dim):
+                pair_code += f"""
+                        <> pair{iaxis} = src{iaxis}_s * quad_order + tgt{iaxis}_s
+                """
+            pair_code += """
+                        <> pair_count = quad_order * quad_order
+                        <> folded_pair_count = (pair_count + 1) // 2
+            """
+
+            def min_expr(values):
+                result = values[0]
+                for value in values[1:]:
+                    result = f"({result} if {result} <= {value} else {value})"
+                return result
+
+            def max_expr(values):
+                result = values[0]
+                for value in values[1:]:
+                    result = f"({result} if {result} >= {value} else {value})"
+                return result
+
+            rank_code = ""
+            for group_id in range(self.dim):
+                size_terms = [
+                    f"(1 if group{iaxis} == {group_id} else 0)"
+                    for iaxis in range(self.dim)
+                ]
+                zero_terms = [
+                    f"(1 if group{iaxis} == {group_id} "
+                    f"and axis_sign{iaxis} == 0 else 0)"
+                    for iaxis in range(self.dim)
+                ]
+                min_terms = [
+                    f"(pair{iaxis} if group{iaxis} == {group_id} else pair_count)"
+                    for iaxis in range(self.dim)
+                ]
+                max_terms = [
+                    f"(pair{iaxis} if group{iaxis} == {group_id} else -1)"
+                    for iaxis in range(self.dim)
+                ]
+                sum_terms = [
+                    f"(pair{iaxis} if group{iaxis} == {group_id} else 0)"
+                    for iaxis in range(self.dim)
+                ]
+                rank_code += f"""
+                        <> group{group_id}_size = {' + '.join(size_terms)}
+                        <> group{group_id}_zero_count = {' + '.join(zero_terms)}
+                        <> group{group_id}_alphabet = (folded_pair_count
+                            if group{group_id}_zero_count > 0 else pair_count)
+                        <> group{group_id}_lo = {min_expr(min_terms)}
+                        <> group{group_id}_hi = {max_expr(max_terms)}
+                        <> group{group_id}_sum = {' + '.join(sum_terms)}
+                        <> group{group_id}_mid = group{group_id}_sum \
+                                - group{group_id}_lo - group{group_id}_hi
+                        <> group{group_id}_value_count = (
+                            1 if group{group_id}_size == 0 else (
+                            group{group_id}_alphabet
+                            if group{group_id}_size == 1 else (
+                            (group{group_id}_alphabet
+                            * (group{group_id}_alphabet + 1)) // 2
+                            if group{group_id}_size == 2 else
+                            (group{group_id}_alphabet
+                            * (group{group_id}_alphabet + 1)
+                            * (group{group_id}_alphabet + 2)) // 6)))
+                        <> group{group_id}_rank = (
+                            0 if group{group_id}_size == 0 else (
+                            group{group_id}_lo
+                            if group{group_id}_size == 1 else (
+                            (group{group_id}_alphabet
+                            * (group{group_id}_alphabet + 1)) // 2
+                            - ((group{group_id}_alphabet - group{group_id}_lo)
+                            * (group{group_id}_alphabet - group{group_id}_lo + 1)
+                            ) // 2
+                            + (group{group_id}_hi - group{group_id}_lo)
+                            if group{group_id}_size == 2 else
+                            (group{group_id}_alphabet
+                            * (group{group_id}_alphabet + 1)
+                            * (group{group_id}_alphabet + 2)) // 6
+                            - ((group{group_id}_alphabet - group{group_id}_lo)
+                            * (group{group_id}_alphabet - group{group_id}_lo + 1)
+                            * (group{group_id}_alphabet - group{group_id}_lo + 2)
+                            ) // 6
+                            + ((group{group_id}_alphabet - group{group_id}_lo)
+                            * (group{group_id}_alphabet - group{group_id}_lo + 1)
+                            ) // 2
+                            - ((group{group_id}_alphabet - group{group_id}_mid)
+                            * (group{group_id}_alphabet - group{group_id}_mid + 1)
+                            ) // 2
+                            + (group{group_id}_hi - group{group_id}_mid))))
+                """
+
+            if self.dim == 2:
+                compact_pair_rank = (
+                    "group0_rank * group1_value_count + group1_rank"
+                )
+            elif self.dim == 3:
+                compact_pair_rank = (
+                    "(group0_rank * group1_value_count + group1_rank) "
+                    "* group2_value_count + group2_rank"
+                )
+            else:
+                raise NotImplementedError("arithmetic ORBIT supports dim 2 or 3")
+
             axis_code = ""
             for iaxis in range(self.dim):
                 perm_name = f"perm{iaxis}"
@@ -745,11 +841,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
                         {decode_code}
                         {axis_code}
                         {sort_code}
-                        <> canonical_source_id = {encode_source}
-                        <> canonical_target_id = {encode_target}
+                        {pair_code}
+                        {rank_code}
                         <> arithmetic_case_rank = arithmetic_case_orbit_ranks[case_id]
-                        <> entry_id = arithmetic_case_rank * (n_q_points * n_q_points) \
-                                + canonical_source_id * n_q_points + canonical_target_id
+                        <> compact_pair_rank = {compact_pair_rank}
+                        <> entry_id = arithmetic_case_value_offsets[
+                                arithmetic_case_rank] + compact_pair_rank
                         <> entry_sign = {" * ".join(
                             f"entry_sign_factor{iaxis}" for iaxis in range(self.dim)
                         )}
@@ -778,6 +875,12 @@ class NearFieldFromCSR(NearFieldEvalBase):
                     "arithmetic_case_axis_group",
                     np.uint8,
                     "n_cases, dim",
+                    is_input=True,
+                ),
+                loopy.GlobalArg(
+                    "arithmetic_case_value_offsets",
+                    np.int32,
+                    "n_arithmetic_case_orbits + 1",
                     is_input=True,
                 ),
                 loopy.GlobalArg(
@@ -1104,7 +1207,7 @@ class NearFieldFromCSR(NearFieldEvalBase):
     def get_cache_key(self):
         return (
             type(self).__name__,
-            "kernel-v13",
+            "kernel-v14",
             self.name,
             self.kname,
             "complex_kernel=" + str(self.integral_kernel.is_complex_valued),
@@ -1186,6 +1289,9 @@ class NearFieldFromCSR(NearFieldEvalBase):
                 ),
                 "arithmetic_case_axis_group": kwargs.pop(
                     "arithmetic_case_axis_group"
+                ),
+                "arithmetic_case_value_offsets": kwargs.pop(
+                    "arithmetic_case_value_offsets"
                 ),
                 "arithmetic_axis_sign_power": kwargs.pop(
                     "arithmetic_axis_sign_power"


### PR DESCRIPTION
## Summary

- Replace dense arithmetic ORBIT value blocks with compact canonical case-orbit value segments.
- Add `case_value_offsets` metadata and compute compact multiset ranks in the List 1 evaluator.
- Add reconstruction diagnostics for online value bytes, generated metadata bytes, normalizer bytes, and dense-block equivalents.
- Update near-field symmetry docs and regression coverage for compact value counts.

## Diagnostics

Scalar 3D Laplace synthetic descriptor diagnostics:

- `q=3`: compact rows `2510`, previous arithmetic rows `7290`, dense-block equivalents `3.44307` vs `10`, metadata `1576` bytes.
- `q=4`: compact rows `12936`, previous arithmetic rows `40960`, dense-block equivalents `3.1582` vs `10`, metadata `1576` bytes.

Directional derivative subgroups with coupled line-sign stabilizers may use a small compact envelope with duplicate representative values, still without a runtime hash table or full-entry maps.

## Testing

- `rtk uv run python -m compileall volumential/list1.py volumential/expansion_wrangler_fpnd.py test/test_nearfield_potential_table.py test/test_volume_fmm.py`
- `rtk uv run python -m pytest test/test_nearfield_potential_table.py --noconftest -k 'arithmetic_orbit_reconstruction_matches_dense_oracle or arithmetic_orbit_reconstruction_q3_payload_diagnostic_row or sorts_nonadjacent_group_axes or directional_source_derivative_without_direction_uses_generated_fallback'`
- `rtk uv run python -m pytest test/test_volume_fmm.py --noconftest -k 'source_kernel_derivation_preserves_source_derivatives or generated_orbit_sign_correction_codegen_uses_distinct_inames'`
- Remote `ipa`: `/tmp/opencode-volumential-venv/bin/python -m pytest test/test_nearfield_potential_table.py`
- Remote `ipa`: `/tmp/opencode-volumential-venv/bin/python -m pytest test/test_volume_fmm.py -k 'source_kernel_derivation_preserves_source_derivatives or generated_orbit_sign_correction_codegen_uses_distinct_inames or split_directional_source_derivative_tracks_direct or source_target_derivative_antisymmetry or target_derivative_list1_preserves_odd_x_symmetry or target_derivative_matches_scalar_fd_sign'`

Local full `test/test_nearfield_potential_table.py --noconftest` still requires an OpenCL platform and fails here with `PLATFORM_NOT_FOUND_KHR`; the same file passes on `ipa`.

Closes #110
