### PR TITLE
feat(bench): add DMK effective-density diagnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           python benchmarks/table_equivalence_cache.py --mode smoke
           python benchmarks/accuracy_preservation.py --mode smoke
           python benchmarks/gaussian_free_space.py --mode smoke --slice-size 8
+          python benchmarks/dmk_effective_density.py --mode smoke --slice-size 8
           python benchmarks/adaptive_timing.py --mode smoke
           python benchmarks/performance_suite.py --list-cases
           python benchmarks/performance_suite.py --mode smoke --dry-run

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,3 +80,17 @@ python benchmarks/adaptive_timing.py --mode smoke --out build/benchmarks/adaptiv
 ```
 
 The benchmark runs 2D Laplace evaluations on deterministically adapted meshes and writes one cold-cache and one warm-cache row per case. Rows report mesh/adaptation setup, geometry construction, table build or load, FMM wall time, and the timing categories exposed by `drive_volume_fmm`. Full paper runs should be wrapped with the paper repository metadata tool before their CSVs are promoted to manuscript data.
+
+## DMK Effective-Density Diagnostic
+
+```bash
+python benchmarks/dmk_effective_density.py --mode smoke --slice-size 8
+```
+
+The benchmark isolates a controlled 3D Laplace Gaussian split with multiplier
+`exp(-sigma^2 |k|^2 / 2) / |k|^2`, defines `rho_eff` by
+`K * rho_eff = K_sigma * rho`, applies Volumential's singular Laplace path to
+the analytic Gaussian-filtered density, and writes CSV/JSON/NPZ diagnostics. It
+records the source Gaussian variance, the DMK-style split scale
+`sigma = box_side_length / sqrt(log(1/epsilon))`, and the fact that residual SOG
+terms are not part of this controlled smoke diagnostic.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -93,4 +93,6 @@ The benchmark isolates a controlled 3D Laplace Gaussian split with multiplier
 the analytic Gaussian-filtered density, and writes CSV/JSON/NPZ diagnostics. It
 records the source Gaussian variance, the DMK-style split scale
 `sigma = box_side_length / sqrt(log(1/epsilon))`, and the fact that residual SOG
-terms are not part of this controlled smoke diagnostic.
+terms are not part of this controlled diagnostic. Smoke mode defaults to a
+uniform `q=4`, `nlevels=2` run so the split-vs-Volumential comparison is
+meaningful while remaining lightweight.

--- a/benchmarks/dmk_effective_density.py
+++ b/benchmarks/dmk_effective_density.py
@@ -166,7 +166,11 @@ def run_benchmark(
     coords = _coords_host(queue, q_points)
     weights = q_weights.get(queue)
     root_extent = 2.0 * root_radius
-    split_box_side_length = root_extent / (2**nlevels)
+    leaf_arrays = mesh_leaf_box_arrays(mesh)
+    leaf_side_lengths = leaf_arrays["leaf_side_lengths"]
+    split_box_side_length = float(np.max(leaf_side_lengths))
+    if not np.allclose(leaf_side_lengths, split_box_side_length):
+        raise RuntimeError("DMK effective-density diagnostic expects a uniform mesh")
     if split_sigma is None:
         split_sigma = dmk_gaussian_split_sigma(split_box_side_length, split_epsilon)
 
@@ -202,7 +206,6 @@ def run_benchmark(
         source_host=effective_density,
     )
 
-    leaf_arrays = mesh_leaf_box_arrays(mesh)
     min_leaf_level, max_leaf_level = _leaf_stats(leaf_arrays)
     source_tail = gaussian_mixture_tail_report(mixture, bbox)
     effective_tail = gaussian_mixture_tail_report(effective_mixture, bbox)
@@ -484,7 +487,7 @@ def main() -> int:
     args = parser.parse_args()
 
     smoke = args.mode == "smoke"
-    q_order = args.q_order if args.q_order is not None else (4 if smoke else 3)
+    q_order = args.q_order if args.q_order is not None else 4
     nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 3)
     fmm_order = args.fmm_order if args.fmm_order is not None else (10 if smoke else 12)
     regular_quad_order = (

--- a/benchmarks/dmk_effective_density.py
+++ b/benchmarks/dmk_effective_density.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""Run a controlled DMK-style effective-density diagnostic.
+
+This benchmark does not implement full adaptive DMK. It isolates one
+translation-invariant Gaussian kernel split for the 3D Laplace Green's function
+
+    K(x) = 1 / (4*pi*|x|),      K_hat(k) = 1 / |k|^2,
+
+using the smooth split multiplier
+
+    K_sigma_hat(k) = exp(-sigma^2 |k|^2 / 2) / |k|^2.
+
+The effective density is therefore defined by
+
+    K * rho_eff = K_sigma * rho,
+    rho_eff_hat(k) = exp(-sigma^2 |k|^2 / 2) rho_hat(k).
+
+For a Gaussian source this filtered density is analytic, so the diagnostic can
+apply Volumential's singular 3D Laplace path to rho_eff and compare it against
+the analytic split potential and the unsmoothed analytic reference. The source
+Gaussian variance, DMK-style split scale sigma, and residual SOG approximation
+status are recorded separately in the emitted metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyopencl as cl
+
+from gaussian_free_space import (  # noqa: PLC2701 - sibling benchmark helper reuse
+    _build_geometry,
+    _coords_host,
+    _device_metadata,
+    _get_table,
+    _git_commit,
+    _leaf_stats,
+    _run_fmm,
+    _select_opencl_device,
+    _table_payload_bytes,
+    _table_phase_seconds,
+)
+from volumential.gaussian import (
+    GaussianComponent,
+    GaussianMixture,
+    axis_aligned_slice_grid,
+    dmk_gaussian_split_sigma,
+    evaluate_gaussian_mixture,
+    gaussian_filter_mixture,
+    gaussian_mixture_tail_report,
+    laplace3d_gaussian_potential,
+    mesh_leaf_box_arrays,
+    nearest_axis_slice,
+    write_json_metadata,
+    write_npz,
+)
+from volumential.version import VERSION_TEXT
+
+
+SUMMARY_FIELDS = (
+    "case_id",
+    "mode",
+    "problem",
+    "dim",
+    "kernel",
+    "kernel_normalization",
+    "split_multiplier",
+    "effective_density_multiplier",
+    "source_alpha",
+    "source_variance_per_axis",
+    "split_epsilon",
+    "split_sigma",
+    "split_box_side_length",
+    "residual_sog_terms",
+    "q_order",
+    "nlevels",
+    "fmm_order",
+    "regular_quad_order",
+    "radial_quad_order",
+    "root_extent",
+    "n_targets",
+    "n_active_boxes",
+    "n_total_boxes",
+    "min_leaf_level",
+    "max_leaf_level",
+    "source_omitted_abs_fraction",
+    "effective_omitted_abs_fraction",
+    "quadrature_source_mass",
+    "quadrature_effective_mass",
+    "table_get_s",
+    "table_build_s",
+    "table_load_s",
+    "table_payload_bytes",
+    "fmm_wall_s",
+    "rel_l2_volumential_vs_split",
+    "weighted_rel_l2_volumential_vs_split",
+    "linf_volumential_vs_split",
+    "rel_l2_split_bias_vs_reference",
+    "weighted_rel_l2_split_bias_vs_reference",
+    "linf_split_bias_vs_reference",
+    "rel_l2_volumential_vs_reference",
+    "weighted_rel_l2_volumential_vs_reference",
+    "linf_volumential_vs_reference",
+)
+
+
+def _source_mixture(source_alpha: float) -> GaussianMixture:
+    return GaussianMixture(
+        name="dmk-effective-density-source-3d",
+        components=(GaussianComponent(1.0, (0.0, 0.0, 0.0), source_alpha),),
+    )
+
+
+def _safe_rel_l2(error: np.ndarray, reference: np.ndarray) -> float:
+    return float(np.linalg.norm(error) / max(float(np.linalg.norm(reference)), 1.0e-300))
+
+
+def _safe_weighted_rel_l2(error: np.ndarray, reference: np.ndarray, weights: np.ndarray) -> float:
+    return float(
+        np.sqrt(np.sum(weights * error**2))
+        / max(float(np.sqrt(np.sum(weights * reference**2))), 1.0e-300)
+    )
+
+
+def _root_extent_tag(root_extent: float) -> str:
+    return f"extent{root_extent:.12g}".replace("-", "m").replace(".", "p")
+
+
+def run_benchmark(
+    *,
+    mode: str,
+    backend: str,
+    cache_dir: Path,
+    q_order: int,
+    nlevels: int,
+    fmm_order: int,
+    regular_quad_order: int,
+    radial_quad_order: int,
+    root_radius: float,
+    source_alpha: float,
+    split_epsilon: float,
+    split_sigma: float | None,
+    force_recompute: bool,
+    slice_size: int,
+) -> dict[str, Any]:
+    mixture = _source_mixture(source_alpha)
+    device = _select_opencl_device(backend)
+    ctx = cl.Context([device])
+    queue = cl.CommandQueue(ctx)
+
+    mesh, bbox, q_points, q_weights, tree, traversal = _build_geometry(
+        ctx,
+        queue,
+        q_order=q_order,
+        nlevels=nlevels,
+        root_radius=root_radius,
+        adapt_steps=0,
+        adapt_fraction=0.35,
+    )
+    coords = _coords_host(queue, q_points)
+    weights = q_weights.get(queue)
+    root_extent = 2.0 * root_radius
+    split_box_side_length = root_extent / (2**nlevels)
+    if split_sigma is None:
+        split_sigma = dmk_gaussian_split_sigma(split_box_side_length, split_epsilon)
+
+    effective_mixture = gaussian_filter_mixture(mixture, split_sigma)
+    source = evaluate_gaussian_mixture(mixture, coords)
+    effective_density = evaluate_gaussian_mixture(effective_mixture, coords)
+    kernel_scale = 1.0 / (4.0 * np.pi)
+    analytic_reference = laplace3d_gaussian_potential(
+        mixture, coords, kernel_scale=kernel_scale
+    )
+    analytic_split = laplace3d_gaussian_potential(
+        effective_mixture, coords, kernel_scale=kernel_scale
+    )
+
+    table, table_timings = _get_table(
+        queue,
+        cache_path=cache_dir
+        / f"dmk-effective-density-laplace3d-q{q_order}-{_root_extent_tag(root_extent)}.sqlite",
+        root_extent=root_extent,
+        q_order=q_order,
+        regular_quad_order=regular_quad_order,
+        radial_quad_order=radial_quad_order,
+        force_recompute=force_recompute,
+    )
+    potential, fmm_wall_s = _run_fmm(
+        ctx,
+        queue,
+        traversal,
+        table,
+        q_order=q_order,
+        fmm_order=fmm_order,
+        q_weights=q_weights,
+        source_host=effective_density,
+    )
+
+    leaf_arrays = mesh_leaf_box_arrays(mesh)
+    min_leaf_level, max_leaf_level = _leaf_stats(leaf_arrays)
+    source_tail = gaussian_mixture_tail_report(mixture, bbox)
+    effective_tail = gaussian_mixture_tail_report(effective_mixture, bbox)
+    error_vs_split = potential - analytic_split
+    split_bias = analytic_split - analytic_reference
+    error_vs_reference = potential - analytic_reference
+    case_id = f"dmk-effective-density-laplace3d-q{q_order}-l{nlevels}"
+
+    row = {
+        "case_id": case_id,
+        "mode": mode,
+        "problem": "controlled-gaussian-split-effective-density",
+        "dim": 3,
+        "kernel": "Laplace",
+        "kernel_normalization": "sumpy_global_scaling_1_over_4pi_r",
+        "split_multiplier": "exp(-sigma^2*|k|^2/2)/|k|^2",
+        "effective_density_multiplier": "exp(-sigma^2*|k|^2/2)",
+        "source_alpha": source_alpha,
+        "source_variance_per_axis": 1.0 / (2.0 * source_alpha),
+        "split_epsilon": split_epsilon,
+        "split_sigma": split_sigma,
+        "split_box_side_length": split_box_side_length,
+        "residual_sog_terms": 0,
+        "q_order": q_order,
+        "nlevels": nlevels,
+        "fmm_order": fmm_order,
+        "regular_quad_order": regular_quad_order,
+        "radial_quad_order": radial_quad_order,
+        "root_extent": root_extent,
+        "n_targets": int(tree.ntargets),
+        "n_active_boxes": int(mesh.n_active_cells()),
+        "n_total_boxes": int(mesh.n_cells()),
+        "min_leaf_level": min_leaf_level,
+        "max_leaf_level": max_leaf_level,
+        "source_omitted_abs_fraction": source_tail["omitted_abs_fraction"],
+        "effective_omitted_abs_fraction": effective_tail["omitted_abs_fraction"],
+        "quadrature_source_mass": float(np.sum(weights * source)),
+        "quadrature_effective_mass": float(np.sum(weights * effective_density)),
+        "table_get_s": table_timings.get("total_s", "") if table_timings else "",
+        "table_build_s": _table_phase_seconds(table_timings, "compute"),
+        "table_load_s": _table_phase_seconds(table_timings, "load"),
+        "table_payload_bytes": _table_payload_bytes(table_timings),
+        "fmm_wall_s": fmm_wall_s,
+        "rel_l2_volumential_vs_split": _safe_rel_l2(error_vs_split, analytic_split),
+        "weighted_rel_l2_volumential_vs_split": _safe_weighted_rel_l2(
+            error_vs_split, analytic_split, weights
+        ),
+        "linf_volumential_vs_split": float(np.max(np.abs(error_vs_split))),
+        "rel_l2_split_bias_vs_reference": _safe_rel_l2(split_bias, analytic_reference),
+        "weighted_rel_l2_split_bias_vs_reference": _safe_weighted_rel_l2(
+            split_bias, analytic_reference, weights
+        ),
+        "linf_split_bias_vs_reference": float(np.max(np.abs(split_bias))),
+        "rel_l2_volumential_vs_reference": _safe_rel_l2(
+            error_vs_reference, analytic_reference
+        ),
+        "weighted_rel_l2_volumential_vs_reference": _safe_weighted_rel_l2(
+            error_vs_reference, analytic_reference, weights
+        ),
+        "linf_volumential_vs_reference": float(np.max(np.abs(error_vs_reference))),
+    }
+
+    node_slice = nearest_axis_slice(
+        coords,
+        {
+            "source": source,
+            "effective_density": effective_density,
+            "potential": potential,
+            "analytic_split": analytic_split,
+            "analytic_reference": analytic_reference,
+            "error_vs_split": error_vs_split,
+            "split_bias": split_bias,
+            "weights": weights,
+        },
+        axis=2,
+        value=0.0,
+    )
+    analytic_slice = axis_aligned_slice_grid(
+        bbox,
+        fixed_axis=2,
+        fixed_value=0.0,
+        shape=(slice_size, slice_size),
+    )
+    analytic_slice_source = evaluate_gaussian_mixture(mixture, analytic_slice.points)
+    analytic_slice_effective_density = evaluate_gaussian_mixture(
+        effective_mixture, analytic_slice.points
+    )
+    analytic_slice_reference = laplace3d_gaussian_potential(
+        mixture, analytic_slice.points, kernel_scale=kernel_scale
+    )
+    analytic_slice_split = laplace3d_gaussian_potential(
+        effective_mixture, analytic_slice.points, kernel_scale=kernel_scale
+    )
+
+    arrays = {
+        "node_coords": coords,
+        "node_weights": weights,
+        "node_source": source,
+        "node_effective_density": effective_density,
+        "node_potential": potential,
+        "node_analytic_split": analytic_split,
+        "node_analytic_reference": analytic_reference,
+        "node_error_vs_split": error_vs_split,
+        "node_split_bias_vs_reference": split_bias,
+        "slice_node_coords": node_slice["coords"],
+        "slice_node_indices": node_slice["indices"],
+        "slice_node_axis_distances": node_slice["axis_distances"],
+        "slice_node_source": node_slice["source"],
+        "slice_node_effective_density": node_slice["effective_density"],
+        "slice_node_potential": node_slice["potential"],
+        "slice_node_analytic_split": node_slice["analytic_split"],
+        "slice_node_analytic_reference": node_slice["analytic_reference"],
+        "slice_node_error_vs_split": node_slice["error_vs_split"],
+        "slice_node_split_bias": node_slice["split_bias"],
+        "slice_node_weights": node_slice["weights"],
+        "analytic_slice_coords": analytic_slice.points,
+        "analytic_slice_shape": np.asarray(analytic_slice.shape, dtype=np.int32),
+        "analytic_slice_axis0": analytic_slice.axis_values[0],
+        "analytic_slice_axis1": analytic_slice.axis_values[1],
+        "analytic_slice_source": analytic_slice_source,
+        "analytic_slice_effective_density": analytic_slice_effective_density,
+        "analytic_slice_reference": analytic_slice_reference,
+        "analytic_slice_split": analytic_slice_split,
+        "analytic_slice_split_bias": analytic_slice_split - analytic_slice_reference,
+        **{f"tree_{name}": values for name, values in leaf_arrays.items()},
+    }
+    metadata = {
+        "case_id": case_id,
+        "mode": mode,
+        "problem": "controlled-gaussian-split-effective-density",
+        "operator_identity": {
+            "fourier_convention": (
+                "forward integral exp(-i k.x), "
+                "inverse (2*pi)^-3 integral exp(i k.x)"
+            ),
+            "laplace_kernel": "K(x)=1/(4*pi*|x|)",
+            "laplace_multiplier": "1/|k|^2",
+            "split_multiplier": row["split_multiplier"],
+            "effective_density_multiplier": row["effective_density_multiplier"],
+            "identity": "K * rho_eff = K_sigma * rho",
+            "rho_eff_formula": "rho_eff = gamma_sigma * rho",
+            "gamma_sigma": "(2*pi*sigma^2)^(-3/2) exp(-|x|^2/(2*sigma^2))",
+            "gaussian_component_map": (
+                "alpha_eff=alpha/(1+2 alpha sigma^2), "
+                "amplitude_eff=amplitude*(alpha_eff/alpha)^(dim/2)"
+            ),
+        },
+        "dmk_parameters": {
+            "epsilon": split_epsilon,
+            "box_side_length": split_box_side_length,
+            "sigma": split_sigma,
+            "sigma_rule": "sigma = box_side_length / sqrt(log(1/epsilon))",
+            "residual_sog_terms": 0,
+            "residual_sog_status": "not used in this controlled smooth split diagnostic",
+        },
+        "kernel": {
+            "name": "Laplace",
+            "dimension": 3,
+            "normalization": "sumpy_global_scaling_1_over_4pi_r",
+            "kernel_scale": kernel_scale,
+        },
+        "fixture": {
+            "source": mixture.as_metadata(),
+            "effective_density": effective_mixture.as_metadata(),
+            "source_variance_per_axis": row["source_variance_per_axis"],
+        },
+        "bbox": bbox,
+        "tail": {
+            "source": source_tail,
+            "effective_density": effective_tail,
+        },
+        "discretization": {
+            "q_order": q_order,
+            "nlevels": nlevels,
+            "adapt_steps": 0,
+            "fmm_order": fmm_order,
+            "regular_quad_order": regular_quad_order,
+            "radial_quad_order": radial_quad_order,
+        },
+        "tree": {
+            "n_targets": int(tree.ntargets),
+            "n_active_boxes": int(mesh.n_active_cells()),
+            "n_total_boxes": int(mesh.n_cells()),
+            "min_leaf_level": min_leaf_level,
+            "max_leaf_level": max_leaf_level,
+        },
+        "errors": {
+            key: row[key]
+            for key in (
+                "rel_l2_volumential_vs_split",
+                "weighted_rel_l2_volumential_vs_split",
+                "linf_volumential_vs_split",
+                "rel_l2_split_bias_vs_reference",
+                "weighted_rel_l2_split_bias_vs_reference",
+                "linf_split_bias_vs_reference",
+                "rel_l2_volumential_vs_reference",
+                "weighted_rel_l2_volumential_vs_reference",
+                "linf_volumential_vs_reference",
+            )
+        },
+        "timing": {
+            "table_get_s": row["table_get_s"],
+            "table_build_s": row["table_build_s"],
+            "table_load_s": row["table_load_s"],
+            "table_payload_bytes": row["table_payload_bytes"],
+            "fmm_wall_s": row["fmm_wall_s"],
+        },
+        "cache": {
+            "cache_dir": str(cache_dir),
+            "force_recompute": force_recompute,
+        },
+        "environment": {
+            "hostname": platform.node(),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "opencl_device": _device_metadata(device),
+        },
+        "volumential": {
+            "version": VERSION_TEXT,
+            "git_commit": _git_commit(),
+        },
+        "stress_cases_designed_not_run": [
+            "cut or clipped Gaussian support to expose boundary-layer rho_eff artifacts",
+            "signed high-frequency residual density rho - gamma_sigma*rho",
+            "box-boundary source center shifts with fixed split sigma",
+        ],
+    }
+    return {"rows": [row], "arrays": arrays, "metadata": metadata}
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=SUMMARY_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
+    parser.add_argument("--backend", default="auto")
+    parser.add_argument("--q-order", type=int)
+    parser.add_argument("--nlevels", type=int)
+    parser.add_argument("--fmm-order", type=int)
+    parser.add_argument("--regular-quad-order", type=int)
+    parser.add_argument("--radial-quad-order", type=int)
+    parser.add_argument("--root-radius", type=float, default=0.5)
+    parser.add_argument("--source-alpha", type=float, default=75.0)
+    parser.add_argument("--split-epsilon", type=float, default=1.0e-6)
+    parser.add_argument(
+        "--split-sigma",
+        type=float,
+        default=None,
+        help="override sigma; otherwise use box_side_length/sqrt(log(1/epsilon))",
+    )
+    parser.add_argument("--slice-size", type=int, default=64)
+    parser.add_argument("--force-recompute", action="store_true")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("build/benchmarks/dmk-effective-density.csv"),
+    )
+    parser.add_argument(
+        "--arrays-out",
+        type=Path,
+        default=Path("build/benchmarks/dmk-effective-density-arrays.npz"),
+    )
+    parser.add_argument(
+        "--metadata-out",
+        type=Path,
+        default=Path("build/benchmarks/dmk-effective-density-metadata.json"),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("build/benchmarks/dmk-effective-density-cache"),
+    )
+    args = parser.parse_args()
+
+    smoke = args.mode == "smoke"
+    q_order = args.q_order if args.q_order is not None else (2 if smoke else 3)
+    nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 3)
+    fmm_order = args.fmm_order if args.fmm_order is not None else (8 if smoke else 12)
+    regular_quad_order = (
+        args.regular_quad_order
+        if args.regular_quad_order is not None
+        else max(8, 4 * q_order)
+    )
+    radial_quad_order = (
+        args.radial_quad_order if args.radial_quad_order is not None else max(25, 10 * q_order)
+    )
+
+    result = run_benchmark(
+        mode=args.mode,
+        backend=args.backend,
+        cache_dir=args.cache_dir,
+        q_order=q_order,
+        nlevels=nlevels,
+        fmm_order=fmm_order,
+        regular_quad_order=regular_quad_order,
+        radial_quad_order=radial_quad_order,
+        root_radius=args.root_radius,
+        source_alpha=args.source_alpha,
+        split_epsilon=args.split_epsilon,
+        split_sigma=args.split_sigma,
+        force_recompute=args.force_recompute,
+        slice_size=args.slice_size,
+    )
+    metadata = result["metadata"]
+    metadata["command"] = {
+        "argv": sys.argv,
+        "cwd": str(Path.cwd()),
+    }
+    metadata["outputs"] = {
+        "summary_csv": str(args.out),
+        "arrays_npz": str(args.arrays_out),
+        "metadata_json": str(args.metadata_out),
+    }
+    write_csv(args.out, result["rows"])
+    write_npz(args.arrays_out, **result["arrays"])
+    write_json_metadata(args.metadata_out, metadata)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/dmk_effective_density.py
+++ b/benchmarks/dmk_effective_density.py
@@ -484,9 +484,9 @@ def main() -> int:
     args = parser.parse_args()
 
     smoke = args.mode == "smoke"
-    q_order = args.q_order if args.q_order is not None else (2 if smoke else 3)
+    q_order = args.q_order if args.q_order is not None else (4 if smoke else 3)
     nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 3)
-    fmm_order = args.fmm_order if args.fmm_order is not None else (8 if smoke else 12)
+    fmm_order = args.fmm_order if args.fmm_order is not None else (10 if smoke else 12)
     regular_quad_order = (
         args.regular_quad_order
         if args.regular_quad_order is not None

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -26,6 +26,8 @@ class SuiteCase:
     script: str
     output_name: str | None
     accepts_backend: bool = False
+    arrays_output_name: str | None = None
+    metadata_output_name: str | None = None
 
 
 SUITE_CASES = (
@@ -61,6 +63,8 @@ SUITE_CASES = (
         script="benchmarks/dmk_effective_density.py",
         output_name="dmk_effective_density.csv",
         accepts_backend=True,
+        arrays_output_name="dmk_effective_density_arrays.npz",
+        metadata_output_name="dmk_effective_density_metadata.json",
     ),
 )
 
@@ -69,9 +73,16 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _case_output_arg(case: SuiteCase, case_dir: Path) -> list[str]:
+    args = []
     if case.output_name is None:
-        return ["--out-dir", str(case_dir)]
-    return ["--out", str(case_dir / case.output_name)]
+        args.extend(["--out-dir", str(case_dir)])
+    else:
+        args.extend(["--out", str(case_dir / case.output_name)])
+    if case.arrays_output_name is not None:
+        args.extend(["--arrays-out", str(case_dir / case.arrays_output_name)])
+    if case.metadata_output_name is not None:
+        args.extend(["--metadata-out", str(case_dir / case.metadata_output_name)])
+    return args
 
 
 def _case_cache_arg(case_dir: Path) -> list[str]:

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -55,6 +55,13 @@ SUITE_CASES = (
         output_name="adaptive_timing.csv",
         accepts_backend=True,
     ),
+    SuiteCase(
+        name="dmk-effective-density",
+        description="controlled Gaussian split effective-density diagnostic",
+        script="benchmarks/dmk_effective_density.py",
+        output_name="dmk_effective_density.csv",
+        accepts_backend=True,
+    ),
 )
 
 

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -122,6 +122,22 @@ def test_gaussian_filter_mixture_preserves_mass_and_broadens_variance():
     assert effective_mass == pytest.approx(source_mass)
 
 
+def test_gaussian_filter_mixture_rejects_invalid_sigma():
+    mixture = GaussianMixture(
+        "single",
+        (GaussianComponent(2.0, (0.0, 0.0, 0.0), 5.0),),
+    )
+
+    with pytest.raises(ValueError, match="sigma"):
+        gaussian_filter_mixture(mixture, 0.0)
+
+    with pytest.raises(ValueError, match="sigma"):
+        gaussian_filter_mixture(mixture, -1.0)
+
+    with pytest.raises(ValueError, match="sigma"):
+        gaussian_filter_mixture(mixture, float("inf"))
+
+
 def test_axis_aligned_slice_grid_embeds_2d_grid_in_3d_box():
     grid = axis_aligned_slice_grid(
         np.array([[-1.0, 1.0], [-2.0, 2.0], [-3.0, 3.0]]),

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -8,7 +8,9 @@ from volumential.gaussian import (
     GaussianComponent,
     GaussianMixture,
     axis_aligned_slice_grid,
+    dmk_gaussian_split_sigma,
     evaluate_gaussian_mixture,
+    gaussian_filter_mixture,
     gaussian_mixture_tail_report,
     laplace3d_gaussian_potential,
     mesh_leaf_box_arrays,
@@ -87,6 +89,37 @@ def test_gaussian_tail_report_uses_separable_box_mass():
     assert report["total_abs_component_mass"] == pytest.approx(math.sqrt(math.pi))
     assert report["omitted_abs_fraction"] == pytest.approx(math.erfc(1.0))
     assert report["components"][0]["omitted_abs_fraction"] == pytest.approx(math.erfc(1.0))
+
+
+def test_dmk_gaussian_split_sigma_uses_box_side_and_requested_precision():
+    sigma = dmk_gaussian_split_sigma(0.25, 1.0e-6)
+
+    assert sigma == pytest.approx(0.25 / math.sqrt(math.log(1.0e6)))
+
+    with pytest.raises(ValueError, match="box_side_length"):
+        dmk_gaussian_split_sigma(0.0, 1.0e-6)
+
+    with pytest.raises(ValueError, match="epsilon"):
+        dmk_gaussian_split_sigma(0.25, 1.0)
+
+
+def test_gaussian_filter_mixture_preserves_mass_and_broadens_variance():
+    mixture = GaussianMixture(
+        "single",
+        (GaussianComponent(2.0, (0.0, 0.0, 0.0), 5.0),),
+    )
+
+    filtered = gaussian_filter_mixture(mixture, 0.2)
+    source = mixture.components[0]
+    effective = filtered.components[0]
+    source_mass = source.amplitude * (math.pi / source.alpha) ** (source.dim / 2.0)
+    effective_mass = effective.amplitude * (math.pi / effective.alpha) ** (
+        effective.dim / 2.0
+    )
+
+    assert effective.alpha == pytest.approx(source.alpha / (1.0 + 2.0 * source.alpha * 0.2**2))
+    assert effective.alpha < source.alpha
+    assert effective_mass == pytest.approx(source_mass)
 
 
 def test_axis_aligned_slice_grid_embeds_2d_grid_in_3d_box():

--- a/volumential/gaussian.py
+++ b/volumential/gaussian.py
@@ -132,6 +132,63 @@ def evaluate_gaussian_mixture(mixture: GaussianMixture, points: np.ndarray) -> n
     return result
 
 
+def dmk_gaussian_split_sigma(box_side_length: float, epsilon: float) -> float:
+    """Return the DMK-style Gaussian split scale for one box level.
+
+    Jiang--Greengard DMK chooses a Gaussian kernel-splitting scale proportional
+    to ``r_l / sqrt(log(1/epsilon))`` for box side length ``r_l`` and requested
+    precision ``epsilon``. This helper records that normalization for controlled
+    diagnostics; it does not include the separate residual sum-of-Gaussians fit.
+    """
+
+    box_side_length = float(box_side_length)
+    epsilon = float(epsilon)
+    if not math.isfinite(box_side_length) or box_side_length <= 0.0:
+        raise ValueError("box_side_length must be finite and positive")
+    if not math.isfinite(epsilon) or not (0.0 < epsilon < 1.0):
+        raise ValueError("epsilon must be finite and between 0 and 1")
+    return box_side_length / math.sqrt(math.log(1.0 / epsilon))
+
+
+def gaussian_filter_mixture(mixture: GaussianMixture, sigma: float) -> GaussianMixture:
+    """Convolve ``mixture`` with a normalized isotropic Gaussian filter.
+
+    The filter is
+
+    ``gamma_sigma(x) = (2*pi*sigma**2)^(-d/2) exp(-|x|**2/(2*sigma**2))``
+
+    and has Fourier multiplier ``exp(-sigma**2 |k|**2 / 2)`` under the
+    convention where the 3D Laplace Green's function ``1/(4*pi*r)`` has
+    multiplier ``1/|k|**2``. Convolving each ``A exp(-alpha |x-c|^2)`` component
+    preserves its mass and maps it to another Gaussian with
+
+    ``alpha_eff = alpha / (1 + 2 alpha sigma**2)``.
+    """
+
+    sigma = float(sigma)
+    if not math.isfinite(sigma) or sigma <= 0.0:
+        raise ValueError("sigma must be finite and positive")
+
+    components = []
+    for component in mixture.components:
+        alpha_eff = component.alpha / (1.0 + 2.0 * component.alpha * sigma**2)
+        amplitude_eff = component.amplitude * (alpha_eff / component.alpha) ** (
+            component.dim / 2.0
+        )
+        components.append(
+            GaussianComponent(
+                amplitude=amplitude_eff,
+                center=component.center,
+                alpha=alpha_eff,
+            )
+        )
+
+    return GaussianMixture(
+        name=f"{mixture.name}-gaussian-filter-sigma-{sigma:.6g}",
+        components=tuple(components),
+    )
+
+
 def laplace3d_gaussian_potential(
     mixture: GaussianMixture,
     points: np.ndarray,


### PR DESCRIPTION
Closes xywei/boxcode-paper#144.

## Summary

- Add a controlled 3D Laplace Gaussian-split diagnostic for the DMK effective-density bridge.
- Define `rho_eff` by `K * rho_eff = K_sigma * rho`, with `K(x)=1/(4*pi*|x|)`, `hat(K)=1/|k|^2`, and `hat(rho_eff)=exp(-sigma^2 |k|^2 / 2) hat(rho)`.
- Add Gaussian helper functions for the DMK-style split scale and analytic Gaussian-filtered mixtures.
- Emit CSV/JSON/NPZ artifacts comparing Volumential applied to `rho_eff`, the analytic split potential, and the unsmoothed analytic Gaussian reference.
- Record source Gaussian variance, actual mesh leaf side length, split `sigma`, requested `epsilon`, and residual SOG status separately; residual SOG terms are intentionally not part of this controlled build.
- Add tests, benchmark README docs, performance-suite registration, and CI smoke coverage.

## Smoke Result

Clean `ipa` scratch clone:

- Run root: `/tmp/opencode/paper1-144-dmk-corrected.rgeDhMLO`
- Commit: `8d9438408830da96832af89b94aecd2c7afb6e98`
- Command: `python benchmarks/dmk_effective_density.py --mode smoke --backend pocl-cpu --slice-size 8`
- Defaults: `q_order=4`, `nlevels=2`, `fmm_order=10`, `n_targets=512`
- Actual `split_box_side_length=0.5`
- `split_sigma=0.13451989969010344`
- `rel_l2_volumential_vs_split=3.229e-3`
- `weighted_rel_l2_volumential_vs_split=2.771e-3`
- `rel_l2_split_bias_vs_reference=2.212e-1`

## Verification

- `python -m pytest test/test_gaussian.py`
- `python -m py_compile benchmarks/dmk_effective_density.py benchmarks/performance_suite.py volumential/gaussian.py`
- `uvx ruff check --select E9,F63,F7,F82`
- `python benchmarks/performance_suite.py --mode smoke --case dmk-effective-density --dry-run --out-dir build/benchmarks/performance-suite-dmk-dry-run`
- `git diff --check`
- Clean `ipa` tmux smoke run with CSV/JSON/NPZ sanity checks