### PR TITLE
fix(bench): correct DMK effective-density demo

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,12 +87,12 @@ The benchmark runs 2D Laplace evaluations on deterministically adapted meshes an
 python benchmarks/dmk_effective_density.py --mode smoke --slice-size 8
 ```
 
-The benchmark isolates a controlled 3D Laplace Gaussian split with multiplier
-`exp(-sigma^2 |k|^2 / 2) / |k|^2`, defines `rho_eff` by
-`K * rho_eff = K_sigma * rho`, applies Volumential's singular Laplace path to
-the analytic Gaussian-filtered density, and writes CSV/JSON/NPZ diagnostics. It
-records the source Gaussian variance, the DMK-style split scale
-`sigma = box_side_length / sqrt(log(1/epsilon))`, and the fact that residual SOG
-terms are not part of this controlled diagnostic. Smoke mode defaults to a
-uniform `q=4`, `nlevels=2` run so the split-vs-Volumential comparison is
-meaningful while remaining lightweight.
+The benchmark isolates a controlled 3D Laplace DMK minimal-smoothing model with
+multiplier `exp(-sigma_l^2 |k|^2 / 4) / |k|^2`, defines `rho_eff` by
+`K * rho_eff = K_sigma_l * rho`, applies Volumential's singular Laplace path to
+the analytic Gaussian-filtered density, and writes CSV/JSON/NPZ diagnostics. In
+the effective-density view, the density smoothing standard deviation is
+`sigma_l / sqrt(2)`, where `sigma_l = box_side_length / sqrt(log(1/epsilon))`.
+Full mode uses an enlarged root box by default so truncation of the smoothed
+density is negligible while preserving the same leaf-side smoothing scale. Smoke
+mode defaults to a uniform `q=4`, `nlevels=2` run and remains lightweight.

--- a/benchmarks/dmk_effective_density.py
+++ b/benchmarks/dmk_effective_density.py
@@ -6,20 +6,23 @@ translation-invariant Gaussian kernel split for the 3D Laplace Green's function
 
     K(x) = 1 / (4*pi*|x|),      K_hat(k) = 1 / |k|^2,
 
-using the smooth split multiplier
+using the finest-level regularized multiplier
 
-    K_sigma_hat(k) = exp(-sigma^2 |k|^2 / 2) / |k|^2.
+    K_sigma_hat(k) = exp(-sigma_l^2 |k|^2 / 4) / |k|^2.
 
 The effective density is therefore defined by
 
     K * rho_eff = K_sigma * rho,
-    rho_eff_hat(k) = exp(-sigma^2 |k|^2 / 2) rho_hat(k).
+    rho_eff_hat(k) = exp(-sigma_l^2 |k|^2 / 4) rho_hat(k).
 
-For a Gaussian source this filtered density is analytic, so the diagnostic can
-apply Volumential's singular 3D Laplace path to rho_eff and compare it against
-the analytic split potential and the unsmoothed analytic reference. The source
-Gaussian variance, DMK-style split scale sigma, and residual SOG approximation
-status are recorded separately in the emitted metadata.
+For a Gaussian source this filtered density is analytic: rho_eff is the source
+convolved with a normalized Gaussian of standard deviation sigma_l/sqrt(2). The
+diagnostic applies Volumential's singular 3D Laplace path to rho_eff on an
+enlarged bounding box and compares it against the analytic DMK-regularized
+potential. The unsmoothed analytic reference remains a secondary diagnostic for
+the intentional regularization bias. The source Gaussian variance, DMK-style split
+scale sigma_l, density smoothing length, and residual SOG approximation status are
+recorded separately in the emitted metadata.
 """
 
 from __future__ import annotations
@@ -70,12 +73,14 @@ SUMMARY_FIELDS = (
     "dim",
     "kernel",
     "kernel_normalization",
-    "split_multiplier",
+    "dmk_regularized_kernel_multiplier",
     "effective_density_multiplier",
+    "primary_comparison",
     "source_alpha",
     "source_variance_per_axis",
     "split_epsilon",
     "split_sigma",
+    "effective_density_smoothing_std",
     "split_box_side_length",
     "residual_sog_terms",
     "q_order",
@@ -98,15 +103,15 @@ SUMMARY_FIELDS = (
     "table_load_s",
     "table_payload_bytes",
     "fmm_wall_s",
-    "rel_l2_volumential_vs_split",
-    "weighted_rel_l2_volumential_vs_split",
-    "linf_volumential_vs_split",
-    "rel_l2_split_bias_vs_reference",
-    "weighted_rel_l2_split_bias_vs_reference",
-    "linf_split_bias_vs_reference",
-    "rel_l2_volumential_vs_reference",
-    "weighted_rel_l2_volumential_vs_reference",
-    "linf_volumential_vs_reference",
+    "rel_l2_volumential_vs_dmk_regularized",
+    "weighted_rel_l2_volumential_vs_dmk_regularized",
+    "linf_volumential_vs_dmk_regularized",
+    "rel_l2_regularized_bias_vs_unsmoothed",
+    "weighted_rel_l2_regularized_bias_vs_unsmoothed",
+    "linf_regularized_bias_vs_unsmoothed",
+    "rel_l2_volumential_vs_unsmoothed",
+    "weighted_rel_l2_volumential_vs_unsmoothed",
+    "linf_volumential_vs_unsmoothed",
 )
 
 
@@ -173,15 +178,18 @@ def run_benchmark(
         raise RuntimeError("DMK effective-density diagnostic expects a uniform mesh")
     if split_sigma is None:
         split_sigma = dmk_gaussian_split_sigma(split_box_side_length, split_epsilon)
+    effective_density_smoothing_std = split_sigma / np.sqrt(2.0)
 
-    effective_mixture = gaussian_filter_mixture(mixture, split_sigma)
+    effective_mixture = gaussian_filter_mixture(
+        mixture, effective_density_smoothing_std
+    )
     source = evaluate_gaussian_mixture(mixture, coords)
     effective_density = evaluate_gaussian_mixture(effective_mixture, coords)
     kernel_scale = 1.0 / (4.0 * np.pi)
     analytic_reference = laplace3d_gaussian_potential(
         mixture, coords, kernel_scale=kernel_scale
     )
-    analytic_split = laplace3d_gaussian_potential(
+    analytic_regularized = laplace3d_gaussian_potential(
         effective_mixture, coords, kernel_scale=kernel_scale
     )
 
@@ -209,24 +217,26 @@ def run_benchmark(
     min_leaf_level, max_leaf_level = _leaf_stats(leaf_arrays)
     source_tail = gaussian_mixture_tail_report(mixture, bbox)
     effective_tail = gaussian_mixture_tail_report(effective_mixture, bbox)
-    error_vs_split = potential - analytic_split
-    split_bias = analytic_split - analytic_reference
-    error_vs_reference = potential - analytic_reference
+    error_vs_regularized = potential - analytic_regularized
+    regularized_bias = analytic_regularized - analytic_reference
+    error_vs_unsmoothed = potential - analytic_reference
     case_id = f"dmk-effective-density-laplace3d-q{q_order}-l{nlevels}"
 
     row = {
         "case_id": case_id,
         "mode": mode,
-        "problem": "controlled-gaussian-split-effective-density",
+        "problem": "controlled-dmk-minimal-smoothing-effective-density",
         "dim": 3,
         "kernel": "Laplace",
         "kernel_normalization": "sumpy_global_scaling_1_over_4pi_r",
-        "split_multiplier": "exp(-sigma^2*|k|^2/2)/|k|^2",
-        "effective_density_multiplier": "exp(-sigma^2*|k|^2/2)",
+        "dmk_regularized_kernel_multiplier": "exp(-sigma_l^2*|k|^2/4)/|k|^2",
+        "effective_density_multiplier": "exp(-sigma_l^2*|k|^2/4)",
+        "primary_comparison": "full_finite_box_laplace_rho_eff_vs_dmk_regularized_potential",
         "source_alpha": source_alpha,
         "source_variance_per_axis": 1.0 / (2.0 * source_alpha),
         "split_epsilon": split_epsilon,
         "split_sigma": split_sigma,
+        "effective_density_smoothing_std": effective_density_smoothing_std,
         "split_box_side_length": split_box_side_length,
         "residual_sog_terms": 0,
         "q_order": q_order,
@@ -249,23 +259,29 @@ def run_benchmark(
         "table_load_s": _table_phase_seconds(table_timings, "load"),
         "table_payload_bytes": _table_payload_bytes(table_timings),
         "fmm_wall_s": fmm_wall_s,
-        "rel_l2_volumential_vs_split": _safe_rel_l2(error_vs_split, analytic_split),
-        "weighted_rel_l2_volumential_vs_split": _safe_weighted_rel_l2(
-            error_vs_split, analytic_split, weights
+        "rel_l2_volumential_vs_dmk_regularized": _safe_rel_l2(
+            error_vs_regularized, analytic_regularized
         ),
-        "linf_volumential_vs_split": float(np.max(np.abs(error_vs_split))),
-        "rel_l2_split_bias_vs_reference": _safe_rel_l2(split_bias, analytic_reference),
-        "weighted_rel_l2_split_bias_vs_reference": _safe_weighted_rel_l2(
-            split_bias, analytic_reference, weights
+        "weighted_rel_l2_volumential_vs_dmk_regularized": _safe_weighted_rel_l2(
+            error_vs_regularized, analytic_regularized, weights
         ),
-        "linf_split_bias_vs_reference": float(np.max(np.abs(split_bias))),
-        "rel_l2_volumential_vs_reference": _safe_rel_l2(
-            error_vs_reference, analytic_reference
+        "linf_volumential_vs_dmk_regularized": float(
+            np.max(np.abs(error_vs_regularized))
         ),
-        "weighted_rel_l2_volumential_vs_reference": _safe_weighted_rel_l2(
-            error_vs_reference, analytic_reference, weights
+        "rel_l2_regularized_bias_vs_unsmoothed": _safe_rel_l2(
+            regularized_bias, analytic_reference
         ),
-        "linf_volumential_vs_reference": float(np.max(np.abs(error_vs_reference))),
+        "weighted_rel_l2_regularized_bias_vs_unsmoothed": _safe_weighted_rel_l2(
+            regularized_bias, analytic_reference, weights
+        ),
+        "linf_regularized_bias_vs_unsmoothed": float(np.max(np.abs(regularized_bias))),
+        "rel_l2_volumential_vs_unsmoothed": _safe_rel_l2(
+            error_vs_unsmoothed, analytic_reference
+        ),
+        "weighted_rel_l2_volumential_vs_unsmoothed": _safe_weighted_rel_l2(
+            error_vs_unsmoothed, analytic_reference, weights
+        ),
+        "linf_volumential_vs_unsmoothed": float(np.max(np.abs(error_vs_unsmoothed))),
     }
 
     node_slice = nearest_axis_slice(
@@ -274,10 +290,10 @@ def run_benchmark(
             "source": source,
             "effective_density": effective_density,
             "potential": potential,
-            "analytic_split": analytic_split,
+            "analytic_regularized": analytic_regularized,
             "analytic_reference": analytic_reference,
-            "error_vs_split": error_vs_split,
-            "split_bias": split_bias,
+            "error_vs_regularized": error_vs_regularized,
+            "regularized_bias": regularized_bias,
             "weights": weights,
         },
         axis=2,
@@ -296,7 +312,7 @@ def run_benchmark(
     analytic_slice_reference = laplace3d_gaussian_potential(
         mixture, analytic_slice.points, kernel_scale=kernel_scale
     )
-    analytic_slice_split = laplace3d_gaussian_potential(
+    analytic_slice_regularized = laplace3d_gaussian_potential(
         effective_mixture, analytic_slice.points, kernel_scale=kernel_scale
     )
 
@@ -306,20 +322,26 @@ def run_benchmark(
         "node_source": source,
         "node_effective_density": effective_density,
         "node_potential": potential,
-        "node_analytic_split": analytic_split,
+        "node_analytic_regularized": analytic_regularized,
+        "node_analytic_split": analytic_regularized,
         "node_analytic_reference": analytic_reference,
-        "node_error_vs_split": error_vs_split,
-        "node_split_bias_vs_reference": split_bias,
+        "node_error_vs_regularized": error_vs_regularized,
+        "node_error_vs_split": error_vs_regularized,
+        "node_regularized_bias_vs_reference": regularized_bias,
+        "node_split_bias_vs_reference": regularized_bias,
         "slice_node_coords": node_slice["coords"],
         "slice_node_indices": node_slice["indices"],
         "slice_node_axis_distances": node_slice["axis_distances"],
         "slice_node_source": node_slice["source"],
         "slice_node_effective_density": node_slice["effective_density"],
         "slice_node_potential": node_slice["potential"],
-        "slice_node_analytic_split": node_slice["analytic_split"],
+        "slice_node_analytic_regularized": node_slice["analytic_regularized"],
+        "slice_node_analytic_split": node_slice["analytic_regularized"],
         "slice_node_analytic_reference": node_slice["analytic_reference"],
-        "slice_node_error_vs_split": node_slice["error_vs_split"],
-        "slice_node_split_bias": node_slice["split_bias"],
+        "slice_node_error_vs_regularized": node_slice["error_vs_regularized"],
+        "slice_node_error_vs_split": node_slice["error_vs_regularized"],
+        "slice_node_regularized_bias": node_slice["regularized_bias"],
+        "slice_node_split_bias": node_slice["regularized_bias"],
         "slice_node_weights": node_slice["weights"],
         "analytic_slice_coords": analytic_slice.points,
         "analytic_slice_shape": np.asarray(analytic_slice.shape, dtype=np.int32),
@@ -328,14 +350,19 @@ def run_benchmark(
         "analytic_slice_source": analytic_slice_source,
         "analytic_slice_effective_density": analytic_slice_effective_density,
         "analytic_slice_reference": analytic_slice_reference,
-        "analytic_slice_split": analytic_slice_split,
-        "analytic_slice_split_bias": analytic_slice_split - analytic_slice_reference,
+        "analytic_slice_regularized": analytic_slice_regularized,
+        "analytic_slice_split": analytic_slice_regularized,
+        "analytic_slice_regularized_bias": (
+            analytic_slice_regularized - analytic_slice_reference
+        ),
+        "analytic_slice_split_bias": analytic_slice_regularized - analytic_slice_reference,
         **{f"tree_{name}": values for name, values in leaf_arrays.items()},
     }
     metadata = {
         "case_id": case_id,
         "mode": mode,
-        "problem": "controlled-gaussian-split-effective-density",
+        "problem": "controlled-dmk-minimal-smoothing-effective-density",
+        "primary_comparison": row["primary_comparison"],
         "operator_identity": {
             "fourier_convention": (
                 "forward integral exp(-i k.x), "
@@ -343,13 +370,22 @@ def run_benchmark(
             ),
             "laplace_kernel": "K(x)=1/(4*pi*|x|)",
             "laplace_multiplier": "1/|k|^2",
-            "split_multiplier": row["split_multiplier"],
+            "dmk_regularized_kernel_multiplier": row[
+                "dmk_regularized_kernel_multiplier"
+            ],
             "effective_density_multiplier": row["effective_density_multiplier"],
-            "identity": "K * rho_eff = K_sigma * rho",
+            "identity": "K * rho_eff = K_sigma_l * rho",
             "rho_eff_formula": "rho_eff = gamma_sigma * rho",
-            "gamma_sigma": "(2*pi*sigma^2)^(-3/2) exp(-|x|^2/(2*sigma^2))",
+            "primary_diagnostic": (
+                "full finite-box singular Laplace VP of rho_eff is compared "
+                "against the analytic DMK-regularized potential"
+            ),
+            "gamma_sigma": (
+                "(2*pi*s_eff^2)^(-3/2) exp(-|x|^2/(2*s_eff^2)), "
+                "where s_eff=sigma_l/sqrt(2)"
+            ),
             "gaussian_component_map": (
-                "alpha_eff=alpha/(1+2 alpha sigma^2), "
+                "alpha_eff=alpha/(1+2 alpha s_eff^2), "
                 "amplitude_eff=amplitude*(alpha_eff/alpha)^(dim/2)"
             ),
         },
@@ -358,8 +394,13 @@ def run_benchmark(
             "box_side_length": split_box_side_length,
             "sigma": split_sigma,
             "sigma_rule": "sigma = box_side_length / sqrt(log(1/epsilon))",
+            "effective_density_smoothing_std": effective_density_smoothing_std,
+            "effective_density_smoothing_rule": "s_eff = sigma / sqrt(2)",
             "residual_sog_terms": 0,
-            "residual_sog_status": "not used in this controlled smooth split diagnostic",
+            "residual_sog_status": (
+                "not used; this diagnostic models the finest DMK regularized "
+                "operator as a global effective density"
+            ),
         },
         "kernel": {
             "name": "Laplace",
@@ -371,6 +412,7 @@ def run_benchmark(
             "source": mixture.as_metadata(),
             "effective_density": effective_mixture.as_metadata(),
             "source_variance_per_axis": row["source_variance_per_axis"],
+            "effective_density_smoothing_std": effective_density_smoothing_std,
         },
         "bbox": bbox,
         "tail": {
@@ -395,15 +437,15 @@ def run_benchmark(
         "errors": {
             key: row[key]
             for key in (
-                "rel_l2_volumential_vs_split",
-                "weighted_rel_l2_volumential_vs_split",
-                "linf_volumential_vs_split",
-                "rel_l2_split_bias_vs_reference",
-                "weighted_rel_l2_split_bias_vs_reference",
-                "linf_split_bias_vs_reference",
-                "rel_l2_volumential_vs_reference",
-                "weighted_rel_l2_volumential_vs_reference",
-                "linf_volumential_vs_reference",
+                "rel_l2_volumential_vs_dmk_regularized",
+                "weighted_rel_l2_volumential_vs_dmk_regularized",
+                "linf_volumential_vs_dmk_regularized",
+                "rel_l2_regularized_bias_vs_unsmoothed",
+                "weighted_rel_l2_regularized_bias_vs_unsmoothed",
+                "linf_regularized_bias_vs_unsmoothed",
+                "rel_l2_volumential_vs_unsmoothed",
+                "weighted_rel_l2_volumential_vs_unsmoothed",
+                "linf_volumential_vs_unsmoothed",
             )
         },
         "timing": {
@@ -453,7 +495,12 @@ def main() -> int:
     parser.add_argument("--fmm-order", type=int)
     parser.add_argument("--regular-quad-order", type=int)
     parser.add_argument("--radial-quad-order", type=int)
-    parser.add_argument("--root-radius", type=float, default=0.5)
+    parser.add_argument(
+        "--root-radius",
+        type=float,
+        default=None,
+        help="root half-width; defaults to 0.5 in smoke mode and 1.0 in full mode",
+    )
     parser.add_argument("--source-alpha", type=float, default=75.0)
     parser.add_argument("--split-epsilon", type=float, default=1.0e-6)
     parser.add_argument(
@@ -488,8 +535,9 @@ def main() -> int:
 
     smoke = args.mode == "smoke"
     q_order = args.q_order if args.q_order is not None else 4
-    nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 3)
+    nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 4)
     fmm_order = args.fmm_order if args.fmm_order is not None else (10 if smoke else 12)
+    root_radius = args.root_radius if args.root_radius is not None else (0.5 if smoke else 1.0)
     regular_quad_order = (
         args.regular_quad_order
         if args.regular_quad_order is not None
@@ -508,7 +556,7 @@ def main() -> int:
         fmm_order=fmm_order,
         regular_quad_order=regular_quad_order,
         radial_quad_order=radial_quad_order,
-        root_radius=args.root_radius,
+        root_radius=root_radius,
         source_alpha=args.source_alpha,
         split_epsilon=args.split_epsilon,
         split_sigma=args.split_sigma,


### PR DESCRIPTION
## Summary

- Replace the prior smooth-split-only DMK effective-density comparison with a global minimal-smoothing effective-density diagnostic.
- Use the DMK `erf(r/sigma_l)` convention, so the effective density is smoothed with `s_eff = sigma_l/sqrt(2)` and multiplier `exp(-sigma_l^2 |k|^2 / 4)`.
- Evaluate Volumential's singular 3D Laplace VP of `rho_eff` on an enlarged full-mode root box so truncation of the smoothed density is negligible.
- Keep the unsmoothed Gaussian analytic reference only as a regularization-bias diagnostic.

## Validation

- `python -m py_compile benchmarks/dmk_effective_density.py benchmarks/gaussian_free_space.py`
- `git diff --check`
- Clean `ipa` smoke run from this branch: `/tmp/opencode/paper1-corrected-dmk-smoke.RFPIEt`, return code `0`
- Clean `ipa` full run under paper metadata wrapper: `/tmp/opencode/paper1-dmk-corrected-final.gWv6ws`, return code `0`

Full-run highlights: root extent `2.0`, actual leaf side `0.25`, `sigma_l=0.06725994984505172`, `s_eff=0.04755996663770315`, effective-density omitted mass fraction `0.0` at reported precision, weighted relative `L2` error vs analytic DMK-regularized potential `4.13e-4`.