### PR TITLE
feat(bench): add Gaussian free-space demo fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
           python examples/helmholtz3d.py
           python benchmarks/table_equivalence_cache.py --mode smoke
           python benchmarks/accuracy_preservation.py --mode smoke
+          python benchmarks/gaussian_free_space.py --mode smoke --slice-size 8
           python benchmarks/adaptive_timing.py --mode smoke
           python benchmarks/performance_suite.py --list-cases
           python benchmarks/performance_suite.py --mode smoke --dry-run

--- a/benchmarks/gaussian_free_space.py
+++ b/benchmarks/gaussian_free_space.py
@@ -345,12 +345,18 @@ def run_benchmark(
     coords = _coords_host(queue, q_points)
     weights = q_weights.get(queue)
     source = evaluate_gaussian_mixture(mixture, coords)
-    reference = laplace3d_gaussian_potential(mixture, coords)
+    kernel_scale = 1.0 / (4.0 * np.pi)
+    reference = laplace3d_gaussian_potential(
+        mixture, coords, kernel_scale=kernel_scale
+    )
+    root_extent = 2.0 * root_radius
+    root_extent_tag = f"extent{root_extent:.12g}".replace("-", "m").replace(".", "p")
 
     table, table_timings = _get_table(
         queue,
-        cache_path=cache_dir / f"gaussian-free-space-laplace3d-q{q_order}.sqlite",
-        root_extent=2.0 * root_radius,
+        cache_path=cache_dir
+        / f"gaussian-free-space-laplace3d-q{q_order}-{root_extent_tag}.sqlite",
+        root_extent=root_extent,
         q_order=q_order,
         regular_quad_order=regular_quad_order,
         radial_quad_order=radial_quad_order,
@@ -380,14 +386,14 @@ def run_benchmark(
         "problem": "gaussian-mixture-free-space",
         "dim": 3,
         "kernel": "Laplace",
-        "kernel_normalization": "sumpy_1_over_r",
+        "kernel_normalization": "sumpy_global_scaling_1_over_4pi_r",
         "q_order": q_order,
         "nlevels": nlevels,
         "adapt_steps": adapt_steps,
         "fmm_order": fmm_order,
         "regular_quad_order": regular_quad_order,
         "radial_quad_order": radial_quad_order,
-        "root_extent": 2.0 * root_radius,
+        "root_extent": root_extent,
         "n_targets": int(tree.ntargets),
         "n_active_boxes": int(mesh.n_active_cells()),
         "n_total_boxes": int(mesh.n_cells()),
@@ -432,7 +438,9 @@ def run_benchmark(
         shape=(slice_size, slice_size),
     )
     analytic_slice_source = evaluate_gaussian_mixture(mixture, analytic_slice.points)
-    analytic_slice_reference = laplace3d_gaussian_potential(mixture, analytic_slice.points)
+    analytic_slice_reference = laplace3d_gaussian_potential(
+        mixture, analytic_slice.points, kernel_scale=kernel_scale
+    )
 
     arrays = {
         "node_coords": coords,
@@ -464,8 +472,9 @@ def run_benchmark(
         "kernel": {
             "name": "Laplace",
             "dimension": 3,
-            "normalization": "sumpy_1_over_r",
-            "analytic_reference": "sum_i mass_i * erf(sqrt(alpha_i) r_i) / r_i",
+            "normalization": "sumpy_global_scaling_1_over_4pi_r",
+            "kernel_scale": kernel_scale,
+            "analytic_reference": "kernel_scale * sum_i mass_i * erf(sqrt(alpha_i) r_i) / r_i",
         },
         "fixture": mixture.as_metadata(),
         "bbox": bbox,

--- a/benchmarks/gaussian_free_space.py
+++ b/benchmarks/gaussian_free_space.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""Run a deterministic Gaussian free-space 3D Laplace smoke demo.
+
+The benchmark evaluates an overlapping Gaussian mixture on a Volumential box
+mesh, compares against the analytic full-space Gaussian/Laplace reference, and
+emits a summary CSV plus NPZ/JSON artifacts suitable for paper plotting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import platform
+import subprocess
+import sys
+import time
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyopencl as cl
+import pyopencl.array as cla
+
+from volumential.gaussian import (
+    axis_aligned_slice_grid,
+    default_overlapping_gaussian_mixture,
+    evaluate_gaussian_mixture,
+    gaussian_mixture_tail_report,
+    laplace3d_gaussian_potential,
+    mesh_leaf_box_arrays,
+    nearest_axis_slice,
+    write_json_metadata,
+    write_npz,
+)
+from volumential.version import VERSION_TEXT
+
+
+SUMMARY_FIELDS = (
+    "case_id",
+    "mode",
+    "problem",
+    "dim",
+    "kernel",
+    "kernel_normalization",
+    "q_order",
+    "nlevels",
+    "adapt_steps",
+    "fmm_order",
+    "regular_quad_order",
+    "radial_quad_order",
+    "root_extent",
+    "n_targets",
+    "n_active_boxes",
+    "n_total_boxes",
+    "min_leaf_level",
+    "max_leaf_level",
+    "source_signed_mass_full_space",
+    "source_signed_mass_box",
+    "source_omitted_signed_mass",
+    "source_abs_mass_full_space",
+    "source_abs_mass_box",
+    "source_omitted_abs_mass",
+    "source_omitted_abs_fraction",
+    "quadrature_source_mass",
+    "table_get_s",
+    "table_build_s",
+    "table_load_s",
+    "table_payload_bytes",
+    "fmm_wall_s",
+    "rel_l2_vs_analytic_full_space",
+    "weighted_rel_l2_vs_analytic_full_space",
+    "linf_vs_analytic_full_space",
+)
+
+
+def _device_supports_fp64(device) -> bool:
+    extensions = set(getattr(device, "extensions", "").split())
+    return "cl_khr_fp64" in extensions or bool(getattr(device, "double_fp_config", 0))
+
+
+def _select_opencl_device(backend: str):
+    backend = backend.lower()
+    platforms = cl.get_platforms()
+
+    if backend == "pocl-cpu":
+        for platform_ in platforms:
+            if "portable computing language" in platform_.name.lower():
+                for device in platform_.get_devices():
+                    if device.type & cl.device_type.CPU and _device_supports_fp64(device):
+                        return device
+        raise RuntimeError("PoCL CPU device with fp64 support not found")
+
+    if backend == "cuda-gpu":
+        for platform_ in platforms:
+            if "nvidia cuda" in platform_.name.lower():
+                for device in platform_.get_devices():
+                    if device.type & cl.device_type.GPU and _device_supports_fp64(device):
+                        return device
+        raise RuntimeError("NVIDIA CUDA GPU device with fp64 support not found")
+
+    if backend != "auto":
+        raise ValueError("backend must be one of: auto, pocl-cpu, cuda-gpu")
+
+    for platform_ in platforms:
+        for device in platform_.get_devices():
+            if device.type & cl.device_type.GPU and _device_supports_fp64(device):
+                return device
+    for platform_ in platforms:
+        for device in platform_.get_devices():
+            if device.type & cl.device_type.CPU and _device_supports_fp64(device):
+                return device
+    raise RuntimeError("No OpenCL GPU/CPU device with fp64 support found")
+
+
+def _build_config(regular_quad_order: int, radial_quad_order: int):
+    from volumential.nearfield_potential_table import DuffyBuildConfig
+
+    return DuffyBuildConfig(
+        radial_rule="tanh-sinh-fast",
+        regular_quad_order=regular_quad_order,
+        radial_quad_order=radial_quad_order,
+    )
+
+
+def _build_mesh(queue, *, q_order: int, nlevels: int, root_radius: float, adapt_steps: int, adapt_fraction: float):
+    import volumential.meshgen as mg
+
+    mixture = default_overlapping_gaussian_mixture(3)
+    mesh = mg.MeshGen3D(q_order, nlevels, -root_radius, root_radius, queue=queue)
+    if adapt_steps and not (0.0 < adapt_fraction <= 1.0):
+        raise ValueError("adapt_fraction must be in (0, 1]")
+    for _ in range(adapt_steps):
+        indicator = np.abs(evaluate_gaussian_mixture(mixture, mesh.get_cell_centers()))
+        mesh.update_mesh(
+            indicator,
+            top_fraction_of_cells=adapt_fraction,
+            bottom_fraction_of_cells=0.0,
+        )
+    return mesh
+
+
+def _build_geometry(ctx, queue, *, q_order: int, nlevels: int, root_radius: float, adapt_steps: int, adapt_fraction: float):
+    import volumential.meshgen as mg
+
+    mesh = _build_mesh(
+        queue,
+        q_order=q_order,
+        nlevels=nlevels,
+        root_radius=root_radius,
+        adapt_steps=adapt_steps,
+        adapt_fraction=adapt_fraction,
+    )
+    bbox = np.array([[-root_radius, root_radius]] * 3, dtype=np.float64)
+    q_points, q_weights, tree, traversal = mg.build_geometry_info(
+        ctx,
+        queue,
+        3,
+        q_order,
+        mesh,
+        bbox=bbox,
+    )
+    return mesh, bbox, q_points, q_weights, tree, traversal
+
+
+def _get_table(
+    queue,
+    *,
+    cache_path: Path,
+    root_extent: float,
+    q_order: int,
+    regular_quad_order: int,
+    radial_quad_order: int,
+    force_recompute: bool,
+):
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with NearFieldInteractionTableManager(
+        str(cache_path), root_extent=root_extent, queue=queue
+    ) as table_manager:
+        table, _ = table_manager.get_table(
+            3,
+            "Laplace",
+            q_order,
+            force_recompute=force_recompute,
+            queue=queue,
+            build_config=_build_config(regular_quad_order, radial_quad_order),
+        )
+        timings = table_manager.last_get_table_timings
+    return table, timings
+
+
+def _build_wrangler(ctx, queue, traversal, table, *, q_order: int, fmm_order: int):
+    from sumpy.expansion import DefaultExpansionFactory
+    from sumpy.kernel import LaplaceKernel
+    from volumential.expansion_wrangler_fpnd import (
+        FPNDExpansionWrangler,
+        FPNDTreeIndependentDataForWrangler,
+    )
+
+    kernel = LaplaceKernel(3)
+    expn_factory = DefaultExpansionFactory()
+    local_expn_class = expn_factory.get_local_expansion_class(kernel)
+    mpole_expn_class = expn_factory.get_multipole_expansion_class(kernel)
+    tree_indep = FPNDTreeIndependentDataForWrangler(
+        ctx,
+        partial(mpole_expn_class, kernel),
+        partial(local_expn_class, kernel),
+        [kernel],
+        exclude_self=True,
+    )
+    self_extra_kwargs = {}
+    if traversal.tree.sources_are_targets:
+        self_extra_kwargs["target_to_source"] = np.arange(
+            traversal.tree.ntargets, dtype=np.int32
+        )
+    return FPNDExpansionWrangler(
+        tree_indep=tree_indep,
+        queue=queue,
+        traversal=traversal,
+        near_field_table=table,
+        dtype=np.float64,
+        fmm_level_to_order=lambda kernel, kernel_args, tree, lev: fmm_order,
+        quad_order=q_order,
+        self_extra_kwargs=self_extra_kwargs,
+    )
+
+
+def _coords_host(queue, q_points) -> np.ndarray:
+    return np.array([axis.get(queue) for axis in q_points], dtype=np.float64).T
+
+
+def _run_fmm(
+    ctx,
+    queue,
+    traversal,
+    table,
+    *,
+    q_order: int,
+    fmm_order: int,
+    q_weights,
+    source_host: np.ndarray,
+):
+    from volumential.volume_fmm import drive_volume_fmm
+
+    source_vals = cla.to_device(queue, np.ascontiguousarray(source_host.astype(np.float64)))
+    wrangler = _build_wrangler(
+        ctx,
+        queue,
+        traversal,
+        table,
+        q_order=q_order,
+        fmm_order=fmm_order,
+    )
+    queue.finish()
+    start = time.perf_counter()
+    (potential,) = drive_volume_fmm(
+        traversal,
+        wrangler,
+        source_vals * q_weights,
+        source_vals,
+        direct_evaluation=False,
+        list1_only=False,
+    )
+    queue.finish()
+    return potential.get(queue), time.perf_counter() - start
+
+
+def _table_phase_seconds(timings, phase: str) -> float | str:
+    if not timings:
+        return ""
+    details = timings.get(phase)
+    if not details:
+        return ""
+    return details.get("total_s", "")
+
+
+def _table_payload_bytes(timings) -> int | str:
+    if not timings:
+        return ""
+    details = timings.get("compute") or timings.get("load") or {}
+    return int(details.get("payload_bytes", 0)) if details else ""
+
+
+def _git_commit() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip()
+
+
+def _device_metadata(device) -> dict[str, Any]:
+    return {
+        "platform": device.platform.name,
+        "device": device.name,
+        "vendor": device.vendor,
+        "version": device.version,
+        "type": int(device.type),
+    }
+
+
+def _leaf_stats(leaf_arrays: dict[str, np.ndarray]) -> tuple[int, int]:
+    levels = leaf_arrays["leaf_levels"]
+    return int(np.min(levels)), int(np.max(levels))
+
+
+def run_benchmark(
+    *,
+    mode: str,
+    backend: str,
+    cache_dir: Path,
+    q_order: int,
+    nlevels: int,
+    adapt_steps: int,
+    adapt_fraction: float,
+    fmm_order: int,
+    regular_quad_order: int,
+    radial_quad_order: int,
+    root_radius: float,
+    force_recompute: bool,
+    slice_size: int,
+) -> dict[str, Any]:
+    mixture = default_overlapping_gaussian_mixture(3)
+    device = _select_opencl_device(backend)
+    ctx = cl.Context([device])
+    queue = cl.CommandQueue(ctx)
+
+    mesh, bbox, q_points, q_weights, tree, traversal = _build_geometry(
+        ctx,
+        queue,
+        q_order=q_order,
+        nlevels=nlevels,
+        root_radius=root_radius,
+        adapt_steps=adapt_steps,
+        adapt_fraction=adapt_fraction,
+    )
+    coords = _coords_host(queue, q_points)
+    weights = q_weights.get(queue)
+    source = evaluate_gaussian_mixture(mixture, coords)
+    reference = laplace3d_gaussian_potential(mixture, coords)
+
+    table, table_timings = _get_table(
+        queue,
+        cache_path=cache_dir / f"gaussian-free-space-laplace3d-q{q_order}.sqlite",
+        root_extent=2.0 * root_radius,
+        q_order=q_order,
+        regular_quad_order=regular_quad_order,
+        radial_quad_order=radial_quad_order,
+        force_recompute=force_recompute,
+    )
+    potential, fmm_wall_s = _run_fmm(
+        ctx,
+        queue,
+        traversal,
+        table,
+        q_order=q_order,
+        fmm_order=fmm_order,
+        q_weights=q_weights,
+        source_host=source,
+    )
+    error = potential - reference
+    reference_norm = max(float(np.linalg.norm(reference)), 1.0e-300)
+    weighted_reference_norm = max(float(np.sqrt(np.sum(weights * reference**2))), 1.0e-300)
+    tail = gaussian_mixture_tail_report(mixture, bbox)
+    leaf_arrays = mesh_leaf_box_arrays(mesh)
+    min_leaf_level, max_leaf_level = _leaf_stats(leaf_arrays)
+
+    case_id = f"gaussian-laplace3d-q{q_order}-l{nlevels}-a{adapt_steps}"
+    row = {
+        "case_id": case_id,
+        "mode": mode,
+        "problem": "gaussian-mixture-free-space",
+        "dim": 3,
+        "kernel": "Laplace",
+        "kernel_normalization": "sumpy_1_over_r",
+        "q_order": q_order,
+        "nlevels": nlevels,
+        "adapt_steps": adapt_steps,
+        "fmm_order": fmm_order,
+        "regular_quad_order": regular_quad_order,
+        "radial_quad_order": radial_quad_order,
+        "root_extent": 2.0 * root_radius,
+        "n_targets": int(tree.ntargets),
+        "n_active_boxes": int(mesh.n_active_cells()),
+        "n_total_boxes": int(mesh.n_cells()),
+        "min_leaf_level": min_leaf_level,
+        "max_leaf_level": max_leaf_level,
+        "source_signed_mass_full_space": tail["total_signed_mass"],
+        "source_signed_mass_box": tail["in_box_signed_mass"],
+        "source_omitted_signed_mass": tail["omitted_signed_mass"],
+        "source_abs_mass_full_space": tail["total_abs_component_mass"],
+        "source_abs_mass_box": tail["in_box_abs_component_mass"],
+        "source_omitted_abs_mass": tail["omitted_abs_component_mass"],
+        "source_omitted_abs_fraction": tail["omitted_abs_fraction"],
+        "quadrature_source_mass": float(np.sum(weights * source)),
+        "table_get_s": table_timings.get("total_s", "") if table_timings else "",
+        "table_build_s": _table_phase_seconds(table_timings, "compute"),
+        "table_load_s": _table_phase_seconds(table_timings, "load"),
+        "table_payload_bytes": _table_payload_bytes(table_timings),
+        "fmm_wall_s": fmm_wall_s,
+        "rel_l2_vs_analytic_full_space": float(np.linalg.norm(error) / reference_norm),
+        "weighted_rel_l2_vs_analytic_full_space": float(
+            np.sqrt(np.sum(weights * error**2)) / weighted_reference_norm
+        ),
+        "linf_vs_analytic_full_space": float(np.max(np.abs(error))),
+    }
+
+    node_slice = nearest_axis_slice(
+        coords,
+        {
+            "source": source,
+            "potential": potential,
+            "reference": reference,
+            "error": error,
+            "weights": weights,
+        },
+        axis=2,
+        value=0.0,
+    )
+    analytic_slice = axis_aligned_slice_grid(
+        bbox,
+        fixed_axis=2,
+        fixed_value=0.0,
+        shape=(slice_size, slice_size),
+    )
+    analytic_slice_source = evaluate_gaussian_mixture(mixture, analytic_slice.points)
+    analytic_slice_reference = laplace3d_gaussian_potential(mixture, analytic_slice.points)
+
+    arrays = {
+        "node_coords": coords,
+        "node_weights": weights,
+        "node_source": source,
+        "node_potential": potential,
+        "node_reference_full_space": reference,
+        "node_error": error,
+        "slice_node_coords": node_slice["coords"],
+        "slice_node_indices": node_slice["indices"],
+        "slice_node_axis_distances": node_slice["axis_distances"],
+        "slice_node_source": node_slice["source"],
+        "slice_node_potential": node_slice["potential"],
+        "slice_node_reference": node_slice["reference"],
+        "slice_node_error": node_slice["error"],
+        "slice_node_weights": node_slice["weights"],
+        "analytic_slice_coords": analytic_slice.points,
+        "analytic_slice_shape": np.asarray(analytic_slice.shape, dtype=np.int32),
+        "analytic_slice_axis0": analytic_slice.axis_values[0],
+        "analytic_slice_axis1": analytic_slice.axis_values[1],
+        "analytic_slice_source": analytic_slice_source,
+        "analytic_slice_reference": analytic_slice_reference,
+        **{f"tree_{name}": values for name, values in leaf_arrays.items()},
+    }
+    metadata = {
+        "case_id": case_id,
+        "mode": mode,
+        "problem": "gaussian-mixture-free-space",
+        "kernel": {
+            "name": "Laplace",
+            "dimension": 3,
+            "normalization": "sumpy_1_over_r",
+            "analytic_reference": "sum_i mass_i * erf(sqrt(alpha_i) r_i) / r_i",
+        },
+        "fixture": mixture.as_metadata(),
+        "bbox": bbox,
+        "tail": tail,
+        "discretization": {
+            "q_order": q_order,
+            "nlevels": nlevels,
+            "adapt_steps": adapt_steps,
+            "adapt_fraction": adapt_fraction,
+            "fmm_order": fmm_order,
+            "regular_quad_order": regular_quad_order,
+            "radial_quad_order": radial_quad_order,
+        },
+        "tree": {
+            "n_targets": int(tree.ntargets),
+            "n_active_boxes": int(mesh.n_active_cells()),
+            "n_total_boxes": int(mesh.n_cells()),
+            "min_leaf_level": min_leaf_level,
+            "max_leaf_level": max_leaf_level,
+        },
+        "slice": {
+            "node_slice_axis": int(node_slice["axis"]),
+            "node_slice_value": float(node_slice["value"]),
+            "node_slice_max_selected_distance": float(
+                node_slice["max_selected_distance"]
+            ),
+            "node_slice_count": int(node_slice["coords"].shape[0]),
+            "analytic_slice_shape": analytic_slice.shape,
+            "analytic_slice_axes": analytic_slice.axes,
+            "analytic_slice_fixed_axis": analytic_slice.fixed_axis,
+            "analytic_slice_fixed_value": analytic_slice.fixed_value,
+        },
+        "errors": {
+            "rel_l2_vs_analytic_full_space": row["rel_l2_vs_analytic_full_space"],
+            "weighted_rel_l2_vs_analytic_full_space": row[
+                "weighted_rel_l2_vs_analytic_full_space"
+            ],
+            "linf_vs_analytic_full_space": row["linf_vs_analytic_full_space"],
+        },
+        "timing": {
+            "table_get_s": row["table_get_s"],
+            "table_build_s": row["table_build_s"],
+            "table_load_s": row["table_load_s"],
+            "table_payload_bytes": row["table_payload_bytes"],
+            "fmm_wall_s": row["fmm_wall_s"],
+        },
+        "cache": {
+            "cache_dir": str(cache_dir),
+            "force_recompute": force_recompute,
+        },
+        "environment": {
+            "hostname": platform.node(),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "opencl_device": _device_metadata(device),
+        },
+        "volumential": {
+            "version": VERSION_TEXT,
+            "git_commit": _git_commit(),
+        },
+    }
+    return {"rows": [row], "arrays": arrays, "metadata": metadata}
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=SUMMARY_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
+    parser.add_argument("--backend", default="auto")
+    parser.add_argument("--q-order", type=int)
+    parser.add_argument("--nlevels", type=int)
+    parser.add_argument("--adapt-steps", type=int)
+    parser.add_argument("--adapt-fraction", type=float, default=0.35)
+    parser.add_argument("--fmm-order", type=int)
+    parser.add_argument("--regular-quad-order", type=int)
+    parser.add_argument("--radial-quad-order", type=int)
+    parser.add_argument("--root-radius", type=float, default=0.5)
+    parser.add_argument("--slice-size", type=int, default=64)
+    parser.add_argument("--force-recompute", action="store_true")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("build/benchmarks/gaussian-free-space.csv"),
+    )
+    parser.add_argument(
+        "--arrays-out",
+        type=Path,
+        default=Path("build/benchmarks/gaussian-free-space-arrays.npz"),
+    )
+    parser.add_argument(
+        "--metadata-out",
+        type=Path,
+        default=Path("build/benchmarks/gaussian-free-space-metadata.json"),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("build/benchmarks/gaussian-free-space-cache"),
+    )
+    args = parser.parse_args()
+
+    smoke = args.mode == "smoke"
+    q_order = args.q_order if args.q_order is not None else (2 if smoke else 3)
+    nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 3)
+    adapt_steps = args.adapt_steps if args.adapt_steps is not None else (0 if smoke else 1)
+    fmm_order = args.fmm_order if args.fmm_order is not None else (8 if smoke else 12)
+    regular_quad_order = (
+        args.regular_quad_order if args.regular_quad_order is not None else max(8, 4 * q_order)
+    )
+    radial_quad_order = (
+        args.radial_quad_order if args.radial_quad_order is not None else max(25, 10 * q_order)
+    )
+
+    result = run_benchmark(
+        mode=args.mode,
+        backend=args.backend,
+        cache_dir=args.cache_dir,
+        q_order=q_order,
+        nlevels=nlevels,
+        adapt_steps=adapt_steps,
+        adapt_fraction=args.adapt_fraction,
+        fmm_order=fmm_order,
+        regular_quad_order=regular_quad_order,
+        radial_quad_order=radial_quad_order,
+        root_radius=args.root_radius,
+        force_recompute=args.force_recompute,
+        slice_size=args.slice_size,
+    )
+    metadata = result["metadata"]
+    metadata["command"] = {
+        "argv": sys.argv,
+        "cwd": str(Path.cwd()),
+    }
+    metadata["outputs"] = {
+        "summary_csv": str(args.out),
+        "arrays_npz": str(args.arrays_out),
+        "metadata_json": str(args.metadata_out),
+    }
+    write_csv(args.out, result["rows"])
+    write_npz(args.arrays_out, **result["arrays"])
+    write_json_metadata(args.metadata_out, metadata)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -1,4 +1,5 @@
 import math
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -10,8 +11,18 @@ from volumential.gaussian import (
     evaluate_gaussian_mixture,
     gaussian_mixture_tail_report,
     laplace3d_gaussian_potential,
+    mesh_leaf_box_arrays,
     nearest_axis_slice,
+    write_json_metadata,
 )
+
+
+class _FakeDeviceArray:
+    def __init__(self, ary):
+        self._ary = np.asarray(ary)
+
+    def get(self):
+        return self._ary
 
 
 def test_evaluate_gaussian_mixture_accepts_point_or_axis_major_points():
@@ -93,6 +104,16 @@ def test_axis_aligned_slice_grid_embeds_2d_grid_in_3d_box():
     np.testing.assert_allclose(grid.axis_values[1], [-3.0, -1.0, 1.0, 3.0])
 
 
+def test_axis_aligned_slice_grid_rejects_degenerate_axes_and_outside_plane():
+    bbox = np.array([[-1.0, 1.0], [-2.0, 2.0], [-3.0, 3.0]])
+
+    with pytest.raises(ValueError, match="distinct non-fixed axes"):
+        axis_aligned_slice_grid(bbox, fixed_axis=2, axes=(0, 0))
+
+    with pytest.raises(ValueError, match="fixed_value"):
+        axis_aligned_slice_grid(bbox, fixed_axis=2, fixed_value=4.0)
+
+
 def test_nearest_axis_slice_selects_nearest_plane_and_fields():
     points = np.array(
         [
@@ -112,3 +133,33 @@ def test_nearest_axis_slice_selects_nearest_plane_and_fields():
     np.testing.assert_array_equal(result["indices"], [1, 2])
     np.testing.assert_allclose(result["value"], [11.0, 12.0])
     np.testing.assert_allclose(result["axis_distances"], [0.1, 0.1])
+
+
+def test_mesh_leaf_box_arrays_exports_active_leaf_geometry():
+    mesh = SimpleNamespace(
+        dim=2,
+        boxtree=SimpleNamespace(
+            active_boxes=_FakeDeviceArray([1, 3]),
+            box_levels=_FakeDeviceArray([0, 1, 1, 2]),
+            box_centers=_FakeDeviceArray(
+                [
+                    [0.0, 0.25, -0.25, 0.5],
+                    [0.0, -0.25, 0.25, 0.5],
+                ]
+            ),
+            root_extent=2.0,
+        ),
+    )
+
+    arrays = mesh_leaf_box_arrays(mesh)
+
+    np.testing.assert_array_equal(arrays["leaf_box_ids"], [1, 3])
+    np.testing.assert_array_equal(arrays["leaf_levels"], [1, 2])
+    np.testing.assert_allclose(arrays["leaf_centers"], [[0.25, -0.25], [0.5, 0.5]])
+    np.testing.assert_allclose(arrays["leaf_side_lengths"], [1.0, 0.5])
+    np.testing.assert_allclose(arrays["leaf_measures"], [1.0, 0.25])
+
+
+def test_write_json_metadata_rejects_nonfinite_values(tmp_path):
+    with pytest.raises(ValueError, match="non-finite"):
+        write_json_metadata(tmp_path / "metadata.json", {"bad": np.array([math.nan])})

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -1,0 +1,114 @@
+import math
+
+import numpy as np
+import pytest
+
+from volumential.gaussian import (
+    GaussianComponent,
+    GaussianMixture,
+    axis_aligned_slice_grid,
+    evaluate_gaussian_mixture,
+    gaussian_mixture_tail_report,
+    laplace3d_gaussian_potential,
+    nearest_axis_slice,
+)
+
+
+def test_evaluate_gaussian_mixture_accepts_point_or_axis_major_points():
+    mixture = GaussianMixture(
+        "two-bumps",
+        (
+            GaussianComponent(2.0, (0.0, 0.0), 1.0),
+            GaussianComponent(0.5, (1.0, 0.0), 4.0),
+        ),
+    )
+    points = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 0.5]])
+
+    values = evaluate_gaussian_mixture(mixture, points)
+    axis_major_values = evaluate_gaussian_mixture(mixture, points.T)
+
+    np.testing.assert_allclose(values, axis_major_values)
+    np.testing.assert_allclose(values[0], 2.0 + 0.5 * math.exp(-4.0))
+    np.testing.assert_allclose(values[1], 2.0 * math.exp(-1.0) + 0.5)
+
+
+def test_laplace3d_gaussian_potential_matches_center_limit_and_kernel_scale():
+    mixture = GaussianMixture(
+        "single",
+        (GaussianComponent(3.0, (0.0, 0.0, 0.0), 2.0),),
+    )
+
+    center_value = laplace3d_gaussian_potential(mixture, np.array([[0.0, 0.0, 0.0]]))[0]
+    classical_center_value = laplace3d_gaussian_potential(
+        mixture,
+        np.array([[0.0, 0.0, 0.0]]),
+        kernel_scale=1.0 / (4.0 * math.pi),
+    )[0]
+
+    assert center_value == pytest.approx(2.0 * math.pi * 3.0 / 2.0)
+    assert classical_center_value == pytest.approx(3.0 / (2.0 * 2.0))
+
+
+def test_laplace3d_gaussian_potential_matches_radial_closed_form():
+    amplitude = 1.25
+    alpha = 5.0
+    radius = 0.7
+    mixture = GaussianMixture(
+        "single",
+        (GaussianComponent(amplitude, (0.0, 0.0, 0.0), alpha),),
+    )
+
+    value = laplace3d_gaussian_potential(mixture, np.array([[radius, 0.0, 0.0]]))[0]
+    mass = amplitude * (math.pi / alpha) ** 1.5
+    expected = mass * math.erf(math.sqrt(alpha) * radius) / radius
+
+    assert value == pytest.approx(expected)
+
+
+def test_gaussian_tail_report_uses_separable_box_mass():
+    mixture = GaussianMixture(
+        "single-1d",
+        (GaussianComponent(1.0, (0.0,), 1.0),),
+    )
+
+    report = gaussian_mixture_tail_report(mixture, np.array([[-1.0, 1.0]]))
+
+    assert report["total_abs_component_mass"] == pytest.approx(math.sqrt(math.pi))
+    assert report["omitted_abs_fraction"] == pytest.approx(math.erfc(1.0))
+    assert report["components"][0]["omitted_abs_fraction"] == pytest.approx(math.erfc(1.0))
+
+
+def test_axis_aligned_slice_grid_embeds_2d_grid_in_3d_box():
+    grid = axis_aligned_slice_grid(
+        np.array([[-1.0, 1.0], [-2.0, 2.0], [-3.0, 3.0]]),
+        fixed_axis=1,
+        fixed_value=0.25,
+        shape=(3, 4),
+    )
+
+    assert grid.points.shape == (12, 3)
+    assert grid.shape == (3, 4)
+    np.testing.assert_allclose(grid.points[:, 1], 0.25)
+    np.testing.assert_allclose(grid.axis_values[0], [-1.0, 0.0, 1.0])
+    np.testing.assert_allclose(grid.axis_values[1], [-3.0, -1.0, 1.0, 3.0])
+
+
+def test_nearest_axis_slice_selects_nearest_plane_and_fields():
+    points = np.array(
+        [
+            [0.0, 0.0, -0.4],
+            [1.0, 0.0, -0.1],
+            [2.0, 0.0, 0.1],
+            [3.0, 0.0, 0.5],
+        ]
+    )
+    result = nearest_axis_slice(
+        points,
+        {"value": np.array([10.0, 11.0, 12.0, 13.0])},
+        axis=2,
+        value=0.0,
+    )
+
+    np.testing.assert_array_equal(result["indices"], [1, 2])
+    np.testing.assert_allclose(result["value"], [11.0, 12.0])
+    np.testing.assert_allclose(result["axis_distances"], [0.1, 0.1])

--- a/volumential/gaussian.py
+++ b/volumential/gaussian.py
@@ -273,8 +273,17 @@ def axis_aligned_slice_grid(
     if axes is None:
         computed_axes = tuple(axis for axis in range(3) if axis != fixed_axis)
         axes = (computed_axes[0], computed_axes[1])
-    if len(axes) != 2 or fixed_axis in axes or any(axis < 0 or axis >= 3 for axis in axes):
-        raise ValueError("axes must contain the two non-fixed axes")
+    if len(axes) != 2:
+        raise ValueError("axes must contain two distinct non-fixed axes")
+    axes = (int(axes[0]), int(axes[1]))
+    if (
+        len(set(axes)) != 2
+        or fixed_axis in axes
+        or any(axis < 0 or axis >= 3 for axis in axes)
+    ):
+        raise ValueError("axes must contain two distinct non-fixed axes")
+    if not (bbox[fixed_axis, 0] <= fixed_value <= bbox[fixed_axis, 1]):
+        raise ValueError("fixed_value must lie within bbox[fixed_axis]")
     if len(shape) != 2 or shape[0] < 2 or shape[1] < 2:
         raise ValueError("shape must contain two entries >= 2")
 
@@ -366,9 +375,13 @@ def mesh_leaf_box_arrays(mesh: Any) -> dict[str, np.ndarray]:
 
 def _json_safe(value: Any) -> Any:
     if isinstance(value, np.ndarray):
-        return value.tolist()
+        return _json_safe(value.tolist())
     if isinstance(value, np.generic):
-        return value.item()
+        return _json_safe(value.item())
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("metadata contains a non-finite float")
+        return value
     if isinstance(value, dict):
         return {str(key): _json_safe(val) for key, val in value.items()}
     if isinstance(value, (list, tuple)):
@@ -381,7 +394,10 @@ def write_json_metadata(path: Path, metadata: dict[str, Any]) -> None:
 
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(_json_safe(metadata), indent=2, sort_keys=True) + "\n")
+    path.write_text(
+        json.dumps(_json_safe(metadata), allow_nan=False, indent=2, sort_keys=True)
+        + "\n"
+    )
 
 
 def write_npz(path: Path, **arrays: np.ndarray) -> None:

--- a/volumential/gaussian.py
+++ b/volumential/gaussian.py
@@ -1,0 +1,392 @@
+"""Gaussian source fixtures and exports for free-space volume-potential demos."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.special import erf
+
+
+@dataclass(frozen=True)
+class GaussianComponent:
+    """One isotropic Gaussian component ``amplitude * exp(-alpha * |x-c|^2)``."""
+
+    amplitude: float
+    center: tuple[float, ...]
+    alpha: float
+
+    def __post_init__(self) -> None:
+        center = tuple(float(value) for value in self.center)
+        if not center:
+            raise ValueError("center must have at least one coordinate")
+        if not np.all(np.isfinite(center)):
+            raise ValueError("center coordinates must be finite")
+        if not math.isfinite(float(self.amplitude)):
+            raise ValueError("amplitude must be finite")
+        if not math.isfinite(float(self.alpha)) or float(self.alpha) <= 0:
+            raise ValueError("alpha must be finite and positive")
+
+        object.__setattr__(self, "amplitude", float(self.amplitude))
+        object.__setattr__(self, "center", center)
+        object.__setattr__(self, "alpha", float(self.alpha))
+
+    @property
+    def dim(self) -> int:
+        return len(self.center)
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "amplitude": self.amplitude,
+            "center": list(self.center),
+            "alpha": self.alpha,
+        }
+
+
+@dataclass(frozen=True)
+class GaussianMixture:
+    """A named collection of compatible :class:`GaussianComponent` objects."""
+
+    name: str
+    components: tuple[GaussianComponent, ...]
+
+    def __post_init__(self) -> None:
+        components = tuple(self.components)
+        if not components:
+            raise ValueError("components must not be empty")
+        dim = components[0].dim
+        if any(component.dim != dim for component in components):
+            raise ValueError("all Gaussian components must have the same dimension")
+        object.__setattr__(self, "components", components)
+
+    @property
+    def dim(self) -> int:
+        return self.components[0].dim
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "dim": self.dim,
+            "components": [component.as_metadata() for component in self.components],
+        }
+
+
+def default_overlapping_gaussian_mixture(dim: int = 3) -> GaussianMixture:
+    """Return a deterministic positive overlapping mixture for smoke demos."""
+
+    if dim < 1 or dim > 3:
+        raise ValueError("default mixture is available for dimensions 1, 2, or 3")
+
+    return GaussianMixture(
+        name=f"overlapping-gaussian-mixture-{dim}d",
+        components=(
+            GaussianComponent(1.0, (-0.10, 0.04, -0.05)[:dim], 75.0),
+            GaussianComponent(0.70, (0.08, -0.07, 0.06)[:dim], 55.0),
+        ),
+    )
+
+
+def _as_points(points: np.ndarray, dim: int | None = None) -> np.ndarray:
+    points = np.asarray(points, dtype=np.float64)
+    if points.ndim != 2:
+        raise ValueError("points must have shape (npoints, dim) or (dim, npoints)")
+    if dim is None:
+        if 1 <= points.shape[1] <= 3:
+            return np.ascontiguousarray(points)
+        if 1 <= points.shape[0] <= 3:
+            return np.ascontiguousarray(points.T)
+        raise ValueError("could not infer point dimension")
+    if points.shape[1] == dim:
+        return np.ascontiguousarray(points)
+    if points.shape[0] == dim:
+        return np.ascontiguousarray(points.T)
+    raise ValueError(f"points do not match dimension {dim}")
+
+
+def _as_bbox(bbox: np.ndarray, dim: int | None = None) -> np.ndarray:
+    bbox = np.asarray(bbox, dtype=np.float64)
+    if bbox.ndim != 2 or bbox.shape[1] != 2:
+        raise ValueError("bbox must have shape (dim, 2)")
+    if dim is not None and bbox.shape[0] != dim:
+        raise ValueError(f"bbox does not match dimension {dim}")
+    if not np.all(np.isfinite(bbox)):
+        raise ValueError("bbox entries must be finite")
+    if np.any(bbox[:, 1] <= bbox[:, 0]):
+        raise ValueError("bbox upper bounds must exceed lower bounds")
+    return np.ascontiguousarray(bbox)
+
+
+def evaluate_gaussian_mixture(mixture: GaussianMixture, points: np.ndarray) -> np.ndarray:
+    """Evaluate the source density at ``points``."""
+
+    points = _as_points(points, mixture.dim)
+    result = np.zeros(points.shape[0], dtype=np.float64)
+    for component in mixture.components:
+        center = np.asarray(component.center, dtype=np.float64)
+        radius_sq = np.sum((points - center) ** 2, axis=1)
+        result += component.amplitude * np.exp(-component.alpha * radius_sq)
+    return result
+
+
+def laplace3d_gaussian_potential(
+    mixture: GaussianMixture,
+    points: np.ndarray,
+    *,
+    kernel_scale: float = 1.0,
+) -> np.ndarray:
+    """Evaluate the full-space 3D Laplace potential of ``mixture``.
+
+    The default ``kernel_scale=1`` matches Volumential/Sumpy's 3D Laplace
+    convention ``K(x, y) = 1 / |x-y|``. Use ``kernel_scale=1/(4*pi)`` for the
+    classical Green's function normalization.
+    """
+
+    if mixture.dim != 3:
+        raise ValueError("the analytic Laplace Gaussian reference is 3D-only")
+
+    points = _as_points(points, 3)
+    result = np.zeros(points.shape[0], dtype=np.float64)
+    for component in mixture.components:
+        center = np.asarray(component.center, dtype=np.float64)
+        radius = np.linalg.norm(points - center, axis=1)
+        sqrt_alpha = math.sqrt(component.alpha)
+        component_mass = component.amplitude * (math.pi / component.alpha) ** 1.5
+
+        contribution = np.empty_like(radius)
+        small = sqrt_alpha * radius < 1.0e-8
+        regular = ~small
+        contribution[regular] = (
+            component_mass * erf(sqrt_alpha * radius[regular]) / radius[regular]
+        )
+        contribution[small] = (
+            2.0
+            * math.pi
+            * component.amplitude
+            / component.alpha
+            * (1.0 - component.alpha * radius[small] ** 2 / 3.0)
+        )
+        result += contribution
+
+    return float(kernel_scale) * result
+
+
+def _component_shape_mass(component: GaussianComponent) -> float:
+    return (math.pi / component.alpha) ** (component.dim / 2.0)
+
+
+def _component_box_shape_mass(component: GaussianComponent, bbox: np.ndarray) -> float:
+    sqrt_alpha = math.sqrt(component.alpha)
+    factor = math.sqrt(math.pi) / (2.0 * sqrt_alpha)
+    integral = 1.0
+    for axis, center in enumerate(component.center):
+        lo, hi = bbox[axis]
+        integral *= factor * (
+            math.erf(sqrt_alpha * (hi - center))
+            - math.erf(sqrt_alpha * (lo - center))
+        )
+    return integral
+
+
+def gaussian_mixture_tail_report(
+    mixture: GaussianMixture,
+    bbox: np.ndarray,
+) -> dict[str, Any]:
+    """Report signed and absolute Gaussian mass omitted outside ``bbox``."""
+
+    bbox = _as_bbox(bbox, mixture.dim)
+    total_signed = 0.0
+    total_abs = 0.0
+    in_box_signed = 0.0
+    in_box_abs = 0.0
+    component_reports = []
+
+    for component in mixture.components:
+        full_shape = _component_shape_mass(component)
+        box_shape = _component_box_shape_mass(component, bbox)
+        full_signed = component.amplitude * full_shape
+        box_signed = component.amplitude * box_shape
+        full_abs = abs(component.amplitude) * full_shape
+        box_abs = abs(component.amplitude) * box_shape
+        omitted_signed = full_signed - box_signed
+        omitted_abs = max(full_abs - box_abs, 0.0)
+
+        total_signed += full_signed
+        total_abs += full_abs
+        in_box_signed += box_signed
+        in_box_abs += box_abs
+        component_reports.append(
+            {
+                **component.as_metadata(),
+                "full_signed_mass": full_signed,
+                "in_box_signed_mass": box_signed,
+                "omitted_signed_mass": omitted_signed,
+                "full_abs_mass": full_abs,
+                "in_box_abs_mass": box_abs,
+                "omitted_abs_mass": omitted_abs,
+                "omitted_abs_fraction": omitted_abs / full_abs if full_abs else 0.0,
+            }
+        )
+
+    omitted_signed = total_signed - in_box_signed
+    omitted_abs = max(total_abs - in_box_abs, 0.0)
+    return {
+        "mixture": mixture.as_metadata(),
+        "bbox": bbox.tolist(),
+        "total_signed_mass": total_signed,
+        "in_box_signed_mass": in_box_signed,
+        "omitted_signed_mass": omitted_signed,
+        "total_abs_component_mass": total_abs,
+        "in_box_abs_component_mass": in_box_abs,
+        "omitted_abs_component_mass": omitted_abs,
+        "omitted_abs_fraction": omitted_abs / total_abs if total_abs else 0.0,
+        "components": component_reports,
+    }
+
+
+@dataclass(frozen=True)
+class SliceGrid:
+    points: np.ndarray
+    shape: tuple[int, int]
+    axes: tuple[int, int]
+    fixed_axis: int
+    fixed_value: float
+    axis_values: tuple[np.ndarray, np.ndarray]
+
+
+def axis_aligned_slice_grid(
+    bbox: np.ndarray,
+    *,
+    fixed_axis: int = 2,
+    fixed_value: float = 0.0,
+    axes: tuple[int, int] | None = None,
+    shape: tuple[int, int] = (64, 64),
+) -> SliceGrid:
+    """Create a 2D Cartesian slice grid embedded in a 3D bounding box."""
+
+    bbox = _as_bbox(bbox, 3)
+    if fixed_axis < 0 or fixed_axis >= 3:
+        raise ValueError("fixed_axis must be 0, 1, or 2")
+    if axes is None:
+        computed_axes = tuple(axis for axis in range(3) if axis != fixed_axis)
+        axes = (computed_axes[0], computed_axes[1])
+    if len(axes) != 2 or fixed_axis in axes or any(axis < 0 or axis >= 3 for axis in axes):
+        raise ValueError("axes must contain the two non-fixed axes")
+    if len(shape) != 2 or shape[0] < 2 or shape[1] < 2:
+        raise ValueError("shape must contain two entries >= 2")
+
+    axis0 = np.linspace(bbox[axes[0], 0], bbox[axes[0], 1], int(shape[0]))
+    axis1 = np.linspace(bbox[axes[1], 0], bbox[axes[1], 1], int(shape[1]))
+    grid0, grid1 = np.meshgrid(axis0, axis1, indexing="ij")
+    points = np.zeros((grid0.size, 3), dtype=np.float64)
+    points[:, fixed_axis] = fixed_value
+    points[:, axes[0]] = grid0.ravel()
+    points[:, axes[1]] = grid1.ravel()
+    return SliceGrid(
+        points=points,
+        shape=(int(shape[0]), int(shape[1])),
+        axes=axes,
+        fixed_axis=int(fixed_axis),
+        fixed_value=float(fixed_value),
+        axis_values=(axis0, axis1),
+    )
+
+
+def nearest_axis_slice(
+    points: np.ndarray,
+    fields: dict[str, np.ndarray] | None = None,
+    *,
+    axis: int = 2,
+    value: float = 0.0,
+    atol: float | None = None,
+) -> dict[str, Any]:
+    """Extract nodes on the plane nearest to ``points[:, axis] == value``."""
+
+    points = _as_points(points)
+    if axis < 0 or axis >= points.shape[1]:
+        raise ValueError("axis is outside the point dimension")
+
+    distances = np.abs(points[:, axis] - float(value))
+    if atol is None:
+        min_distance = float(np.min(distances))
+        tolerance = max(1.0e-14, 1.0e-12 * max(abs(min_distance), 1.0))
+        mask = np.abs(distances - min_distance) <= tolerance
+    else:
+        if atol < 0:
+            raise ValueError("atol must be non-negative")
+        mask = distances <= atol
+
+    indices = np.nonzero(mask)[0]
+    result: dict[str, Any] = {
+        "coords": points[indices],
+        "indices": indices.astype(np.int64),
+        "axis_distances": distances[indices],
+        "axis": int(axis),
+        "value": float(value),
+        "max_selected_distance": float(np.max(distances[indices])) if indices.size else math.nan,
+    }
+
+    if fields is not None:
+        for name, values in fields.items():
+            values = np.asarray(values)
+            if values.shape[0] != points.shape[0]:
+                raise ValueError(f"field {name!r} does not match the point count")
+            result[name] = values[indices]
+
+    return result
+
+
+def _host_array(value: Any) -> np.ndarray:
+    if hasattr(value, "get"):
+        return np.asarray(value.get())
+    return np.asarray(value)
+
+
+def mesh_leaf_box_arrays(mesh: Any) -> dict[str, np.ndarray]:
+    """Return host arrays describing the active leaf boxes of a Volumential mesh."""
+
+    boxtree = mesh.boxtree
+    leaf_box_ids = _host_array(boxtree.active_boxes).astype(np.int64)
+    all_levels = _host_array(boxtree.box_levels).astype(np.int32)
+    all_centers = _host_array(boxtree.box_centers).astype(np.float64)
+    levels = all_levels[leaf_box_ids]
+    centers = all_centers[:, leaf_box_ids].T
+    side_lengths = boxtree.root_extent / np.power(2.0, levels)
+    return {
+        "leaf_box_ids": leaf_box_ids,
+        "leaf_centers": centers,
+        "leaf_levels": levels,
+        "leaf_side_lengths": side_lengths.astype(np.float64),
+        "leaf_measures": (side_lengths**mesh.dim).astype(np.float64),
+    }
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(val) for val in value]
+    return value
+
+
+def write_json_metadata(path: Path, metadata: dict[str, Any]) -> None:
+    """Write JSON metadata with NumPy values converted to plain Python values."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_json_safe(metadata), indent=2, sort_keys=True) + "\n")
+
+
+def write_npz(path: Path, **arrays: np.ndarray) -> None:
+    """Write NumPy arrays, creating the parent directory when needed."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(path, **arrays)

--- a/volumential/gaussian.py
+++ b/volumential/gaussian.py
@@ -140,9 +140,9 @@ def laplace3d_gaussian_potential(
 ) -> np.ndarray:
     """Evaluate the full-space 3D Laplace potential of ``mixture``.
 
-    The default ``kernel_scale=1`` matches Volumential/Sumpy's 3D Laplace
-    convention ``K(x, y) = 1 / |x-y|``. Use ``kernel_scale=1/(4*pi)`` for the
-    classical Green's function normalization.
+    The default ``kernel_scale=1`` gives the unnormalized kernel
+    ``K(x, y) = 1 / |x-y|``. Use ``kernel_scale=1/(4*pi)`` for the classical
+    Green's function normalization used by Sumpy's 3D Laplace global scaling.
     """
 
     if mixture.dim != 3:

--- a/volumential/nearfield_potential_table.py
+++ b/volumential/nearfield_potential_table.py
@@ -377,7 +377,7 @@ def sumpy_kernel_to_lambda(sknl, fallback_dim=None, parameter_values=None):
             "get_expression and get_global_scaling_const methods"
         )
 
-    from sympy import Symbol, lambdify, symbols
+    from sympy import Matrix, Symbol, lambdify, symbols
 
     import scipy.special as sp
 
@@ -392,11 +392,12 @@ def sumpy_kernel_to_lambda(sknl, fallback_dim=None, parameter_values=None):
     var_names = " ".join([var_name_prefix + str(i) for i in range(dim)])
     arg_names = symbols(var_names)
     args = [Symbol(var_name_prefix + str(i)) for i in range(dim)]
+    arg_vec = Matrix(args)
 
     expr = (
         sknl.postprocess_at_target(
-            sknl.postprocess_at_source(sknl.get_expression(args), args),
-            args,
+            sknl.postprocess_at_source(sknl.get_expression(args), arg_vec),
+            arg_vec,
         )
         * sknl.get_global_scaling_const()
     )


### PR DESCRIPTION
Closes xywei/boxcode-paper#142.

## Summary

- Add reusable Gaussian mixture fixtures, analytic 3D Laplace free-space references, and separable tail-mass accounting.
- Add slice extraction, Cartesian slice grids, mesh leaf-box export helpers, and strict JSON/NPZ artifact writers.
- Add `benchmarks/gaussian_free_space.py` to emit summary CSV, field/error arrays, and metadata for Paper 1 plotting.
- Scale the benchmark analytic reference to Sumpy's 3D Laplace global scaling and include root extent in cache filenames.
- Wire the new Gaussian smoke benchmark into the existing examples-smoke CI path.
- Fix `sumpy_kernel_to_lambda` for newer `sumpy` postprocessors that expect SymPy vector objects.

## Verification

- `python -m py_compile volumential/nearfield_potential_table.py volumential/gaussian.py benchmarks/gaussian_free_space.py test/test_gaussian.py`
- Direct importlib checks for Gaussian evaluation, unscaled/scaled analytic center values, strict JSON validation, and tail fraction
- `git diff --check`

Local pytest was not runnable in this environment because `sumpy` is not installed; CI runs with the project dependency setup.