### PR TITLE
bench: add log and source-derivative table checks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -44,7 +44,7 @@ python /path/to/boxcode-paper/tools/run_benchmark_with_metadata.py \
   --mode full \
   --repo volumential=/path/to/volumential \
   --param kernel=laplace \
-  --param dimension=3 \
+  --param dimensions=2,3 \
   --param cache_state=cold-and-warm \
   --result-file table_equivalence.csv \
   --result-file cache_economics.csv \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -54,7 +54,7 @@ python /path/to/boxcode-paper/tools/run_benchmark_with_metadata.py \
 
 The script writes:
 
-- `table_equivalence.csv`: max absolute/relative mismatch between direct per-level tables and a scaled canonical level-0 table.
+- `table_equivalence.csv`: max absolute/relative mismatch between direct per-level tables and a scaled canonical level-0 table. Log-Laplace rows also report the mismatch when the separable logarithmic correction is intentionally omitted.
 - `cache_economics.csv`: cold build, warm load, payload bytes, cache bytes, and symmetry-reduction counts from the table manager and table diagnostics.
 
 ## Accuracy Preservation

--- a/benchmarks/table_equivalence_cache.py
+++ b/benchmarks/table_equivalence_cache.py
@@ -214,16 +214,26 @@ def _full_table_data(table) -> np.ndarray:
     return np.asarray(table.data, dtype=table.dtype)
 
 
-def _apply_log_scaling(canonical_table, canonical_data: np.ndarray, extent_ratio: float):
+def _apply_log_laplace_scaling(
+    canonical_table,
+    canonical_data: np.ndarray,
+    *,
+    extent_ratio: float,
+    scale_factor: float,
+):
     scaled = np.array(canonical_data, copy=True)
     for entry_id, value in enumerate(canonical_data):
         if not np.isfinite(value):
             continue
-        scaled[entry_id] = canonical_table.get_potential_scaler(
-            entry_id,
-            source_box_size=extent_ratio,
-            kernel_type="log",
-        )(value)
+        source_mode_index = canonical_table.decode_index(entry_id)["source_mode_index"]
+        displacement = (
+            -0.5
+            / np.pi
+            * scale_factor
+            * np.log(extent_ratio)
+            * canonical_table.mode_normalizers[source_mode_index]
+        )
+        scaled[entry_id] = scale_factor * value + displacement
     return scaled
 
 
@@ -255,10 +265,11 @@ def _equivalence_row(
     canonical_data = _full_table_data(canonical_table)
     scaled_canonical_without_log_correction = scale_factor * canonical_data
     if case.scale_rule == "log":
-        scaled_canonical = _apply_log_scaling(
+        scaled_canonical = _apply_log_laplace_scaling(
             canonical_table,
             canonical_data,
-            extent_ratio,
+            extent_ratio=extent_ratio,
+            scale_factor=scale_factor,
         )
     else:
         scaled_canonical = scaled_canonical_without_log_correction

--- a/benchmarks/table_equivalence_cache.py
+++ b/benchmarks/table_equivalence_cache.py
@@ -31,6 +31,7 @@ class BenchmarkCase:
     q_orders: tuple[int, ...]
     max_level: int
     scale_exponent: int
+    scale_rule: str = "power"
 
 
 SMOKE_CASES = (
@@ -48,6 +49,25 @@ SMOKE_CASES = (
         dim=3,
         kernel_type="Laplace-Dx",
         derivative="target_dx",
+        q_orders=(1,),
+        max_level=1,
+        scale_exponent=1,
+    ),
+    BenchmarkCase(
+        case_id="laplace2d-log-q1-l0-1",
+        dim=2,
+        kernel_type="Laplace",
+        derivative="none",
+        q_orders=(1,),
+        max_level=1,
+        scale_exponent=2,
+        scale_rule="log",
+    ),
+    BenchmarkCase(
+        case_id="laplace3d-source-dx-q1-l0-1",
+        dim=3,
+        kernel_type="Laplace-Sx",
+        derivative="source_dx",
         q_orders=(1,),
         max_level=1,
         scale_exponent=1,
@@ -73,6 +93,25 @@ FULL_CASES = (
         max_level=4,
         scale_exponent=1,
     ),
+    BenchmarkCase(
+        case_id="laplace2d-log-q1-4-l0-4",
+        dim=2,
+        kernel_type="Laplace",
+        derivative="none",
+        q_orders=(1, 2, 3, 4),
+        max_level=4,
+        scale_exponent=2,
+        scale_rule="log",
+    ),
+    BenchmarkCase(
+        case_id="laplace3d-source-dx-q1-3-l0-4",
+        dim=3,
+        kernel_type="Laplace-Sx",
+        derivative="source_dx",
+        q_orders=(1, 2, 3),
+        max_level=4,
+        scale_exponent=1,
+    ),
 )
 
 
@@ -87,10 +126,14 @@ EQUIVALENCE_FIELDS = (
     "source_box_extent",
     "canonical_source_box_extent",
     "scale_exponent",
+    "scale_rule",
     "scale_factor",
+    "log_correction_applied",
     "finite_entry_count",
     "max_abs_mismatch",
     "max_rel_mismatch",
+    "max_abs_mismatch_without_log_correction",
+    "max_rel_mismatch_without_log_correction",
     "reference_linf",
 )
 
@@ -171,6 +214,31 @@ def _full_table_data(table) -> np.ndarray:
     return np.asarray(table.data, dtype=table.dtype)
 
 
+def _apply_log_scaling(canonical_table, canonical_data: np.ndarray, extent_ratio: float):
+    scaled = np.array(canonical_data, copy=True)
+    for entry_id, value in enumerate(canonical_data):
+        if not np.isfinite(value):
+            continue
+        scaled[entry_id] = canonical_table.get_potential_scaler(
+            entry_id,
+            source_box_size=extent_ratio,
+            kernel_type="log",
+        )(value)
+    return scaled
+
+
+def _mismatch_stats(reference: np.ndarray, candidate: np.ndarray):
+    finite_mask = np.isfinite(candidate) & np.isfinite(reference)
+    if not np.any(finite_mask):
+        return finite_mask, np.nan, np.nan, np.nan
+
+    diff = np.abs(reference[finite_mask] - candidate[finite_mask])
+    reference_linf = float(np.max(np.abs(reference[finite_mask])))
+    max_abs_mismatch = float(np.max(diff))
+    max_rel_mismatch = float(max_abs_mismatch / max(reference_linf, 1e-300))
+    return finite_mask, max_abs_mismatch, max_rel_mismatch, reference_linf
+
+
 def _equivalence_row(
     *,
     mode: str,
@@ -181,20 +249,28 @@ def _equivalence_row(
 ) -> dict[str, Any]:
     canonical_extent = float(canonical_table.source_box_extent)
     level_extent = float(level_table.source_box_extent)
-    scale_factor = (level_extent / canonical_extent) ** case.scale_exponent
+    extent_ratio = level_extent / canonical_extent
+    scale_factor = extent_ratio ** case.scale_exponent
 
-    scaled_canonical = scale_factor * _full_table_data(canonical_table)
-    level_data = _full_table_data(level_table)
-    finite_mask = np.isfinite(scaled_canonical) & np.isfinite(level_data)
-    if not np.any(finite_mask):
-        max_abs_mismatch = np.nan
-        max_rel_mismatch = np.nan
-        reference_linf = np.nan
+    canonical_data = _full_table_data(canonical_table)
+    scaled_canonical_without_log_correction = scale_factor * canonical_data
+    if case.scale_rule == "log":
+        scaled_canonical = _apply_log_scaling(
+            canonical_table,
+            canonical_data,
+            extent_ratio,
+        )
     else:
-        diff = np.abs(level_data[finite_mask] - scaled_canonical[finite_mask])
-        reference_linf = float(np.max(np.abs(level_data[finite_mask])))
-        max_abs_mismatch = float(np.max(diff))
-        max_rel_mismatch = float(max_abs_mismatch / max(reference_linf, 1e-300))
+        scaled_canonical = scaled_canonical_without_log_correction
+    level_data = _full_table_data(level_table)
+    finite_mask, max_abs_mismatch, max_rel_mismatch, reference_linf = _mismatch_stats(
+        level_data,
+        scaled_canonical,
+    )
+    _, max_abs_mismatch_without_log, max_rel_mismatch_without_log, _ = _mismatch_stats(
+        level_data,
+        scaled_canonical_without_log_correction,
+    )
 
     return {
         "case_id": case.case_id,
@@ -207,10 +283,18 @@ def _equivalence_row(
         "source_box_extent": level_extent,
         "canonical_source_box_extent": canonical_extent,
         "scale_exponent": case.scale_exponent,
+        "scale_rule": case.scale_rule,
         "scale_factor": scale_factor,
+        "log_correction_applied": case.scale_rule == "log",
         "finite_entry_count": int(np.count_nonzero(finite_mask)),
         "max_abs_mismatch": max_abs_mismatch,
         "max_rel_mismatch": max_rel_mismatch,
+        "max_abs_mismatch_without_log_correction": (
+            max_abs_mismatch_without_log if case.scale_rule == "log" else None
+        ),
+        "max_rel_mismatch_without_log_correction": (
+            max_rel_mismatch_without_log if case.scale_rule == "log" else None
+        ),
         "reference_linf": reference_linf,
     }
 
@@ -263,6 +347,12 @@ def _cache_row(
 
 
 def _build_or_load_table(tm, *, case: BenchmarkCase, q_order: int, level: int, queue):
+    build_kwargs = {"build_config": _default_build_config(q_order)}
+    if case.derivative == "source_dx":
+        from sumpy.kernel import AxisSourceDerivative, LaplaceKernel
+
+        build_kwargs["sumpy_knl"] = AxisSourceDerivative(0, LaplaceKernel(case.dim))
+
     return tm.get_table(
         case.dim,
         case.kernel_type,
@@ -270,7 +360,7 @@ def _build_or_load_table(tm, *, case: BenchmarkCase, q_order: int, level: int, q
         source_box_level=level,
         force_recompute=False,
         queue=queue,
-        build_config=_default_build_config(q_order),
+        **build_kwargs,
     )
 
 


### PR DESCRIPTION
## Summary

- Extend `table_equivalence_cache.py` with 2D log-Laplace rows that apply the separable logarithmic correction.
- Report the omitted-correction mismatch for log rows so the failure mode is visible in the CSV.
- Add source-derivative Laplace rows using explicit Sumpy kernels, without adding new public table-manager aliases.
- Document the new log-correction columns in `benchmarks/README.md`.

## Validation

- `rtk git diff --check`
- Local syntax check: `/home/xywei/Work/fmm/volumential/.venv/bin/python -m py_compile benchmarks/table_equivalence_cache.py`
- `ipa` smoke: `PYTHONPATH=/tmp/opencode/paper1-issue73/volumential-37f4f85 PYOPENCL_CTX=portable:0 /home/xywei/Work/fmm/volumential/.venv/bin/python benchmarks/table_equivalence_cache.py --mode smoke --out-dir /tmp/opencode/paper1-issue73/smoke-7b4ee58 --cache-dir /tmp/opencode/paper1-issue73/smoke-7b4ee58/cache`

Smoke highlights: corrected log row has max relative mismatch `8.22e-16` at level 1, while omitting the log correction gives `6.53e-1`; source-derivative smoke rows have zero mismatch.

Refs xywei/boxcode-paper#73.