### PR TITLE
bench: compare split sweep to direct tables

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,7 +71,7 @@ The benchmark compares canonical rescaled tables, direct per-level tables, and d
 python benchmarks/split_parameter_sweep.py --mode smoke --out build/benchmarks/split-parameter-sweep.csv
 ```
 
-The benchmark sweeps 2D scalar Helmholtz wave numbers and Yukawa screening parameters. Rows compare each split order against the highest split order in the same run for that kernel parameter, giving a split-order convergence measurement while holding the pretabulated basis-table family fixed. Each row records split cache accounting. In `_row_from_result`, the `online_remainder_s` column is a conservative upper bound: it equals `split_warm_s` when `uses_online_remainder` is true, and is `0.0` otherwise, because the current wrangler instrumentation does not isolate smooth online-remainder work from the rest of the warm FMM/List-1 evaluation.
+The benchmark sweeps 2D scalar Helmholtz wave numbers and Yukawa screening parameters. Rows compare each split order against a fixed-parameter direct near-field table for that kernel parameter, giving an independent reference while holding the pretabulated split/RKE channel-table family fixed. Each row records split cache accounting. In `_row_from_result`, the `online_remainder_s` column is a conservative upper bound: it equals `split_warm_s` when `uses_online_remainder` is true, and is `0.0` otherwise, because the current wrangler instrumentation does not isolate smooth online-remainder work from the rest of the warm FMM/List-1 evaluation.
 
 ## Adaptive Timing
 

--- a/benchmarks/split_parameter_sweep.py
+++ b/benchmarks/split_parameter_sweep.py
@@ -3,8 +3,8 @@
 
 The benchmark sweeps the Helmholtz wave number and Yukawa screening parameter
 while recording split-table accounting. For each kernel parameter, rows compare
-against the highest split order in the same run, giving a direct split-order
-convergence measurement without changing the pretabulated basis-table family.
+against a fixed-parameter direct near-field table, giving an independent
+reference for the split/RKE channel family.
 
 Smoke mode is intended for CI/local validation. Full mode is intended for
 metadata-wrapped runs on controlled machines such as ``ipa``.
@@ -264,7 +264,7 @@ def _run_path(
     elif kernel == "Yukawa":
         out_kernel = YukawaKernel(2)
         kernel_kwargs = {out_kernel.yukawa_lambda_name: float(parameter)}
-        dtype = np.complex128 if split else np.float64
+        dtype = np.complex128
     else:
         raise ValueError(f"unknown kernel: {kernel}")
 
@@ -420,8 +420,39 @@ def run_benchmark(
                 source_values_host, _exact_values = _helmholtz_manufactured_source_and_exact(
                     _coords_host(queue, q_points), parameter
                 )
+                direct_reference_table = _build_helmholtz_2d_table(
+                    queue,
+                    cache_dir / f"direct-helmholtz-k{parameter:g}-q{q_order}.sqlite",
+                    q_order,
+                    parameter,
+                    nlevels,
+                )
             else:
                 source_values_host = _gaussian_source_host(_coords_host(queue, q_points))
+                direct_reference_table = _get_yukawa_2d_table(
+                    queue,
+                    cache_dir / f"direct-yukawa-lambda{parameter:g}-q{q_order}.sqlite",
+                    q_order,
+                    parameter,
+                    nlevels,
+                )
+
+            reference_values, reference_warm_s, _ = _run_path(
+                ctx=ctx,
+                queue=queue,
+                traversal=traversal,
+                q_order=q_order,
+                fmm_order=fmm_order,
+                kernel=kernel,
+                parameter=parameter,
+                table=direct_reference_table,
+                source_weights=source_weights,
+                q_points=q_points,
+                source_values_host=source_values_host,
+                split=False,
+                split_order=1,
+            )
+            reference_path = "direct_fixed_parameter_table"
 
             split_results = []
             for split_order in split_orders:
@@ -447,10 +478,6 @@ def run_benchmark(
                     (split_order, split_values, split_warm_s, accounting)
                 )
 
-            reference_split_order, reference_values, reference_warm_s, _ = max(
-                split_results, key=lambda result: result[0]
-            )
-            reference_path = f"split_order_{reference_split_order}"
             for split_order, split_values, split_warm_s, accounting in split_results:
                 rows.append(
                     _row_from_result(

--- a/benchmarks/split_parameter_sweep.py
+++ b/benchmarks/split_parameter_sweep.py
@@ -161,33 +161,23 @@ def _build_helmholtz_2d_table(
     queue, cache_path: Path, q_order: int, wave_number: float, level: int
 ):
     from sumpy.kernel import HelmholtzKernel
-
-    import volumential.nearfield_potential_table as npt
+    from volumential.table_manager import NearFieldInteractionTableManager
 
     kernel = HelmholtzKernel(2)
-    kernel_kwargs = {kernel.helmholtz_k_name: float(wave_number)}
-    table = npt.NearFieldInteractionTable(
-        quad_order=q_order,
-        dim=2,
-        build_method="DuffyRadial",
-        kernel_func=npt.sumpy_kernel_to_lambda(kernel, parameter_values=kernel_kwargs),
-        kernel_type="helmholtz-direct",
-        sumpy_kernel=kernel,
-        source_box_extent=2.0 * (2 ** (-int(level))),
-        dtype=np.complex128,
-        progress_bar=False,
-    )
-    table.source_box_level = int(level)
-    table.table_root_extent = 2.0
-    table._table_cache_filename = str(cache_path)
-    table._table_cache_root_extent = 2.0
-    table.build_table_via_duffy_radial(
-        queue=queue,
-        radial_rule="tanh-sinh-fast",
-        regular_quad_order=max(8, 4 * q_order),
-        radial_quad_order=max(21, 10 * q_order),
-        **kernel_kwargs,
-    )
+    with NearFieldInteractionTableManager(
+        str(cache_path), root_extent=2.0, dtype=np.complex128, queue=queue
+    ) as table_manager:
+        table, _ = table_manager.get_table(
+            2,
+            "Helmholtz-Reference",
+            q_order,
+            source_box_level=int(level),
+            force_recompute=False,
+            queue=queue,
+            build_config=_build_config(q_order),
+            sumpy_knl=kernel,
+            **{kernel.helmholtz_k_name: float(wave_number)},
+        )
     return table
 
 


### PR DESCRIPTION
## Summary

- compare `split_parameter_sweep.py` rows against fixed-parameter direct near-field tables instead of the highest split order in the same run
- keep the existing CSV schema and write `reference_path=direct_fixed_parameter_table`
- run Yukawa direct-reference paths with `complex128`, matching the symbolic Sumpy Yukawa kernel and avoiding invalid complex-scaling codegen
- update the benchmark README to describe the independent reference

## Validation

- `python -m py_compile benchmarks/split_parameter_sweep.py`
- `git diff --check`
- on `ipa`: `PYTHONPATH=/tmp/boxcode-paper-table1-refresh/volumential-68f360d PYOPENCL_CTX=portable:0 /home/xywei/Work/fmm/volumential/.venv/bin/python -m pytest test/test_volume_fmm.py::test_volume_fmm_2d_helmholtz_split_scalar_tracks_nonsplit -q`
- on `ipa`: `PYTHONPATH=/tmp/boxcode-paper-table1-refresh/volumential-68f360d PYOPENCL_CTX=portable:0 /home/xywei/Work/fmm/volumential/.venv/bin/python benchmarks/split_parameter_sweep.py --mode smoke --backend pocl-cpu --out /tmp/opencode/split-independent-smoke.csv --cache-dir /tmp/opencode/split-independent-smoke-cache`

## Notes

This is stacked on `fix/issue-113-fast-orbit-discovery` so the PR diff stays limited to the split-parameter benchmark change.
