### PR TITLE
fix: speed scalar orbit discovery

### DIFF
--- a/doc/source/nearfield_symmetry.rst
+++ b/doc/source/nearfield_symmetry.rst
@@ -10,6 +10,10 @@ Orbit canonicalization
 - A full table entry is mapped to a canonical representative entry.
 - The dense compatibility path uses an index map from full entry IDs to
   canonical entry IDs.
+- Scalar full-symmetry table construction enumerates compact arithmetic ORBIT
+  representatives directly. It does not build the dense canonical entry map or
+  run signed union-find unless a diagnostic/reconstruction API explicitly asks
+  for dense canonical metadata.
 - Scalar arithmetic ORBIT reconstruction avoids sending that full-entry map to
   the GPU for full-symmetry scalar tables. The List 1 evaluator canonicalizes
   ``(source_mode, target_point, case)`` with packed per-case descriptors and

--- a/test/test_nearfield_potential_table.py
+++ b/test/test_nearfield_potential_table.py
@@ -355,12 +355,12 @@ def test_invariant_entry_info_matches_orbit_decode_metadata(dim, q_order):
 
     invariant_info = table._get_invariant_entry_info()
     invariant_entry_ids = np.array(invariant_info["entry_ids"], dtype=np.int64)
-    canonical_entry_ids = np.array(
-        invariant_info["canonical_entry_ids"], dtype=np.int64
-    )
-
-    assert canonical_entry_ids.shape == (len(table.data),)
-    assert np.array_equal(np.unique(canonical_entry_ids), invariant_entry_ids)
+    if "canonical_entry_ids" in invariant_info:
+        canonical_entry_ids = np.array(
+            invariant_info["canonical_entry_ids"], dtype=np.int64
+        )
+        assert canonical_entry_ids.shape == (len(table.data),)
+        assert np.array_equal(np.unique(canonical_entry_ids), invariant_entry_ids)
 
     decoded_case_ids = np.array(
         [
@@ -395,6 +395,70 @@ def test_invariant_entry_info_matches_orbit_decode_metadata(dim, q_order):
     assert np.array_equal(invariant_info["mode_axes"], expected_mode_axes)
 
 
+def test_scalar_arithmetic_invariant_info_skips_signed_union_find(monkeypatch):
+    from sumpy.kernel import LaplaceKernel
+
+    from volumential.expansion_wrangler_fpnd import _prepare_table_data_and_entry_map
+
+    table = npt.NearFieldInteractionTable(
+        quad_order=3,
+        dim=3,
+        build_method="DuffyRadial",
+        kernel_func=npt.constant_one,
+        kernel_type="inv_power",
+        sumpy_kernel=LaplaceKernel(3),
+        derive_kernel_func=False,
+        progress_bar=False,
+        precomputed_q_points=_precomputed_legendre_q_points(3, 3),
+    )
+
+    def fail_union(cls, parent, rank, rel, ia, ib, sign_b_over_a):
+        raise AssertionError("scalar arithmetic invariant info used signed union-find")
+
+    monkeypatch.setattr(
+        npt.NearFieldInteractionTable,
+        "_signed_uf_union",
+        classmethod(fail_union),
+    )
+
+    invariant_info = table._get_invariant_entry_info()
+    invariant_entry_ids = np.asarray(invariant_info["entry_ids"], dtype=np.int64)
+    assert invariant_info["kind"] == "scalar-arithmetic-orbit"
+    assert "canonical_entry_ids" not in invariant_info
+    assert len(invariant_entry_ids) == 2510
+
+    def fake_batched_values(
+        queue,
+        invariant_info,
+        local_entry_indices,
+        radial_rule,
+        deg_theta,
+        radial_quad_order,
+        mp_dps,
+        kernel_kwargs=None,
+    ):
+        del queue, invariant_info, radial_rule, deg_theta, radial_quad_order, mp_dps
+        del kernel_kwargs
+        return np.asarray(local_entry_indices, dtype=table.dtype) + 1
+
+    monkeypatch.setattr(
+        table, "_batched_duffy_values_for_local_indices", fake_batched_values
+    )
+    table.build_table_via_duffy_radial_batched(
+        queue=None,
+        radial_rule="tanh-sinh-fast",
+        deg_theta=8,
+        radial_quad_order=31,
+    )
+
+    _, _, _, table_entry_ids, table_entry_scales, recon = (
+        _prepare_table_data_and_entry_map([table])
+    )
+    assert recon["kind"] == "scalar-arithmetic-orbit"
+    assert table_entry_ids.size == 0
+    assert table_entry_scales.size == 0
+
+
 def test_orbit_canonicalization_preserves_value_lookup_equivalence():
     from volumential.table_manager import ConstantKernel
 
@@ -408,7 +472,7 @@ def test_orbit_canonicalization_preserves_value_lookup_equivalence():
         progress_bar=False,
     )
 
-    info = table._get_invariant_entry_info()
+    info = table._get_orbit_canonical_info()
     canonical_entry_ids = np.array(info["canonical_entry_ids"], dtype=np.int64)
 
     rng = np.random.default_rng(seed=11)
@@ -457,7 +521,7 @@ def test_orbit_canonicalization_tracks_sign_for_target_derivative_kernel():
         progress_bar=False,
     )
 
-    info = table._get_invariant_entry_info()
+    info = table._get_orbit_canonical_info()
     scales = np.asarray(info["canonical_scales"])
 
     # Derivative kernels are odd under some reflections; orbit metadata must
@@ -480,7 +544,7 @@ def test_orbit_canonicalization_tracks_sign_for_directional_source_derivative():
         progress_bar=False,
     )
 
-    info = table._get_invariant_entry_info()
+    info = table._get_orbit_canonical_info()
     scales = np.asarray(info["canonical_scales"])
     assert np.any(scales < 0)
 
@@ -1992,9 +2056,11 @@ def test_duffy_radial_batched_stores_compact_orbit_payload(monkeypatch):
 
     assert table.table_data_is_symmetry_reduced
     assert table.data.shape == (len(invariant_entry_ids),)
-    assert table.data.nbytes == len(invariant_entry_ids) * np.dtype(table.dtype).itemsize
+    assert table.data.nbytes == (
+        len(invariant_entry_ids) * np.dtype(table.dtype).itemsize
+    )
     assert len(table.data) == 2510
-    np.testing.assert_array_equal(table.reduced_entry_ids, invariant_entry_ids)
+    np.testing.assert_array_equal(table.reduced_entry_ids, np.sort(invariant_entry_ids))
     np.testing.assert_allclose(
         table.get_entry_data_for_full_indices(invariant_entry_ids),
         np.arange(1, len(invariant_entry_ids) + 1, dtype=table.dtype),
@@ -2091,7 +2157,7 @@ def test_duffy_radial_batched_keeps_symmetry_reduced_storage(ctx_factory):
     )
     assert table.table_data_is_symmetry_reduced
     assert table.data.shape == (len(invariant_entry_ids),)
-    np.testing.assert_array_equal(table.reduced_entry_ids, invariant_entry_ids)
+    np.testing.assert_array_equal(table.reduced_entry_ids, np.sort(invariant_entry_ids))
     assert table.has_entry_data_for_full_indices(invariant_entry_ids)
 
     dense_reconstructed = table.reconstruct_full_table_from_symmetry()
@@ -2412,10 +2478,20 @@ def test_arithmetic_orbit_reconstruction_matches_dense_oracle(kernel_case):
         reconstruction_info,
     ) = _prepare_table_data_and_entry_map([table])
 
-    expected_entry_ids = entry_ids[table_entry_ids]
-    expected_scales = np.real(table_entry_scales).astype(np.int8)
-
-    dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
+    if table_entry_ids.size == 0:
+        canonical_entry_ids = np.asarray(
+            orbit_info["canonical_entry_ids"], dtype=np.int64
+        )
+        canonical_scales = np.asarray(orbit_info["canonical_scales"], dtype=table.dtype)
+        expected_entry_ids = canonical_entry_ids
+        expected_scales = np.real(canonical_scales).astype(np.int8)
+        dense_metadata_bytes = (
+            canonical_entry_ids.astype(np.int32).nbytes + canonical_scales.nbytes
+        )
+    else:
+        expected_entry_ids = entry_ids[table_entry_ids]
+        expected_scales = np.real(table_entry_scales).astype(np.int8)
+        dense_metadata_bytes = table_entry_ids.nbytes + table_entry_scales.nbytes
     assert reconstruction_info["metadata_bytes"] < dense_metadata_bytes
 
     if reconstruction_info["kind"] == "scalar-arithmetic-orbit":
@@ -2590,7 +2666,7 @@ def test_arithmetic_orbit_reconstruction_q3_payload_diagnostic_row():
     assert recon["representative_entry_count"] == 2510
     assert recon["dense_arithmetic_layout_entry_count"] == 7290
     assert recon["unused_layout_entry_count"] == 0
-    assert dense_metadata_bytes == 1215972
+    assert dense_metadata_bytes == 0
     assert recon["metadata_bytes"] == 1576
 
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -56,28 +56,13 @@ from volumential.expansion_wrangler_interface import (
 )
 from volumential.lagrange import barycentric_lagrange_weights
 from volumential.nearfield_potential_table import NearFieldInteractionTable
+from volumential.orbit_arithmetic import _decode_mode_axes, _encode_mode_axes
 
 
 logger = logging.getLogger(__name__)
 
 
 _ORBIT_RECONSTRUCTION_HASH_MULTIPLIER = 33
-
-
-def _encode_mode_axes(axes, q_order):
-    result = 0
-    for axis_value in axes:
-        result = result * int(q_order) + int(axis_value)
-    return int(result)
-
-
-def _decode_mode_axes(mode_id, q_order, dim):
-    axes = [0] * int(dim)
-    residual = int(mode_id)
-    for iaxis in range(int(dim) - 1, -1, -1):
-        axes[iaxis] = residual % int(q_order)
-        residual //= int(q_order)
-    return axes
 
 
 @dataclass(frozen=True)
@@ -1675,6 +1660,67 @@ def _build_scalar_arithmetic_orbit_reconstruction(
     )
 
 
+def _build_fast_scalar_arithmetic_orbit_reconstruction(table):
+    if not hasattr(table, "_get_scalar_arithmetic_invariant_entry_info"):
+        return None
+    if not bool(getattr(table, "table_data_is_symmetry_reduced", False)):
+        return None
+
+    invariant_info = table._get_scalar_arithmetic_invariant_entry_info()
+    if invariant_info is None:
+        return None
+
+    metadata = invariant_info.get("arithmetic_metadata")
+    if metadata is None:
+        return None
+
+    layout_entry_ids = np.asarray(invariant_info["entry_ids"], dtype=np.int64)
+    layout_entry_scales = np.ones(len(layout_entry_ids), dtype=np.int8)
+    axis_direction_signs = np.asarray(
+        metadata["axis_direction_signs"], dtype=np.int8
+    )
+    direction_sign_axis = int(metadata["direction_sign_axis"])
+
+    metadata_arrays = (
+        np.asarray(metadata["case_orbit_ranks"], dtype=np.uint16),
+        np.asarray(metadata["case_axis_perm"], dtype=np.uint8),
+        np.asarray(metadata["case_axis_sign"], dtype=np.int8),
+        np.asarray(metadata["case_axis_group"], dtype=np.uint8),
+        np.asarray(metadata["axis_sign_power"], dtype=np.uint8),
+        np.asarray(metadata["case_value_offsets"], dtype=np.int32),
+    )
+    if direction_sign_axis >= 0:
+        metadata_arrays += (axis_direction_signs,)
+
+    distinct_layout_entry_count = int(len(np.unique(layout_entry_ids)))
+    return {
+        "kind": "scalar-arithmetic-orbit",
+        "case_orbit_ranks": metadata_arrays[0],
+        "case_axis_perm": metadata_arrays[1],
+        "case_axis_sign": metadata_arrays[2],
+        "case_axis_group": metadata_arrays[3],
+        "case_value_offsets": metadata_arrays[5],
+        "axis_sign_power": metadata_arrays[4],
+        "axis_direction_signs": axis_direction_signs,
+        "direction_sign_axis": direction_sign_axis,
+        "layout_entry_ids": layout_entry_ids,
+        "layout_entry_scales": layout_entry_scales,
+        "n_case_orbits": int(len(metadata["canonical_case_ids"])),
+        "metadata_bytes": int(sum(arr.nbytes for arr in metadata_arrays)),
+        "dense_arithmetic_layout_entry_count": int(
+            len(metadata["canonical_case_ids"]) * table.n_pairs
+        ),
+        "compact_value_entry_count": int(len(layout_entry_ids)),
+        "representative_entry_count": int(len(layout_entry_ids)),
+        "distinct_layout_entry_count": distinct_layout_entry_count,
+        "duplicate_layout_entry_count": int(
+            len(layout_entry_ids) - distinct_layout_entry_count
+        ),
+        "unused_layout_entry_count": 0,
+        "sign_convention_conflict_count": 0,
+    }
+
+
 def _build_generated_orbit_reconstruction(table, table_entry_ids, table_entry_scales):
     if not hasattr(table, "_get_orbit_reconstruction_maps"):
         return None
@@ -1775,6 +1821,63 @@ def _prepare_table_data_and_entry_map(table_levels):
         table_value_dtype = np.asarray(table0_values).dtype
     else:
         table_value_dtype = np.asarray(table0.data).dtype
+
+    if reduced_flags[0]:
+        fast_reconstruction_info = _build_fast_scalar_arithmetic_orbit_reconstruction(
+            table0
+        )
+        if fast_reconstruction_info is not None:
+            layout_entry_ids = np.asarray(
+                fast_reconstruction_info["layout_entry_ids"], dtype=np.int64
+            )
+            layout_entry_scales = np.asarray(
+                fast_reconstruction_info["layout_entry_scales"], dtype=table_value_dtype
+            )
+            if len(layout_entry_ids) == 0:
+                raise RuntimeError(
+                    "near-field reconstruction layout contains no entries"
+                )
+
+            if not table0.has_entry_data_for_full_indices(layout_entry_ids):
+                raise RuntimeError(
+                    "near-field reconstruction layout references missing data"
+                )
+            for table in table_levels[1:]:
+                if not table.has_entry_data_for_full_indices(layout_entry_ids):
+                    raise RuntimeError(
+                        "near-field levels disagree on reconstruction layout "
+                        "availability"
+                    )
+
+            table_data_combined = np.zeros(
+                (len(table_levels), len(layout_entry_ids)),
+                dtype=table_value_dtype,
+            )
+            mode_nmlz_combined = np.zeros(
+                (len(table_levels), len(table0.mode_normalizers)),
+                dtype=table0.mode_normalizers.dtype,
+            )
+            exterior_mode_nmlz_combined = np.zeros(
+                (len(table_levels), len(table0.kernel_exterior_normalizers)),
+                dtype=table0.kernel_exterior_normalizers.dtype,
+            )
+
+            for lev, table in enumerate(table_levels):
+                layout_values = table.get_entry_data_for_full_indices(layout_entry_ids)
+                table_data_combined[lev, :] = layout_values * layout_entry_scales
+                mode_nmlz_combined[lev, :] = table.mode_normalizers
+                exterior_mode_nmlz_combined[lev, :] = (
+                    table.kernel_exterior_normalizers
+                )
+
+            return (
+                table_data_combined,
+                mode_nmlz_combined,
+                exterior_mode_nmlz_combined,
+                np.empty(0, dtype=np.int32),
+                np.empty(0, dtype=table_value_dtype),
+                fast_reconstruction_info,
+            )
 
     if reduced_flags[0]:
         table_entry_scales = np.ones(n_full_entries, dtype=table_value_dtype)

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -1692,6 +1692,7 @@ def _build_fast_scalar_arithmetic_orbit_reconstruction(table):
     if direction_sign_axis >= 0:
         metadata_arrays += (axis_direction_signs,)
 
+    n_case_orbits = int(metadata_arrays[5].size - 1)
     distinct_layout_entry_count = int(len(np.unique(layout_entry_ids)))
     return {
         "kind": "scalar-arithmetic-orbit",
@@ -1705,10 +1706,10 @@ def _build_fast_scalar_arithmetic_orbit_reconstruction(table):
         "direction_sign_axis": direction_sign_axis,
         "layout_entry_ids": layout_entry_ids,
         "layout_entry_scales": layout_entry_scales,
-        "n_case_orbits": int(len(metadata["canonical_case_ids"])),
+        "n_case_orbits": n_case_orbits,
         "metadata_bytes": int(sum(arr.nbytes for arr in metadata_arrays)),
         "dense_arithmetic_layout_entry_count": int(
-            len(metadata["canonical_case_ids"]) * table.n_pairs
+            n_case_orbits * table.n_pairs
         ),
         "compact_value_entry_count": int(len(layout_entry_ids)),
         "representative_entry_count": int(len(layout_entry_ids)),

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -38,6 +38,10 @@ from volumential.lagrange import (
     barycentric_lagrange_weights,
     evaluate_lagrange_basis_1d,
 )
+from volumential.orbit_arithmetic import (
+    build_arithmetic_case_metadata,
+    enumerate_scalar_arithmetic_representatives,
+)
 
 
 logger = logging.getLogger("NearFieldInteractionTable")
@@ -45,6 +49,7 @@ logger = logging.getLogger("NearFieldInteractionTable")
 
 _TABLE_BUILD_METHOD = "DuffyRadial"
 _DUFFY_PROGRESS_STAGES = 3
+_ARITHMETIC_INVARIANT_CACHE = {}
 _ORBIT_CANONICAL_CACHE = {}
 
 
@@ -1178,7 +1183,74 @@ class NearFieldInteractionTable:
         )
         return xi, barycentric_lagrange_weights(xi).astype(geom_dtype)
 
+    def _orbit_cache_key(self):
+        return (
+            int(self.dim),
+            int(self.quad_order),
+            tuple(tuple(int(c) for c in vec) for vec in self.interaction_case_vecs),
+            repr(self.integral_knl),
+            None
+            if self.symmetry_source_direction is None
+            else tuple(
+                np.asarray(self.symmetry_source_direction, dtype=float).tolist()
+            ),
+        )
+
+    def _get_scalar_arithmetic_invariant_entry_info(self):
+        if self.dim not in (2, 3):
+            return None
+        if _kernel_requires_identity_online_symmetry_maps(self.integral_knl):
+            return None
+
+        cache_key = ("scalar-arithmetic", self._orbit_cache_key())
+        cached = self._orbit_info_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        cached = _ARITHMETIC_INVARIANT_CACHE.get(cache_key)
+        if cached is not None:
+            self._orbit_info_cache[cache_key] = cached
+            return cached
+
+        metadata = build_arithmetic_case_metadata(self)
+        if metadata is None:
+            return None
+
+        entry_ids = enumerate_scalar_arithmetic_representatives(self, metadata)
+        n_q_points_i64 = np.int64(self.n_q_points)
+        n_pairs_i64 = np.int64(self.n_pairs)
+
+        source_mode_indices = (
+            (entry_ids % n_pairs_i64) // n_q_points_i64
+        ).astype(np.int32)
+        target_point_indices = (entry_ids % n_q_points_i64).astype(np.int32)
+        case_indices = (entry_ids // n_pairs_i64).astype(np.int32)
+        mode_axes = np.ascontiguousarray(
+            self._get_all_mode_axes()[source_mode_indices], dtype=np.int32
+        )
+
+        metadata_payload = {
+            key: value
+            for key, value in metadata.items()
+            if key not in {"case_value_offsets_i64"}
+        }
+        result = {
+            "kind": "scalar-arithmetic-orbit",
+            "entry_ids": np.ascontiguousarray(entry_ids, dtype=np.int64),
+            "case_indices": case_indices,
+            "target_point_indices": target_point_indices,
+            "source_mode_indices": source_mode_indices,
+            "mode_axes": mode_axes,
+            "arithmetic_metadata": metadata_payload,
+        }
+        _ARITHMETIC_INVARIANT_CACHE[cache_key] = result
+        self._orbit_info_cache[cache_key] = result
+        return result
+
     def _get_invariant_entry_info(self):
+        fast_info = self._get_scalar_arithmetic_invariant_entry_info()
+        if fast_info is not None:
+            return fast_info
         return self._get_orbit_canonical_info()
 
     def reconstruct_full_table_from_symmetry(self, canonical_data=None):
@@ -1573,17 +1645,7 @@ class NearFieldInteractionTable:
     def _get_orbit_canonical_info(self):
         """Canonicalize (source_mode, target_mode, case) under full group action."""
 
-        cache_key = (
-            int(self.dim),
-            int(self.quad_order),
-            tuple(tuple(int(c) for c in vec) for vec in self.interaction_case_vecs),
-            repr(self.integral_knl),
-            None
-            if self.symmetry_source_direction is None
-            else tuple(
-                np.asarray(self.symmetry_source_direction, dtype=float).tolist()
-            ),
-        )
+        cache_key = self._orbit_cache_key()
         cached = self._orbit_info_cache.get(cache_key)
         if cached is not None:
             return cached

--- a/volumential/orbit_arithmetic.py
+++ b/volumential/orbit_arithmetic.py
@@ -1,0 +1,785 @@
+__copyright__ = "Copyright (C) 2017 - 2018 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import itertools
+import math
+
+import numpy as np
+
+
+def _encode_mode_axes(axes, q_order):
+    result = 0
+    for axis_value in axes:
+        result = result * int(q_order) + int(axis_value)
+    return int(result)
+
+
+def _decode_mode_axes(mode_id, q_order, dim):
+    axes = [0] * int(dim)
+    residual = int(mode_id)
+    for iaxis in range(int(dim) - 1, -1, -1):
+        axes[iaxis] = residual % int(q_order)
+        residual //= int(q_order)
+    return axes
+
+
+def _case_arithmetic_axis_descriptors(
+    case_vec,
+    *,
+    axis_groups=None,
+    direction_signs=None,
+):
+    case_vec = [int(val) for val in case_vec]
+    dim = len(case_vec)
+    if axis_groups is None:
+        axis_group_specs = (tuple(range(dim)),)
+    else:
+        axis_group_specs = axis_groups
+    axis_group_specs = tuple(
+        tuple(int(axis) for axis in group) for group in axis_group_specs
+    )
+    direction_signs = np.zeros(dim, dtype=np.int8) if direction_signs is None else (
+        np.asarray(direction_signs, dtype=np.int8)
+    )
+
+    axis_perm = np.empty(dim, dtype=np.uint8)
+    axis_signs = np.empty(dim, dtype=np.int8)
+    axis_group_ids = np.empty(dim, dtype=np.uint8)
+    next_runtime_group = 0
+
+    def sign_to_negative(value):
+        value = int(value)
+        if value > 0:
+            return -1
+        if value < 0:
+            return 1
+        return 0
+
+    active_group_specs = []
+    inactive_group_specs = []
+    for group in axis_group_specs:
+        out_axes = tuple(sorted(group))
+        active_direction_axes = [
+            axis for axis in out_axes if direction_signs[axis] != 0
+        ]
+        if active_direction_axes:
+            if len(active_direction_axes) != len(out_axes):
+                raise ValueError("directional arithmetic groups cannot mix active axes")
+            active_group_specs.append(out_axes)
+        else:
+            inactive_group_specs.append(out_axes)
+
+    if active_group_specs:
+        from itertools import permutations, product
+
+        sorted_active_axes = tuple(
+            sorted(axis for group in active_group_specs for axis in group)
+        )
+        permutation_options = [
+            tuple(permutations(group)) for group in active_group_specs
+        ]
+        best_key = None
+        best_axis_perm = None
+        best_axis_sign = None
+
+        for line_sign in (-1, 1):
+            for permuted_groups in product(*permutation_options):
+                candidate_axis_perm = {}
+                candidate_axis_sign = {}
+                for out_axes, permuted_axes in zip(
+                    active_group_specs,
+                    permuted_groups,
+                    strict=True,
+                ):
+                    for out_axis, in_axis in zip(out_axes, permuted_axes, strict=True):
+                        sign = (
+                            int(line_sign)
+                            * int(direction_signs[out_axis])
+                            * int(direction_signs[in_axis])
+                        )
+                        candidate_axis_perm[out_axis] = int(in_axis)
+                        candidate_axis_sign[out_axis] = int(sign)
+
+                key = (
+                    tuple(
+                        int(case_vec[candidate_axis_perm[axis]])
+                        * int(candidate_axis_sign[axis])
+                        for axis in sorted_active_axes
+                    ),
+                    tuple(candidate_axis_perm[axis] for axis in sorted_active_axes),
+                )
+                if best_key is None or key < best_key:
+                    best_key = key
+                    best_axis_perm = candidate_axis_perm
+                    best_axis_sign = candidate_axis_sign
+
+        for out_axis in sorted_active_axes:
+            axis_perm[out_axis] = best_axis_perm[out_axis]
+            axis_signs[out_axis] = best_axis_sign[out_axis]
+            # Avoid over-canonicalizing directional stabilizers: source/target
+            # flips in active directional groups are tied by one line sign.
+            axis_group_ids[out_axis] = next_runtime_group
+            next_runtime_group += 1
+
+    for out_axes in inactive_group_specs:
+        free_order = sorted(
+            out_axes,
+            key=lambda iaxis: (-abs(case_vec[iaxis]), iaxis),
+        )
+
+        last_abs = None
+        current_runtime_group = next_runtime_group - 1
+        for out_axis, in_axis in zip(out_axes, free_order, strict=True):
+            value = int(case_vec[in_axis])
+            abs_value = abs(value)
+            if last_abs != abs_value:
+                current_runtime_group += 1
+                last_abs = abs_value
+            axis_perm[out_axis] = in_axis
+            axis_signs[out_axis] = sign_to_negative(value)
+            axis_group_ids[out_axis] = current_runtime_group
+
+        next_runtime_group = current_runtime_group + 1
+
+    return axis_perm, axis_signs, axis_group_ids
+
+
+def _canonical_case_from_axis_descriptors(case_vec, axis_perm, axis_sign):
+    canonical = []
+    for in_axis, sign in zip(axis_perm, axis_sign, strict=True):
+        value = int(case_vec[int(in_axis)])
+        sign = int(sign)
+        canonical.append(0 if sign == 0 else value * sign)
+
+    return canonical
+
+
+def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
+    dim = int(table.dim)
+    fixed_axes = set()
+    axis_sign_power = np.zeros(dim, dtype=np.uint8)
+    direction_signs = np.zeros(dim, dtype=np.int8)
+    direction_sign_axis = -1
+    direction_abs_group = np.full(dim, -1, dtype=np.int16)
+    direction_sign_power = np.uint8(0)
+    direction_vector = None
+    has_directional_source = False
+
+    kernel = table.integral_knl
+    while kernel is not None:
+        cls_name = kernel.__class__.__name__
+        if cls_name in {"AxisTargetDerivative", "AxisSourceDerivative"}:
+            axis = int(kernel.axis)
+            if axis < 0 or axis >= dim:
+                return None
+            fixed_axes.add(axis)
+            axis_sign_power[axis] ^= np.uint8(1)
+            kernel = kernel.inner_kernel
+            continue
+
+        if cls_name == "DirectionalSourceDerivative":
+            source_direction = getattr(kernel, "_volumential_source_direction", None)
+            if source_direction is None:
+                return None
+            source_direction = np.asarray(source_direction, dtype=np.float64).ravel()
+            if source_direction.shape != (dim,):
+                return None
+            direction_sign_power ^= np.uint8(1)
+            if has_directional_source:
+                if not np.allclose(source_direction, direction_vector):
+                    return None
+                kernel = kernel.inner_kernel
+                continue
+
+            axis_candidates = np.flatnonzero(
+                np.abs(source_direction) > 100 * np.finfo(np.float64).eps
+            )
+            if len(axis_candidates) == 0:
+                return None
+
+            active_axes = tuple(sorted(int(axis) for axis in axis_candidates))
+            active_axis_list = list(active_axes)
+            direction_signs[active_axis_list] = np.sign(
+                source_direction[active_axis_list]
+            ).astype(np.int8)
+            active_abs_groups = []
+            for axis in active_axes:
+                abs_value = abs(float(source_direction[axis]))
+                for group_id, (group_abs, group_axes) in enumerate(active_abs_groups):
+                    if np.isclose(abs_value, group_abs):
+                        group_axes.append(axis)
+                        direction_abs_group[axis] = group_id
+                        break
+                else:
+                    direction_abs_group[axis] = len(active_abs_groups)
+                    active_abs_groups.append((abs_value, [axis]))
+            direction_sign_axis = int(active_axes[0])
+            direction_vector = source_direction.copy()
+            has_directional_source = True
+            kernel = kernel.inner_kernel
+            continue
+
+        if hasattr(kernel, "inner_kernel"):
+            kernel = kernel.inner_kernel
+            continue
+
+        break
+
+    from itertools import permutations, product
+
+    if not has_directional_source:
+        free_axes = tuple(axis for axis in range(dim) if axis not in fixed_axes)
+        axis_groups = tuple((axis,) for axis in sorted(fixed_axes))
+        if free_axes:
+            axis_groups += (free_axes,)
+    else:
+        axis_groups = []
+        for group_id in sorted(
+            int(group_id)
+            for group_id in np.unique(direction_abs_group)
+            if group_id >= 0
+        ):
+            group_axes = tuple(
+                axis
+                for axis in range(dim)
+                if int(direction_abs_group[axis]) == group_id
+            )
+            fixed_group_axes = tuple(axis for axis in group_axes if axis in fixed_axes)
+            free_group_axes = tuple(
+                axis for axis in group_axes if axis not in fixed_axes
+            )
+            axis_groups.extend((axis,) for axis in fixed_group_axes)
+            if free_group_axes:
+                axis_groups.append(free_group_axes)
+
+        inactive_fixed_axes = tuple(
+            axis
+            for axis in sorted(fixed_axes)
+            if int(direction_abs_group[axis]) < 0
+        )
+        inactive_free_axes = tuple(
+            axis
+            for axis in range(dim)
+            if int(direction_abs_group[axis]) < 0 and axis not in fixed_axes
+        )
+        axis_groups.extend((axis,) for axis in inactive_fixed_axes)
+        if inactive_free_axes:
+            axis_groups.append(inactive_free_axes)
+        axis_groups = tuple(axis_groups)
+
+    expected = set()
+    for sign_tuple in product([-1, 1], repeat=dim):
+        for perm_tuple in permutations(range(dim)):
+            line_sign = 1
+            if not has_directional_source:
+                if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
+                    continue
+            else:
+                line_sign = None
+                valid = True
+                if any(int(perm_tuple[axis]) != axis for axis in fixed_axes):
+                    continue
+                for out_axis in range(dim):
+                    in_axis = int(perm_tuple[out_axis])
+                    out_dir = int(direction_signs[out_axis])
+                    in_dir = int(direction_signs[in_axis])
+                    if out_dir == 0 or in_dir == 0:
+                        if out_dir != in_dir:
+                            valid = False
+                            break
+                        continue
+                    if int(direction_abs_group[out_axis]) != int(
+                        direction_abs_group[in_axis]
+                    ):
+                        valid = False
+                        break
+
+                    candidate = int(sign_tuple[in_axis]) * out_dir * in_dir
+                    if line_sign is None:
+                        line_sign = candidate
+                    elif candidate != line_sign:
+                        valid = False
+                        break
+
+                if not valid or line_sign is None:
+                    continue
+
+            transform_sign = 1
+            for axis in range(dim):
+                if int(axis_sign_power[axis]):
+                    transform_sign *= int(sign_tuple[axis])
+            if int(direction_sign_power):
+                transform_sign *= int(line_sign)
+
+            expected.add(
+                (
+                    tuple(int(val) for val in sign_tuple),
+                    tuple(int(val) for val in perm_tuple),
+                    int(transform_sign),
+                )
+            )
+
+    signatures = reconstruction_maps.get("transform_signatures")
+    if signatures is None:
+        return None
+
+    actual = {
+        (
+            tuple(int(val) for val in sign_tuple),
+            tuple(int(val) for val in perm_tuple),
+            int(transform_sign),
+        )
+        for (sign_tuple, perm_tuple), transform_sign in zip(
+            signatures,
+            np.asarray(reconstruction_maps["transform_signs"], dtype=np.int8),
+            strict=True,
+        )
+    }
+
+    if actual != expected:
+        return None
+
+    if len(actual) != len(signatures):
+        return None
+
+    return {
+        "axis_groups": axis_groups,
+        "axis_sign_power": axis_sign_power,
+        "axis_direction_signs": direction_signs,
+        "direction_sign_axis": int(direction_sign_axis if direction_sign_power else -1),
+    }
+
+
+def _evaluate_arithmetic_orbit_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    axis_sign_power=None,
+    axis_direction_signs=None,
+    direction_sign_axis=-1,
+    q_order,
+    dim,
+):
+    if axis_sign_power is None:
+        axis_sign_power = np.zeros(int(dim), dtype=np.uint8)
+    if axis_direction_signs is None:
+        axis_direction_signs = np.zeros(int(dim), dtype=np.int8)
+
+    source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
+    target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
+
+    source_axes = []
+    target_axes = []
+    groups = []
+    entry_sign = 1
+    for out_axis in range(int(dim)):
+        in_axis = int(case_axis_perm[case_id, out_axis])
+        axis_sign = int(case_axis_sign[case_id, out_axis])
+        source_axis = source_axes_raw[in_axis]
+        target_axis = target_axes_raw[in_axis]
+        applied_axis_sign = 1
+
+        if axis_sign < 0:
+            source_axis = int(q_order) - 1 - source_axis
+            target_axis = int(q_order) - 1 - target_axis
+            applied_axis_sign = -1
+        elif axis_sign == 0:
+            flipped_source = int(q_order) - 1 - source_axis
+            flipped_target = int(q_order) - 1 - target_axis
+            if (flipped_source, flipped_target) < (source_axis, target_axis):
+                source_axis = flipped_source
+                target_axis = flipped_target
+                applied_axis_sign = -1
+
+        if int(axis_sign_power[in_axis]):
+            entry_sign *= applied_axis_sign
+        if int(direction_sign_axis) == out_axis:
+            entry_sign *= (
+                applied_axis_sign
+                * int(axis_direction_signs[in_axis])
+                * int(axis_direction_signs[out_axis])
+            )
+
+        source_axes.append(source_axis)
+        target_axes.append(target_axis)
+        groups.append(int(case_axis_group[case_id, out_axis]))
+
+    def compare_swap(iaxis, jaxis):
+        if groups[iaxis] != groups[jaxis]:
+            return
+        if (source_axes[jaxis], target_axes[jaxis]) < (
+            source_axes[iaxis],
+            target_axes[iaxis],
+        ):
+            source_axes[iaxis], source_axes[jaxis] = (
+                source_axes[jaxis],
+                source_axes[iaxis],
+            )
+            target_axes[iaxis], target_axes[jaxis] = (
+                target_axes[jaxis],
+                target_axes[iaxis],
+            )
+
+    if int(dim) == 2:
+        compare_swap(0, 1)
+    elif int(dim) == 3:
+        compare_swap(0, 1)
+        compare_swap(1, 2)
+        compare_swap(0, 1)
+        compare_swap(0, 2)
+    else:
+        raise NotImplementedError("scalar arithmetic ORBIT supports dim 2 or 3")
+
+    canonical_source = _encode_mode_axes(source_axes, q_order)
+    canonical_target = _encode_mode_axes(target_axes, q_order)
+    n_q_points = int(q_order) ** int(dim)
+    entry_id = (
+        int(case_orbit_ranks[case_id]) * n_q_points * n_q_points
+        + canonical_source * n_q_points
+        + canonical_target
+    )
+    return int(entry_id), int(entry_sign)
+
+
+def _evaluate_scalar_arithmetic_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    q_order,
+    dim,
+):
+    entry_id, _ = _evaluate_arithmetic_orbit_entry(
+        case_id,
+        source_mode_id,
+        target_point_id,
+        case_orbit_ranks=case_orbit_ranks,
+        case_axis_perm=case_axis_perm,
+        case_axis_sign=case_axis_sign,
+        case_axis_group=case_axis_group,
+        q_order=q_order,
+        dim=dim,
+    )
+    return entry_id
+
+
+def _rank_multiset(values, alphabet_size):
+    values = [int(value) for value in values]
+    alphabet_size = int(alphabet_size)
+    rank = 0
+    min_allowed = 0
+    nvalues = len(values)
+
+    for i, value in enumerate(values):
+        remaining = nvalues - i - 1
+        for candidate in range(min_allowed, value):
+            rank += math.comb(alphabet_size - candidate + remaining - 1, remaining)
+        min_allowed = value
+
+    return int(rank)
+
+
+def _compact_arithmetic_case_value_count(case_axis_sign, case_axis_group, q_order):
+    case_axis_sign = np.asarray(case_axis_sign, dtype=np.int8)
+    case_axis_group = np.asarray(case_axis_group, dtype=np.int64)
+    pair_count = int(q_order) * int(q_order)
+    folded_pair_count = (pair_count + 1) // 2
+    value_count = 1
+
+    for group_id in range(int(np.max(case_axis_group)) + 1):
+        axes = np.flatnonzero(case_axis_group == group_id)
+        if len(axes) == 0:
+            continue
+        alphabet_size = (
+            folded_pair_count
+            if np.any(case_axis_sign[axes] == 0)
+            else pair_count
+        )
+        value_count *= math.comb(int(alphabet_size) + len(axes) - 1, len(axes))
+
+    return int(value_count)
+
+
+def _evaluate_compact_arithmetic_orbit_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_value_offsets,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    axis_sign_power=None,
+    axis_direction_signs=None,
+    direction_sign_axis=-1,
+    q_order,
+    dim,
+):
+    if axis_sign_power is None:
+        axis_sign_power = np.zeros(int(dim), dtype=np.uint8)
+    if axis_direction_signs is None:
+        axis_direction_signs = np.zeros(int(dim), dtype=np.int8)
+
+    source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
+    target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
+
+    source_axes = []
+    target_axes = []
+    groups = []
+    axis_signs = []
+    entry_sign = 1
+    for out_axis in range(int(dim)):
+        in_axis = int(case_axis_perm[case_id, out_axis])
+        axis_sign = int(case_axis_sign[case_id, out_axis])
+        source_axis = source_axes_raw[in_axis]
+        target_axis = target_axes_raw[in_axis]
+        applied_axis_sign = 1
+
+        if axis_sign < 0:
+            source_axis = int(q_order) - 1 - source_axis
+            target_axis = int(q_order) - 1 - target_axis
+            applied_axis_sign = -1
+        elif axis_sign == 0:
+            flipped_source = int(q_order) - 1 - source_axis
+            flipped_target = int(q_order) - 1 - target_axis
+            if (flipped_source, flipped_target) < (source_axis, target_axis):
+                source_axis = flipped_source
+                target_axis = flipped_target
+                applied_axis_sign = -1
+
+        if int(axis_sign_power[in_axis]):
+            entry_sign *= applied_axis_sign
+        if int(direction_sign_axis) == out_axis:
+            entry_sign *= (
+                applied_axis_sign
+                * int(axis_direction_signs[in_axis])
+                * int(axis_direction_signs[out_axis])
+            )
+
+        source_axes.append(source_axis)
+        target_axes.append(target_axis)
+        groups.append(int(case_axis_group[case_id, out_axis]))
+        axis_signs.append(axis_sign)
+
+    pair_codes = [
+        int(source_axis) * int(q_order) + int(target_axis)
+        for source_axis, target_axis in zip(source_axes, target_axes, strict=True)
+    ]
+    pair_count = int(q_order) * int(q_order)
+    folded_pair_count = (pair_count + 1) // 2
+
+    group_ranks = []
+    group_value_counts = []
+    for group_id in range(max(groups) + 1):
+        axes = [axis for axis, group in enumerate(groups) if group == group_id]
+        if not axes:
+            group_ranks.append(0)
+            group_value_counts.append(1)
+            continue
+
+        alphabet_size = (
+            folded_pair_count
+            if any(axis_signs[axis] == 0 for axis in axes)
+            else pair_count
+        )
+        group_values = sorted(pair_codes[axis] for axis in axes)
+        group_ranks.append(_rank_multiset(group_values, alphabet_size))
+        group_value_counts.append(
+            math.comb(int(alphabet_size) + len(axes) - 1, len(axes))
+        )
+
+    compact_pair_rank = 0
+    for group_rank, group_value_count in zip(
+        group_ranks,
+        group_value_counts,
+        strict=True,
+    ):
+        compact_pair_rank = compact_pair_rank * int(group_value_count) + int(group_rank)
+
+    case_rank = int(case_orbit_ranks[case_id])
+    return int(case_value_offsets[case_rank]) + compact_pair_rank, int(entry_sign)
+
+
+def _entry_has_odd_reconstruction_stabilizer(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    reconstruction_maps,
+):
+    transform_case_map = np.asarray(reconstruction_maps["transform_case_map"])
+    transform_qpoint_map = np.asarray(reconstruction_maps["transform_qpoint_map"])
+    transform_signs = np.asarray(reconstruction_maps["transform_signs"])
+
+    for transform_id, transform_sign in enumerate(transform_signs):
+        if int(transform_sign) >= 0:
+            continue
+        if int(transform_case_map[transform_id, case_id]) != int(case_id):
+            continue
+        if int(transform_qpoint_map[transform_id, source_mode_id]) != int(
+            source_mode_id
+        ):
+            continue
+        if int(transform_qpoint_map[transform_id, target_point_id]) != int(
+            target_point_id
+        ):
+            continue
+        return True
+
+    return False
+
+
+def build_arithmetic_case_metadata(table, arithmetic_symmetry=None):
+    if arithmetic_symmetry is None:
+        axis_groups = None
+        axis_sign_power = np.zeros(int(table.dim), dtype=np.uint8)
+        axis_direction_signs = np.zeros(int(table.dim), dtype=np.int8)
+        direction_sign_axis = -1
+    else:
+        axis_groups = arithmetic_symmetry["axis_groups"]
+        axis_sign_power = np.asarray(
+            arithmetic_symmetry["axis_sign_power"], dtype=np.uint8
+        )
+        axis_direction_signs = np.asarray(
+            arithmetic_symmetry["axis_direction_signs"], dtype=np.int8
+        )
+        direction_sign_axis = int(arithmetic_symmetry["direction_sign_axis"])
+
+    case_vecs = np.asarray(table.interaction_case_vecs, dtype=np.int32)
+    canonical_case_ids = np.empty(table.n_cases, dtype=np.int32)
+    case_axis_perm = np.empty((table.n_cases, table.dim), dtype=np.uint8)
+    case_axis_sign = np.empty((table.n_cases, table.dim), dtype=np.int8)
+    case_axis_group = np.empty((table.n_cases, table.dim), dtype=np.uint8)
+
+    for case_id, case_vec in enumerate(case_vecs):
+        axis_perm, axis_sign, axis_group = _case_arithmetic_axis_descriptors(
+            case_vec,
+            axis_groups=axis_groups,
+            direction_signs=axis_direction_signs,
+        )
+        canonical_vec = _canonical_case_from_axis_descriptors(
+            case_vec,
+            axis_perm,
+            axis_sign,
+        )
+        canonical_case_ids[case_id] = int(
+            table.case_indices[table.case_encode(canonical_vec)]
+        )
+        case_axis_perm[case_id, :] = axis_perm
+        case_axis_sign[case_id, :] = axis_sign
+        case_axis_group[case_id, :] = axis_group
+
+    unique_canonical_case_ids = np.unique(canonical_case_ids)
+    if len(unique_canonical_case_ids) > np.iinfo(np.uint16).max:
+        return None
+
+    canonical_case_rank_by_id = {
+        int(case_id): rank for rank, case_id in enumerate(unique_canonical_case_ids)
+    }
+    case_orbit_ranks = np.empty(table.n_cases, dtype=np.uint16)
+    for case_id in range(table.n_cases):
+        case_orbit_ranks[case_id] = canonical_case_rank_by_id[
+            int(canonical_case_ids[case_id])
+        ]
+
+    case_value_counts = np.empty(len(unique_canonical_case_ids), dtype=np.int64)
+    for case_rank, canonical_case_id in enumerate(unique_canonical_case_ids):
+        case_value_counts[case_rank] = _compact_arithmetic_case_value_count(
+            case_axis_sign[canonical_case_id],
+            case_axis_group[canonical_case_id],
+            table.quad_order,
+        )
+
+    case_value_offsets_i64 = np.zeros(
+        len(unique_canonical_case_ids) + 1, dtype=np.int64
+    )
+    case_value_offsets_i64[1:] = np.cumsum(case_value_counts, dtype=np.int64)
+    if case_value_offsets_i64[-1] > np.iinfo(np.int32).max:
+        return None
+
+    return {
+        "canonical_case_ids": unique_canonical_case_ids.astype(np.int32),
+        "case_orbit_ranks": case_orbit_ranks,
+        "case_axis_perm": case_axis_perm,
+        "case_axis_sign": case_axis_sign,
+        "case_axis_group": case_axis_group,
+        "case_value_offsets": case_value_offsets_i64.astype(np.int32),
+        "case_value_offsets_i64": case_value_offsets_i64,
+        "axis_sign_power": axis_sign_power,
+        "axis_direction_signs": axis_direction_signs,
+        "direction_sign_axis": int(direction_sign_axis),
+        "n_compact_entries": int(case_value_offsets_i64[-1]),
+    }
+
+
+def enumerate_scalar_arithmetic_representatives(table, metadata):
+    pair_count = int(table.quad_order) * int(table.quad_order)
+    folded_pair_count = (pair_count + 1) // 2
+    canonical_case_ids = np.asarray(metadata["canonical_case_ids"], dtype=np.int32)
+    case_axis_sign = np.asarray(metadata["case_axis_sign"], dtype=np.int8)
+    case_axis_group = np.asarray(metadata["case_axis_group"], dtype=np.uint8)
+    case_value_offsets = np.asarray(metadata["case_value_offsets_i64"], dtype=np.int64)
+
+    entry_ids = np.empty(int(metadata["n_compact_entries"]), dtype=np.int64)
+    for case_rank, case_id_raw in enumerate(canonical_case_ids.tolist()):
+        case_id = int(case_id_raw)
+        group_options = []
+        case_groups = case_axis_group[case_id]
+        case_signs = case_axis_sign[case_id]
+        for group_id in range(int(np.max(case_groups)) + 1):
+            axes = np.flatnonzero(case_groups == group_id).astype(int).tolist()
+            alphabet_size = (
+                folded_pair_count if np.any(case_signs[axes] == 0) else pair_count
+            )
+            options = itertools.combinations_with_replacement(
+                range(alphabet_size), len(axes)
+            )
+            group_options.append((axes, tuple(options)))
+
+        out = int(case_value_offsets[case_rank])
+        for combo_by_group in itertools.product(*(opts for _, opts in group_options)):
+            source_axes = [0] * int(table.dim)
+            target_axes = [0] * int(table.dim)
+            for (axes, _), values in zip(group_options, combo_by_group, strict=True):
+                for axis, pair_code in zip(axes, values, strict=True):
+                    source_axes[axis] = int(pair_code) // int(table.quad_order)
+                    target_axes[axis] = int(pair_code) % int(table.quad_order)
+
+            source_mode_id = _encode_mode_axes(source_axes, table.quad_order)
+            target_point_id = _encode_mode_axes(target_axes, table.quad_order)
+            entry_ids[out] = (
+                int(case_id) * int(table.n_pairs)
+                + source_mode_id * int(table.n_q_points)
+                + target_point_id
+            )
+            out += 1
+
+    return entry_ids

--- a/volumential/orbit_arithmetic.py
+++ b/volumential/orbit_arithmetic.py
@@ -369,12 +369,11 @@ def _kernel_axis_preserving_arithmetic_symmetry(table, reconstruction_maps):
     }
 
 
-def _evaluate_arithmetic_orbit_entry(
+def _canonicalize_arithmetic_entry_axes(
     case_id,
     source_mode_id,
     target_point_id,
     *,
-    case_orbit_ranks,
     case_axis_perm,
     case_axis_sign,
     case_axis_group,
@@ -395,6 +394,7 @@ def _evaluate_arithmetic_orbit_entry(
     source_axes = []
     target_axes = []
     groups = []
+    axis_signs = []
     entry_sign = 1
     for out_axis in range(int(dim)):
         in_axis = int(case_axis_perm[case_id, out_axis])
@@ -427,6 +427,41 @@ def _evaluate_arithmetic_orbit_entry(
         source_axes.append(source_axis)
         target_axes.append(target_axis)
         groups.append(int(case_axis_group[case_id, out_axis]))
+        axis_signs.append(axis_sign)
+
+    return source_axes, target_axes, groups, axis_signs, entry_sign
+
+
+def _evaluate_arithmetic_orbit_entry(
+    case_id,
+    source_mode_id,
+    target_point_id,
+    *,
+    case_orbit_ranks,
+    case_axis_perm,
+    case_axis_sign,
+    case_axis_group,
+    axis_sign_power=None,
+    axis_direction_signs=None,
+    direction_sign_axis=-1,
+    q_order,
+    dim,
+):
+    source_axes, target_axes, groups, _, entry_sign = (
+        _canonicalize_arithmetic_entry_axes(
+            case_id,
+            source_mode_id,
+            target_point_id,
+            case_axis_perm=case_axis_perm,
+            case_axis_sign=case_axis_sign,
+            case_axis_group=case_axis_group,
+            axis_sign_power=axis_sign_power,
+            axis_direction_signs=axis_direction_signs,
+            direction_sign_axis=direction_sign_axis,
+            q_order=q_order,
+            dim=dim,
+        )
+    )
 
     def compare_swap(iaxis, jaxis):
         if groups[iaxis] != groups[jaxis]:
@@ -544,51 +579,21 @@ def _evaluate_compact_arithmetic_orbit_entry(
     q_order,
     dim,
 ):
-    if axis_sign_power is None:
-        axis_sign_power = np.zeros(int(dim), dtype=np.uint8)
-    if axis_direction_signs is None:
-        axis_direction_signs = np.zeros(int(dim), dtype=np.int8)
-
-    source_axes_raw = _decode_mode_axes(source_mode_id, q_order, dim)
-    target_axes_raw = _decode_mode_axes(target_point_id, q_order, dim)
-
-    source_axes = []
-    target_axes = []
-    groups = []
-    axis_signs = []
-    entry_sign = 1
-    for out_axis in range(int(dim)):
-        in_axis = int(case_axis_perm[case_id, out_axis])
-        axis_sign = int(case_axis_sign[case_id, out_axis])
-        source_axis = source_axes_raw[in_axis]
-        target_axis = target_axes_raw[in_axis]
-        applied_axis_sign = 1
-
-        if axis_sign < 0:
-            source_axis = int(q_order) - 1 - source_axis
-            target_axis = int(q_order) - 1 - target_axis
-            applied_axis_sign = -1
-        elif axis_sign == 0:
-            flipped_source = int(q_order) - 1 - source_axis
-            flipped_target = int(q_order) - 1 - target_axis
-            if (flipped_source, flipped_target) < (source_axis, target_axis):
-                source_axis = flipped_source
-                target_axis = flipped_target
-                applied_axis_sign = -1
-
-        if int(axis_sign_power[in_axis]):
-            entry_sign *= applied_axis_sign
-        if int(direction_sign_axis) == out_axis:
-            entry_sign *= (
-                applied_axis_sign
-                * int(axis_direction_signs[in_axis])
-                * int(axis_direction_signs[out_axis])
-            )
-
-        source_axes.append(source_axis)
-        target_axes.append(target_axis)
-        groups.append(int(case_axis_group[case_id, out_axis]))
-        axis_signs.append(axis_sign)
+    source_axes, target_axes, groups, axis_signs, entry_sign = (
+        _canonicalize_arithmetic_entry_axes(
+            case_id,
+            source_mode_id,
+            target_point_id,
+            case_axis_perm=case_axis_perm,
+            case_axis_sign=case_axis_sign,
+            case_axis_group=case_axis_group,
+            axis_sign_power=axis_sign_power,
+            axis_direction_signs=axis_direction_signs,
+            direction_sign_axis=direction_sign_axis,
+            q_order=q_order,
+            dim=dim,
+        )
+    )
 
     pair_codes = [
         int(source_axis) * int(q_order) + int(target_axis)


### PR DESCRIPTION
Closes #113.

## Summary

- Add compact scalar arithmetic ORBIT invariant discovery for normal table builds.
- Avoid dense signed union-find and dense `canonical_entry_ids` construction on the scalar full-symmetry build path.
- Keep dense canonical metadata available through explicit diagnostic/reconstruction APIs.
- Make arithmetic reduced-table payload prep skip dense `table_entry_ids`/`table_entry_scales` entirely.
- Document the normal-build versus diagnostic split and add regression coverage.

## Performance Check

On `ipa`, scalar 3D Laplace `q=6` invariant discovery now reports:

```text
scalar-arithmetic-orbit 140496 0.29802568815648556 has_dense False
```

This replaces the dense signed union-find setup path that issue #113 measured at roughly 1000 s for `q=6`.

## Validation

- `uv run python -m compileall volumential/orbit_arithmetic.py volumential/nearfield_potential_table.py volumential/expansion_wrangler_fpnd.py test/test_nearfield_potential_table.py`
- `PYTHONPATH=/tmp/opencode-volumential-112 pytest test/test_nearfield_potential_table.py` on `ipa`: `82 passed, 13 skipped, 6 xfailed`
- `PYTHONPATH=/tmp/opencode-volumential-112 pytest test/test_duffy_batched_manufactured.py` on `ipa`: `22 passed, 11 skipped, 11 xfailed`
- `PYTHONPATH=/tmp/opencode-volumential-112 pytest test/test_table_manager_sqlite_migration.py -k 'reduced or payload or symmetry'` on `ipa`: `6 passed, 32 deselected`
