### PR TITLE
fix: store orbit-reduced tables compactly

### DIFF
--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -70,6 +70,21 @@ preparation validates generated representative IDs and generated signs against
 ``table_entry_ids`` / ``table_entry_scales`` before the generated descriptor is
 used.
 
+Compact table storage
+---------------------
+
+Symmetry-reduced Duffy builds store representative values directly in a compact
+``table.data`` array and keep the corresponding full table IDs in
+``reduced_entry_ids``. The dense ``n_cases*n_q_points**2`` value buffer is
+allocated only if a legacy caller explicitly requests dense indexing before the
+build or asks for explicit reconstruction afterward.
+
+``get_entry_data`` and ``reconstruct_full_table_from_symmetry`` are the dense
+compatibility adapters. Cache payloads use ``reduced_entry_ids`` plus compact
+``reduced_data`` for reduced tables, and online List 1 payload preparation reads
+representative values through the same full-entry-ID adapter before applying the
+compact arithmetic ORBIT layout.
+
 GPU scheduling
 --------------
 

--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -75,15 +75,16 @@ Compact table storage
 
 Symmetry-reduced Duffy builds store representative values directly in a compact
 ``table.data`` array and keep the corresponding full table IDs in
-``reduced_entry_ids``. The dense ``n_cases*n_q_points**2`` value buffer is
-allocated only if a legacy caller explicitly requests dense indexing before the
-build or asks for explicit reconstruction afterward.
+``reduced_entry_ids``. Reduced tables do not use a dense
+``n_cases*n_q_points**2`` value buffer as their storage representation.
 
 ``get_entry_data`` and ``reconstruct_full_table_from_symmetry`` are the dense
-compatibility adapters. Cache payloads use ``reduced_entry_ids`` plus compact
-``reduced_data`` for reduced tables, and online List 1 payload preparation reads
-representative values through the same full-entry-ID adapter before applying the
-compact arithmetic ORBIT layout.
+compatibility adapters. A caller that needs full dense values must request an
+explicit reconstructed array and keep it outside the table/cache storage path.
+Cache payloads always use ``reduced_entry_ids`` plus compact ``reduced_data`` for
+reduced tables, and online List 1 payload preparation reads representative
+values through the same full-entry-ID adapter before applying the compact
+arithmetic ORBIT layout.
 
 GPU scheduling
 --------------

--- a/test/test_duffy_batched_manufactured.py
+++ b/test/test_duffy_batched_manufactured.py
@@ -148,7 +148,7 @@ def test_duffy_batched_gpu_constant_kernel_matches_exact_volume(ctx_factory, dim
     exact = table.source_box_extent**dim
     for case_id in range(table.n_cases):
         entry_id = table.get_entry_index(0, 0, case_id)
-        rel_err = abs(table.data[entry_id] - exact) / max(1.0, abs(exact))
+        rel_err = abs(table.get_entry_data(entry_id) - exact) / max(1.0, abs(exact))
         assert rel_err < 1e-11
 
 
@@ -213,7 +213,7 @@ def test_duffy_batched_gpu_laplace_derivative_matches_finite_difference(
 
     # AxisTargetDerivative in this table setup carries the opposite sign
     # of d/d(target_x) applied to the box integral assembled above.
-    rel_err = abs(table_dx.data[entry_id] + fd_target_derivative) / max(
+    rel_err = abs(table_dx.get_entry_data(entry_id) + fd_target_derivative) / max(
         1.0, abs(fd_target_derivative)
     )
     assert rel_err < 1e-8
@@ -269,15 +269,15 @@ def test_duffy_batched_gpu_helmholtz_plane_wave_matches_exact_values(ctx_factory
     exact_potential = (np.sin(k * (1.0 - target_x)) - np.sin(-k * target_x)) / k
     exact_target_derivative = np.cos(k * target_x) - np.cos(k * (1.0 - target_x))
 
-    pot_rel_err = abs(table.data[entry_id] - exact_potential) / max(
+    pot_rel_err = abs(table.get_entry_data(entry_id) - exact_potential) / max(
         1.0, abs(exact_potential)
     )
     assert pot_rel_err < 1e-8
 
     # Same sign convention as in the Laplace derivative test above.
-    dpot_rel_err = abs(table_dx.data[entry_id] + exact_target_derivative) / max(
-        1.0, abs(exact_target_derivative)
-    )
+    dpot_rel_err = abs(
+        table_dx.get_entry_data(entry_id) + exact_target_derivative
+    ) / max(1.0, abs(exact_target_derivative))
     assert dpot_rel_err < 1e-8
 
 
@@ -341,7 +341,7 @@ def test_duffy_batched_gpu_yukawa_derivative_matches_finite_difference(
     )
 
     # Same sign convention as Laplace/Helmholtz target-derivative checks above.
-    rel_err = abs(table_dx.data[entry_id] + fd_target_derivative) / max(
+    rel_err = abs(table_dx.get_entry_data(entry_id) + fd_target_derivative) / max(
         1.0, abs(fd_target_derivative)
     )
     assert rel_err < 1e-7

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -1947,6 +1947,8 @@ def test_duffy_radial_batched_matches_scalar_reference_entries(
 def test_duffy_radial_batched_stores_compact_orbit_payload(monkeypatch):
     from sumpy.kernel import LaplaceKernel
 
+    from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map
+
     q_order = 3
     dim = 3
     table = npt.NearFieldInteractionTable(
@@ -1997,6 +1999,38 @@ def test_duffy_radial_batched_stores_compact_orbit_payload(monkeypatch):
         table.get_entry_data_for_full_indices(invariant_entry_ids),
         np.arange(1, len(invariant_entry_ids) + 1, dtype=table.dtype),
     )
+
+    table_data_combined, _, _, _, _, recon = _prepare_table_data_and_entry_map([table])
+    assert table.data.shape == (len(invariant_entry_ids),)
+    assert table_data_combined.shape[1] == len(invariant_entry_ids)
+    assert recon["kind"] == "scalar-arithmetic-orbit"
+
+
+def test_compact_reduced_storage_validates_entry_ids():
+    table = npt.NearFieldInteractionTable(
+        quad_order=2,
+        dim=2,
+        build_method="DuffyRadial",
+        kernel_func=npt.constant_one,
+        kernel_type="const",
+        sumpy_kernel=ConstantKernel(2),
+        progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(2, 2),
+    )
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        table.set_reduced_table_data(np.array([[0, 1]]), np.array([[1.0, 2.0]]))
+
+    with pytest.raises(ValueError, match="valid full table entry IDs"):
+        table.set_reduced_table_data(np.array([-1]), np.array([1.0]))
+
+    with pytest.raises(ValueError, match="valid full table entry IDs"):
+        table.set_reduced_table_data(
+            np.array([table.n_cases * table.n_pairs]), np.array([1.0])
+        )
+
+    with pytest.raises(ValueError, match="unique"):
+        table.set_reduced_table_data(np.array([1, 1]), np.array([1.0, 2.0]))
 
 
 def test_duffy_radial_batched_laplace_center_case_is_finite(ctx_factory):

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -1914,7 +1914,7 @@ def test_duffy_radial_batched_matches_scalar_reference_entries(
     )
 
     invariant_entry_ids = table._get_invariant_entry_info()["entry_ids"]
-    assert np.all(np.isfinite(table.data[invariant_entry_ids]))
+    assert table.has_entry_data_for_full_indices(invariant_entry_ids)
 
     sample_entry_ids = sorted(
         {
@@ -1940,8 +1940,63 @@ def test_duffy_radial_batched_matches_scalar_reference_entries(
             deg_theta=regular_quad_order,
             radial_quad_order=radial_quad_order,
         )
-        rel_err = abs(table.data[entry_id] - ref_val) / max(1.0, abs(ref_val))
+        rel_err = abs(table.get_entry_data(entry_id) - ref_val) / max(1.0, abs(ref_val))
         assert rel_err < rtol
+
+
+def test_duffy_radial_batched_stores_compact_orbit_payload(monkeypatch):
+    from sumpy.kernel import LaplaceKernel
+
+    q_order = 3
+    dim = 3
+    table = npt.NearFieldInteractionTable(
+        quad_order=q_order,
+        dim=dim,
+        build_method="DuffyRadial",
+        kernel_func=npt.constant_one,
+        kernel_type="inv_power",
+        sumpy_kernel=LaplaceKernel(dim),
+        derive_kernel_func=False,
+        progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(q_order, dim),
+    )
+    invariant_entry_ids = np.asarray(
+        table._get_invariant_entry_info()["entry_ids"], dtype=np.int64
+    )
+
+    def fake_batched_values(
+        queue,
+        invariant_info,
+        local_entry_indices,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
+        del queue, invariant_info, radial_rule, deg_theta, radial_quad_order, mp_dps
+        del kernel_kwargs
+        return np.asarray(local_entry_indices, dtype=table.dtype) + 1
+
+    monkeypatch.setattr(
+        table, "_batched_duffy_values_for_local_indices", fake_batched_values
+    )
+    table.build_table_via_duffy_radial_batched(
+        queue=None,
+        radial_rule="tanh-sinh-fast",
+        deg_theta=8,
+        radial_quad_order=31,
+    )
+
+    assert table.table_data_is_symmetry_reduced
+    assert table.data.shape == (len(invariant_entry_ids),)
+    assert table.data.nbytes == len(invariant_entry_ids) * np.dtype(table.dtype).itemsize
+    assert len(table.data) == 2510
+    np.testing.assert_array_equal(table.reduced_entry_ids, invariant_entry_ids)
+    np.testing.assert_allclose(
+        table.get_entry_data_for_full_indices(invariant_entry_ids),
+        np.arange(1, len(invariant_entry_ids) + 1, dtype=table.dtype),
+    )
 
 
 def test_duffy_radial_batched_laplace_center_case_is_finite(ctx_factory):
@@ -2000,20 +2055,19 @@ def test_duffy_radial_batched_keeps_symmetry_reduced_storage(ctx_factory):
     invariant_entry_ids = np.asarray(
         table._get_invariant_entry_info()["entry_ids"], dtype=np.int64
     )
-    non_invariant_ids = np.setdiff1d(
-        np.arange(len(table.data), dtype=np.int64),
-        invariant_entry_ids,
-    )
-
-    assert non_invariant_ids.size > 0
     assert table.table_data_is_symmetry_reduced
-    assert np.all(np.isfinite(table.data[invariant_entry_ids]))
-    assert np.all(np.isnan(table.data[non_invariant_ids]))
+    assert table.data.shape == (len(invariant_entry_ids),)
+    np.testing.assert_array_equal(table.reduced_entry_ids, invariant_entry_ids)
+    assert table.has_entry_data_for_full_indices(invariant_entry_ids)
 
-    # Reduced tables must still provide finite values through get_entry_index.
+    dense_reconstructed = table.reconstruct_full_table_from_symmetry()
+    assert dense_reconstructed.shape == (table.n_cases * table.n_pairs,)
+    assert np.all(np.isfinite(dense_reconstructed))
+
+    # Reduced tables must still provide finite values through the dense adapter.
     for case_id in range(table.n_cases):
         entry_id = table.get_entry_index(0, 0, case_id)
-        assert np.isfinite(table.data[entry_id])
+        assert np.isfinite(table.get_entry_data(entry_id))
 
 
 def test_prepare_table_data_and_entry_map_rejects_mixed_storage_modes():
@@ -2522,6 +2576,7 @@ def test_table_payload_serialization_excludes_nan_sentinels_for_reduced_tables()
         kernel_type="const",
         sumpy_kernel=ConstantKernel(2),
         progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(2, 2),
     )
 
     table.data[:] = np.array([1.0, np.nan, 2.0] + [np.nan] * (len(table.data) - 3))

--- a/test/test_table_manager.py
+++ b/test/test_table_manager.py
@@ -218,8 +218,8 @@ def laplace_const_source_same_box(table_2d_order1, queue, q_order, dim=2):
             pair_id = source_mode_index * n_q_points + target_point_index
             entry_id = case_same_box * n_pairs + pair_id
             # print(source_mode_index, target_point_index, pair_id, entry_id,
-            # nft.data[entry_id])
-            pot[target_point_index] += 1.0 * nft.data[entry_id]
+            # nft.get_entry_data(entry_id))
+            pot[target_point_index] += 1.0 * nft.get_entry_data(entry_id)
 
     return pot
 
@@ -239,8 +239,8 @@ def laplace_cons_source_neighbor_box(table_2d_order1, queue, q_order, case_id, d
             pair_id = source_mode_index * n_q_points + target_point_index
             entry_id = case_id * n_pairs + pair_id
             # print(source_mode_index, target_point_index, pair_id, entry_id,
-            # nft.data[entry_id])
-            pot[target_point_index] += 1.0 * nft.data[entry_id]
+            # nft.get_entry_data(entry_id))
+            pot[target_point_index] += 1.0 * nft.get_entry_data(entry_id)
 
     return pot
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -97,9 +97,13 @@ class HelmholtzSplitCacheAccounting:
 
 
 def _nearfield_table_payload_bytes(table):
-    data = np.asarray(table.data)
     if bool(getattr(table, "table_data_is_symmetry_reduced", False)):
+        if hasattr(table, "get_reduced_table_data"):
+            _, values = table.get_reduced_table_data()
+            return int(np.asarray(values).nbytes)
+        data = np.asarray(table.data)
         return int(np.count_nonzero(np.isfinite(data)) * data.dtype.itemsize)
+    data = np.asarray(table.data)
     return int(data.nbytes)
 
 
@@ -1752,7 +1756,10 @@ def _prepare_table_data_and_entry_map(table_levels):
         raise ValueError("table_levels cannot be empty")
 
     table0 = table_levels[0]
-    n_full_entries = len(table0.data)
+    if hasattr(table0, "n_cases") and hasattr(table0, "n_pairs"):
+        n_full_entries = int(table0.n_cases * table0.n_pairs)
+    else:
+        n_full_entries = len(table0.data)
 
     reduced_flags = [
         bool(getattr(table, "table_data_is_symmetry_reduced", False))
@@ -1775,15 +1782,29 @@ def _prepare_table_data_and_entry_map(table_levels):
             if len(kept_entry_ids) == 0:
                 raise RuntimeError("near-field table contains no canonical entries")
 
-            finite_mask = np.isfinite(table0.data)
-            if not np.all(finite_mask[kept_entry_ids]):
+            if hasattr(table0, "has_entry_data_for_full_indices"):
+                has_kept_entries = table0.has_entry_data_for_full_indices(
+                    kept_entry_ids
+                )
+            else:
+                finite_mask = np.isfinite(table0.data)
+                has_kept_entries = bool(np.all(finite_mask[kept_entry_ids]))
+            if not has_kept_entries:
                 raise RuntimeError(
                     "near-field table is missing finite values for canonical entries"
                 )
 
             for table in table_levels[1:]:
-                level_finite_mask = np.isfinite(table.data)
-                if not np.all(level_finite_mask[kept_entry_ids]):
+                if hasattr(table, "has_entry_data_for_full_indices"):
+                    level_has_kept_entries = table.has_entry_data_for_full_indices(
+                        kept_entry_ids
+                    )
+                else:
+                    level_finite_mask = np.isfinite(table.data)
+                    level_has_kept_entries = bool(
+                        np.all(level_finite_mask[kept_entry_ids])
+                    )
+                if not level_has_kept_entries:
                     raise RuntimeError(
                         "near-field levels disagree on canonical entry availability"
                     )
@@ -1796,15 +1817,25 @@ def _prepare_table_data_and_entry_map(table_levels):
                     orbit_info["canonical_scales"], dtype=table0.data.dtype
                 )
         else:
-            finite_mask = np.isfinite(table0.data)
+            if hasattr(table0, "get_reduced_table_data"):
+                kept_entry_ids, _ = table0.get_reduced_table_data()
+                kept_entry_ids = np.asarray(kept_entry_ids, dtype=np.int64)
+                finite_mask = None
+            else:
+                finite_mask = np.isfinite(table0.data)
+                kept_entry_ids = np.flatnonzero(finite_mask).astype(np.int64)
             for table in table_levels[1:]:
-                level_finite_mask = np.isfinite(table.data)
-                if not np.array_equal(level_finite_mask, finite_mask):
+                if hasattr(table, "get_reduced_table_data"):
+                    level_entry_ids, _ = table.get_reduced_table_data()
+                    level_matches = np.array_equal(level_entry_ids, kept_entry_ids)
+                else:
+                    level_finite_mask = np.isfinite(table.data)
+                    level_matches = np.array_equal(level_finite_mask, finite_mask)
+                if not level_matches:
                     raise RuntimeError(
                         "near-field levels disagree on symmetry-reduced entry ids"
                     )
 
-            kept_entry_ids = np.flatnonzero(finite_mask).astype(np.int64)
             if len(kept_entry_ids) == 0:
                 raise RuntimeError("near-field table contains no finite entries")
 
@@ -1863,10 +1894,26 @@ def _prepare_table_data_and_entry_map(table_levels):
     used_layout_scales = layout_entry_scales[used_layout_mask]
     if len(used_layout_entry_ids) == 0:
         raise RuntimeError("near-field reconstruction layout contains no entries")
-    if not np.all(np.isfinite(table0.data[used_layout_entry_ids])):
+    if hasattr(table0, "has_entry_data_for_full_indices"):
+        layout_entries_available = table0.has_entry_data_for_full_indices(
+            used_layout_entry_ids
+        )
+    else:
+        layout_entries_available = bool(
+            np.all(np.isfinite(table0.data[used_layout_entry_ids]))
+        )
+    if not layout_entries_available:
         raise RuntimeError("near-field reconstruction layout references missing data")
     for table in table_levels[1:]:
-        if not np.all(np.isfinite(table.data[used_layout_entry_ids])):
+        if hasattr(table, "has_entry_data_for_full_indices"):
+            level_layout_entries_available = table.has_entry_data_for_full_indices(
+                used_layout_entry_ids
+            )
+        else:
+            level_layout_entries_available = bool(
+                np.all(np.isfinite(table.data[used_layout_entry_ids]))
+            )
+        if not level_layout_entries_available:
             raise RuntimeError(
                 "near-field levels disagree on reconstruction layout availability"
             )
@@ -1885,9 +1932,11 @@ def _prepare_table_data_and_entry_map(table_levels):
     )
 
     for lev, table in enumerate(table_levels):
-        table_data_combined[lev, used_layout_mask] = (
-            table.data[used_layout_entry_ids] * used_layout_scales
-        )
+        if hasattr(table, "get_entry_data_for_full_indices"):
+            layout_values = table.get_entry_data_for_full_indices(used_layout_entry_ids)
+        else:
+            layout_values = table.data[used_layout_entry_ids]
+        table_data_combined[lev, used_layout_mask] = layout_values * used_layout_scales
         mode_nmlz_combined[lev, :] = table.mode_normalizers
         exterior_mode_nmlz_combined[lev, :] = table.kernel_exterior_normalizers
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1768,8 +1768,16 @@ def _prepare_table_data_and_entry_map(table_levels):
     if any(flag != reduced_flags[0] for flag in reduced_flags[1:]):
         raise RuntimeError("mixed full/reduced near-field table storage across levels")
 
+    if hasattr(table0, "dtype"):
+        table_value_dtype = np.dtype(table0.dtype)
+    elif hasattr(table0, "get_reduced_table_data"):
+        _, table0_values = table0.get_reduced_table_data()
+        table_value_dtype = np.asarray(table0_values).dtype
+    else:
+        table_value_dtype = np.asarray(table0.data).dtype
+
     if reduced_flags[0]:
-        table_entry_scales = np.ones(n_full_entries, dtype=table0.data.dtype)
+        table_entry_scales = np.ones(n_full_entries, dtype=table_value_dtype)
         orbit_info = None
         if hasattr(table0, "_get_orbit_canonical_info"):
             orbit_info = table0._get_orbit_canonical_info()
@@ -1814,7 +1822,7 @@ def _prepare_table_data_and_entry_map(table_levels):
             table_entry_ids = compact_ids[canonical_entry_ids]
             if "canonical_scales" in orbit_info:
                 table_entry_scales = np.asarray(
-                    orbit_info["canonical_scales"], dtype=table0.data.dtype
+                    orbit_info["canonical_scales"], dtype=table_value_dtype
                 )
         else:
             if hasattr(table0, "get_reduced_table_data"):
@@ -1850,7 +1858,7 @@ def _prepare_table_data_and_entry_map(table_levels):
         kept_entry_ids = np.arange(n_full_entries, dtype=np.int64)
         table_entry_ids = np.full(n_full_entries, -1, dtype=np.int32)
         table_entry_ids[kept_entry_ids] = np.arange(len(kept_entry_ids), dtype=np.int32)
-        table_entry_scales = np.ones(n_full_entries, dtype=table0.data.dtype)
+        table_entry_scales = np.ones(n_full_entries, dtype=table_value_dtype)
 
     reconstruction_info = _build_scalar_arithmetic_orbit_reconstruction(
         table0,
@@ -1883,9 +1891,9 @@ def _prepare_table_data_and_entry_map(table_levels):
     layout_entry_ids = np.asarray(layout_entry_ids, dtype=np.int64)
     layout_entry_scales = reconstruction_info.get("layout_entry_scales")
     if layout_entry_scales is None:
-        layout_entry_scales = np.ones(len(layout_entry_ids), dtype=table0.data.dtype)
+        layout_entry_scales = np.ones(len(layout_entry_ids), dtype=table_value_dtype)
     else:
-        layout_entry_scales = np.asarray(layout_entry_scales, dtype=table0.data.dtype)
+        layout_entry_scales = np.asarray(layout_entry_scales, dtype=table_value_dtype)
     if layout_entry_scales.shape != layout_entry_ids.shape:
         raise RuntimeError("reconstruction layout entry scales have incompatible shape")
 
@@ -1920,7 +1928,7 @@ def _prepare_table_data_and_entry_map(table_levels):
 
     table_data_combined = np.zeros(
         (len(table_levels), len(layout_entry_ids)),
-        dtype=table0.data.dtype,
+        dtype=table_value_dtype,
     )
     mode_nmlz_combined = np.zeros(
         (len(table_levels), len(table0.mode_normalizers)),

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -621,6 +621,7 @@ class NearFieldInteractionTable:
     def data(self, value):
         self._data = np.asarray(value, dtype=self.dtype)
         self.reduced_entry_ids = None
+        self.table_data_is_symmetry_reduced = False
 
     def _get_geom_dtype(self):
         value_dtype = np.dtype(self.dtype)
@@ -971,7 +972,9 @@ class NearFieldInteractionTable:
     def get_entry_data(self, entry_id):
         """Return the requested entry value from full or orbit-reduced storage."""
         if not self.table_data_is_symmetry_reduced:
-            return self.data[entry_id]
+            if self._data is None:
+                raise RuntimeError("table data has not been built")
+            return self._data[entry_id]
 
         orbit_info = self._get_orbit_canonical_info()
         canonical_entry_ids = orbit_info["canonical_entry_ids"]
@@ -991,37 +994,57 @@ class NearFieldInteractionTable:
         """Return full entry IDs stored by the current reduced representation."""
 
         if not self.table_data_is_symmetry_reduced:
-            return np.arange(len(self.data), dtype=np.int64)
+            if self._data is None:
+                return np.empty(0, dtype=np.int64)
+            return np.arange(len(self._data), dtype=np.int64)
 
         if self.reduced_entry_ids is not None:
             return np.asarray(self.reduced_entry_ids, dtype=np.int64)
 
         if self._uses_dense_entry_indexing():
-            return np.flatnonzero(np.isfinite(self.data)).astype(np.int64)
+            return np.flatnonzero(np.isfinite(self._data)).astype(np.int64)
 
         raise RuntimeError("compact reduced table is missing reduced_entry_ids")
 
     def get_reduced_table_data(self):
         """Return ``(full_entry_ids, values)`` for stored table entries."""
 
+        if not self.table_data_is_symmetry_reduced:
+            if self._data is None:
+                return (
+                    np.empty(0, dtype=np.int64),
+                    np.empty(0, dtype=self.dtype),
+                )
+            data = np.asarray(self._data)
+            return np.arange(len(data), dtype=np.int64), data
+
         entry_ids = self.get_reduced_entry_ids()
-        if self.table_data_is_symmetry_reduced and not self._uses_dense_entry_indexing():
-            return entry_ids, np.asarray(self.data)
-        return entry_ids, np.asarray(self.data)[entry_ids]
+        if not self._uses_dense_entry_indexing():
+            return entry_ids, np.asarray(self._data)
+        return entry_ids, np.asarray(self._data)[entry_ids]
 
     def set_reduced_table_data(self, entry_ids, values):
         """Store reduced table values compactly by full entry ID."""
 
-        entry_ids = np.ascontiguousarray(entry_ids, dtype=np.int64)
-        values = np.ascontiguousarray(values, dtype=self.dtype)
+        entry_ids = np.asarray(entry_ids, dtype=np.int64)
+        values = np.asarray(values, dtype=self.dtype)
+        if entry_ids.ndim != 1 or values.ndim != 1:
+            raise ValueError("entry_ids and values must be one-dimensional")
         if entry_ids.shape != values.shape:
             raise ValueError(
                 "entry_ids and values must have the same shape for reduced storage"
             )
         if entry_ids.size and not np.all(entry_ids[:-1] <= entry_ids[1:]):
             order = np.argsort(entry_ids, kind="stable")
-            entry_ids = np.ascontiguousarray(entry_ids[order], dtype=np.int64)
-            values = np.ascontiguousarray(values[order], dtype=self.dtype)
+            entry_ids = entry_ids[order]
+            values = values[order]
+        if entry_ids.size:
+            if entry_ids[0] < 0 or entry_ids[-1] >= self._full_entry_count():
+                raise ValueError("entry_ids must be valid full table entry IDs")
+            if np.any(entry_ids[:-1] == entry_ids[1:]):
+                raise ValueError("entry_ids must be unique")
+        entry_ids = np.ascontiguousarray(entry_ids, dtype=np.int64)
+        values = np.ascontiguousarray(values, dtype=self.dtype)
         self.reduced_entry_ids = entry_ids
         self._data = values
         self.table_data_is_symmetry_reduced = True
@@ -1031,10 +1054,12 @@ class NearFieldInteractionTable:
 
         entry_ids = np.asarray(entry_ids, dtype=np.int64)
         if not self.table_data_is_symmetry_reduced:
-            return np.asarray(self.data)[entry_ids]
+            if self._data is None:
+                raise RuntimeError("table data has not been built")
+            return np.asarray(self._data)[entry_ids]
 
         if self._uses_dense_entry_indexing():
-            values = np.asarray(self.data)[entry_ids]
+            values = np.asarray(self._data)[entry_ids]
             if not np.all(np.isfinite(values)):
                 raise RuntimeError(
                     "missing canonical table entry data for orbit-reduced table"
@@ -1049,14 +1074,16 @@ class NearFieldInteractionTable:
             raise RuntimeError(
                 "missing canonical table entry data for compact orbit-reduced table"
             )
-        return np.asarray(self.data)[positions]
+        return np.asarray(self._data)[positions]
 
     def has_entry_data_for_full_indices(self, entry_ids):
         """Return whether all full entry IDs have stored finite values."""
 
         entry_ids = np.asarray(entry_ids, dtype=np.int64)
         if not self.table_data_is_symmetry_reduced:
-            return bool(np.all(np.isfinite(np.asarray(self.data)[entry_ids])))
+            if self._data is None:
+                return False
+            return bool(np.all(np.isfinite(np.asarray(self._data)[entry_ids])))
         try:
             values = self.get_entry_data_for_full_indices(entry_ids)
         except RuntimeError:

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -588,8 +588,8 @@ class NearFieldInteractionTable:
         else:
             raise NotImplementedError
 
-        self.data = np.empty(self.n_pairs * self.n_cases, dtype=self.dtype)
-        self.data.fill(np.nan)
+        self.reduced_entry_ids = None
+        self._data = None
 
         if self.dim == 2:
             total_evals = self.n_q_points + _DUFFY_PROGRESS_STAGES
@@ -609,6 +609,18 @@ class NearFieldInteractionTable:
         self.table_data_is_symmetry_reduced = False
 
     # }}} End constructor
+
+    @property
+    def data(self):
+        if self._data is None:
+            self._data = np.empty(self._full_entry_count(), dtype=self.dtype)
+            self._data.fill(np.nan)
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data = np.asarray(value, dtype=self.dtype)
+        self.reduced_entry_ids = None
 
     def _get_geom_dtype(self):
         value_dtype = np.dtype(self.dtype)
@@ -958,22 +970,98 @@ class NearFieldInteractionTable:
 
     def get_entry_data(self, entry_id):
         """Return the requested entry value from full or orbit-reduced storage."""
-        value = self.data[entry_id]
-        if np.isfinite(value):
-            return value
+        if not self.table_data_is_symmetry_reduced:
+            return self.data[entry_id]
 
         orbit_info = self._get_orbit_canonical_info()
         canonical_entry_ids = orbit_info["canonical_entry_ids"]
         canonical_scales = orbit_info["canonical_scales"]
         canonical_entry_id = int(canonical_entry_ids[entry_id])
-        canonical_value = self.data[canonical_entry_id]
-
-        if not np.isfinite(canonical_value):
-            raise RuntimeError(
-                "missing canonical table entry data for orbit-reduced table"
-            )
+        canonical_value = self.get_entry_data_for_full_indices([canonical_entry_id])[0]
 
         return self.dtype(canonical_scales[entry_id]) * canonical_value
+
+    def _full_entry_count(self):
+        return int(self.n_cases * self.n_pairs)
+
+    def _uses_dense_entry_indexing(self):
+        return self._data is not None and int(len(self._data)) == self._full_entry_count()
+
+    def get_reduced_entry_ids(self):
+        """Return full entry IDs stored by the current reduced representation."""
+
+        if not self.table_data_is_symmetry_reduced:
+            return np.arange(len(self.data), dtype=np.int64)
+
+        if self.reduced_entry_ids is not None:
+            return np.asarray(self.reduced_entry_ids, dtype=np.int64)
+
+        if self._uses_dense_entry_indexing():
+            return np.flatnonzero(np.isfinite(self.data)).astype(np.int64)
+
+        raise RuntimeError("compact reduced table is missing reduced_entry_ids")
+
+    def get_reduced_table_data(self):
+        """Return ``(full_entry_ids, values)`` for stored table entries."""
+
+        entry_ids = self.get_reduced_entry_ids()
+        if self.table_data_is_symmetry_reduced and not self._uses_dense_entry_indexing():
+            return entry_ids, np.asarray(self.data)
+        return entry_ids, np.asarray(self.data)[entry_ids]
+
+    def set_reduced_table_data(self, entry_ids, values):
+        """Store reduced table values compactly by full entry ID."""
+
+        entry_ids = np.ascontiguousarray(entry_ids, dtype=np.int64)
+        values = np.ascontiguousarray(values, dtype=self.dtype)
+        if entry_ids.shape != values.shape:
+            raise ValueError(
+                "entry_ids and values must have the same shape for reduced storage"
+            )
+        if entry_ids.size and not np.all(entry_ids[:-1] <= entry_ids[1:]):
+            order = np.argsort(entry_ids, kind="stable")
+            entry_ids = np.ascontiguousarray(entry_ids[order], dtype=np.int64)
+            values = np.ascontiguousarray(values[order], dtype=self.dtype)
+        self.reduced_entry_ids = entry_ids
+        self._data = values
+        self.table_data_is_symmetry_reduced = True
+
+    def get_entry_data_for_full_indices(self, entry_ids):
+        """Return stored values addressed by full table entry IDs."""
+
+        entry_ids = np.asarray(entry_ids, dtype=np.int64)
+        if not self.table_data_is_symmetry_reduced:
+            return np.asarray(self.data)[entry_ids]
+
+        if self._uses_dense_entry_indexing():
+            values = np.asarray(self.data)[entry_ids]
+            if not np.all(np.isfinite(values)):
+                raise RuntimeError(
+                    "missing canonical table entry data for orbit-reduced table"
+                )
+            return values
+
+        stored_entry_ids = self.get_reduced_entry_ids()
+        positions = np.searchsorted(stored_entry_ids, entry_ids)
+        if np.any(positions >= len(stored_entry_ids)) or not np.array_equal(
+            stored_entry_ids[positions], entry_ids
+        ):
+            raise RuntimeError(
+                "missing canonical table entry data for compact orbit-reduced table"
+            )
+        return np.asarray(self.data)[positions]
+
+    def has_entry_data_for_full_indices(self, entry_ids):
+        """Return whether all full entry IDs have stored finite values."""
+
+        entry_ids = np.asarray(entry_ids, dtype=np.int64)
+        if not self.table_data_is_symmetry_reduced:
+            return bool(np.all(np.isfinite(np.asarray(self.data)[entry_ids])))
+        try:
+            values = self.get_entry_data_for_full_indices(entry_ids)
+        except RuntimeError:
+            return False
+        return bool(np.all(np.isfinite(values)))
 
     def compute_table_entry_duffy_radial(
         self,
@@ -1069,20 +1157,32 @@ class NearFieldInteractionTable:
     def reconstruct_full_table_from_symmetry(self, canonical_data=None):
         """Reconstruct full table data from orbit-canonical representatives."""
         orbit_info = self._get_orbit_canonical_info()
+        entry_ids = np.asarray(orbit_info["entry_ids"], dtype=np.int64)
         canonical_entry_ids = np.asarray(orbit_info["canonical_entry_ids"], dtype=np.int64)
         canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=self.dtype)
 
         if canonical_data is None:
-            canonical_data = self.data
-        canonical_data = np.asarray(canonical_data, dtype=self.dtype)
+            representative_values = self.get_entry_data_for_full_indices(entry_ids)
+        else:
+            canonical_data = np.asarray(canonical_data, dtype=self.dtype)
+            if canonical_data.shape[0] == self._full_entry_count():
+                representative_values = canonical_data[entry_ids]
+            elif canonical_data.shape[0] == len(entry_ids):
+                representative_values = canonical_data
+            else:
+                raise ValueError(
+                    "canonical_data must be indexed by full table entry ids or "
+                    "by orbit representatives; "
+                    f"expected length {self._full_entry_count()} or "
+                    f"{len(entry_ids)}, got {canonical_data.shape[0]}"
+                )
 
-        if canonical_data.shape[0] != len(self.data):
-            raise ValueError(
-                "canonical_data must be indexed by full table entry ids; "
-                f"expected length {len(self.data)}, got {canonical_data.shape[0]}"
-            )
-
-        return canonical_scales * canonical_data[canonical_entry_ids]
+        representative_positions = np.searchsorted(entry_ids, canonical_entry_ids)
+        if np.any(representative_positions >= len(entry_ids)) or not np.array_equal(
+            entry_ids[representative_positions], canonical_entry_ids
+        ):
+            raise RuntimeError("orbit canonical IDs are not present in representatives")
+        return canonical_scales * representative_values[representative_positions]
 
     def get_symmetry_reduction_diagnostics(self, reference_data=None):
         """Return paper-facing symmetry-reduction counts and reconstruction errors."""
@@ -1115,17 +1215,21 @@ class NearFieldInteractionTable:
         max_reconstruction_error = None
         l2_reconstruction_error = None
         if reference_data is None:
-            reference_data = self.data
-        reference_data = np.asarray(reference_data, dtype=self.dtype)
-        if reference_data.shape[0] != full_entry_count:
-            raise ValueError(
-                "reference_data must be indexed by full table entry ids; "
-                f"expected length {full_entry_count}, got {reference_data.shape[0]}"
-            )
+            if self.table_data_is_symmetry_reduced:
+                reference_data = None
+            else:
+                reference_data = self.data
+        if reference_data is not None:
+            reference_data = np.asarray(reference_data, dtype=self.dtype)
+            if reference_data.shape[0] != full_entry_count:
+                raise ValueError(
+                    "reference_data must be indexed by full table entry ids; "
+                    f"expected length {full_entry_count}, got {reference_data.shape[0]}"
+                )
 
-        if np.all(np.isfinite(reference_data[canonical_entry_ids])) and np.all(
-            np.isfinite(reference_data)
-        ):
+        if reference_data is not None and np.all(
+            np.isfinite(reference_data[canonical_entry_ids])
+        ) and np.all(np.isfinite(reference_data)):
             reconstructed = self.reconstruct_full_table_from_symmetry(reference_data)
             errors = np.abs(reconstructed - reference_data)
             max_reconstruction_error = float(np.max(errors))
@@ -2484,8 +2588,7 @@ class NearFieldInteractionTable:
         self._progress_step()
 
         t_scatter_start = time.perf_counter()
-        for ientry, entry_id in enumerate(invariant_entry_ids):
-            self.data[entry_id] = table_host[ientry]
+        self.set_reduced_table_data(invariant_entry_ids, table_host)
         t_scatter_end = time.perf_counter()
         self._progress_step()
 
@@ -2496,7 +2599,6 @@ class NearFieldInteractionTable:
         t_symmetry_fill_end = t_symmetry_fill_start
         self._progress_step()
 
-        self.table_data_is_symmetry_reduced = bool(np.any(np.isnan(self.data)))
         self.is_built = True
 
         t_total_end = time.perf_counter()
@@ -2717,7 +2819,8 @@ class NearFieldInteractionTable:
             self._progress_step()
 
             t_quadrature_start = time.perf_counter()
-            for entry_id in invariant_entry_ids:
+            table_values = np.empty(len(invariant_entry_ids), dtype=self.dtype)
+            for ientry, entry_id in enumerate(invariant_entry_ids):
                 _, entry_val = self.compute_table_entry_duffy_radial(
                     entry_id,
                     radial_rule=radial_rule,
@@ -2725,7 +2828,7 @@ class NearFieldInteractionTable:
                     radial_quad_order=radial_quad_order,
                     mp_dps=mp_dps,
                 )
-                self.data[entry_id] = entry_val
+                table_values[ientry] = entry_val
             t_quadrature_end = time.perf_counter()
             self._progress_step()
 
@@ -2736,7 +2839,7 @@ class NearFieldInteractionTable:
             t_symmetry_fill_end = t_symmetry_fill_start
             self._progress_step()
 
-            self.table_data_is_symmetry_reduced = bool(np.isnan(self.data).any())
+            self.set_reduced_table_data(invariant_entry_ids, table_values)
             self.is_built = True
 
             t_total_end = time.perf_counter()

--- a/volumential/table_manager.py
+++ b/volumential/table_manager.py
@@ -180,7 +180,6 @@ def _deserialize_array(blob):
 
 
 def _serialize_table_payload(table):
-    data = np.array(table.data)
     table_data_is_symmetry_reduced = bool(
         getattr(table, "table_data_is_symmetry_reduced", False)
     )
@@ -204,10 +203,18 @@ def _serialize_table_payload(table):
         )
 
     if table_data_is_symmetry_reduced:
-        reduced_entry_ids = np.flatnonzero(np.isfinite(data)).astype(np.int64)
+        if hasattr(table, "get_reduced_table_data"):
+            reduced_entry_ids, reduced_data = table.get_reduced_table_data()
+            reduced_entry_ids = np.asarray(reduced_entry_ids, dtype=np.int64)
+            reduced_data = np.asarray(reduced_data)
+        else:
+            data = np.array(table.data)
+            reduced_entry_ids = np.flatnonzero(np.isfinite(data)).astype(np.int64)
+            reduced_data = data[reduced_entry_ids]
         payload["reduced_entry_ids"] = reduced_entry_ids
-        payload["reduced_data"] = data[reduced_entry_ids]
+        payload["reduced_data"] = reduced_data
     else:
+        data = np.array(table.data)
         payload["data"] = data
 
     with BytesIO() as f:
@@ -1592,8 +1599,13 @@ class NearFieldInteractionTableManager:
             if "data" in payload:
                 table.data[:] = payload["data"]
             elif "reduced_entry_ids" in payload and "reduced_data" in payload:
-                table.data[:] = np.nan
-                table.data[payload["reduced_entry_ids"]] = payload["reduced_data"]
+                if hasattr(table, "set_reduced_table_data"):
+                    table.set_reduced_table_data(
+                        payload["reduced_entry_ids"], payload["reduced_data"]
+                    )
+                else:
+                    table.data[:] = np.nan
+                    table.data[payload["reduced_entry_ids"]] = payload["reduced_data"]
             else:
                 raise KeyError("payload is missing table data arrays")
 


### PR DESCRIPTION
## Summary

- Store symmetry-reduced Duffy table values as compact representative arrays with `reduced_entry_ids` instead of dense `NaN`-filled `table.data` buffers.
- Keep dense compatibility through `get_entry_data()`, `get_entry_data_for_full_indices()`, and explicit `reconstruct_full_table_from_symmetry()` arrays.
- Ensure SQLite cache payloads always serialize reduced tables as compact `reduced_entry_ids` plus `reduced_data`, never dense reconstructed values.
- Update online List 1 payload preparation to consume compact reduced values through full-entry-ID adapters.
- Document the compact storage contract.

Closes #112.

## Validation

- Local: `rtk uv run python -m compileall volumential/nearfield_potential_table.py volumential/expansion_wrangler_fpnd.py volumential/table_manager.py test/test_nearfield_potential_table.py test/test_table_manager_sqlite_migration.py`
- Local: `rtk uv run python -m pytest test/test_nearfield_potential_table.py test/test_table_manager_sqlite_migration.py --noconftest -k 'duffy_radial_batched_stores_compact_orbit_payload or prepare_table_data_and_entry_map or arithmetic_orbit_reconstruction or table_payload_serialization or symmetry_reduced_payload_roundtrip_uses_sparse_arrays'`
- Remote `ipa`: `PYTHONPATH=. python -m pytest test/test_nearfield_potential_table.py -k "duffy_radial_batched_matches_scalar_reference_entries or duffy_radial_batched_keeps_symmetry_reduced_storage or duffy_radial_batched_stores_compact_orbit_payload or arithmetic_orbit_reconstruction_q3_payload_diagnostic_row"`
- Remote `ipa`: `PYTHONPATH=. python -m pytest test/test_volume_fmm.py -k "source_kernel_derivation_preserves_source_derivatives or target_derivative_matches_scalar_fd_sign or source_target_derivative_antisymmetry or target_derivative_list1_preserves_odd_x_symmetry"`
- Remote `ipa`: `PYTHONPATH=. python -m pytest test/test_table_manager.py -k "test_lcssb_1 or test_direct_quad"`
- Remote `ipa`: `PYTHONPATH=. python -m pytest test/test_duffy_batched_manufactured.py -k "batched_gpu"`
- Remote `ipa` diagnostic: scalar 3D Laplace build keeps `_data is None` before build, then stores `q=3: 2510` values / `20080` bytes and `q=4: 12936` values / `103488` bytes.
