### PR TITLE
feat: strengthen numerical benchmarks and add branched-flow solver

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,11 +41,12 @@ dependency resolution.
 
 ## Remote Setup
 
-Use the same environment recipe on remote machines used for heavier numerical
-experiments (for example `ipa`).
+Use the same environment recipe on a suitable, currently idle remote machine for
+heavier numerical experiments. Select the host through the private global
+remote-compute tracker and replace `<remote-host>` below with its SSH alias.
 
 ```bash
-ssh ipa
+ssh <remote-host>
 git clone <repo-url>
 cd volumential
 micromamba create -n volumential-dev -c conda-forge -c nodefaults \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-These scripts emit reproducible CSV artifacts for manuscript evidence. Keep smoke modes lightweight enough for CI/local checks and reserve full sweeps for controlled machines such as `ipa`.
+These scripts emit reproducible CSV artifacts for manuscript evidence. Keep smoke modes lightweight enough for CI/local checks and reserve full sweeps for a suitable, currently idle remote compute host. Keep infrastructure-identifying metadata private and redact it from public artifacts.
 
 ## Performance Suite Driver
 
@@ -11,7 +11,7 @@ layout and JSON command manifest:
 python benchmarks/performance_suite.py --mode smoke --out-dir build/benchmarks/performance-suite
 ```
 
-For full runs, execute on a controlled machine such as `ipa` and wrap the suite
+For full runs, execute on a controlled remote compute host and wrap the suite
 with the paper repository metadata tool before promoting results:
 
 ```bash
@@ -71,7 +71,7 @@ The benchmark compares canonical rescaled tables, direct per-level tables, and d
 python benchmarks/split_parameter_sweep.py --mode smoke --out build/benchmarks/split-parameter-sweep.csv
 ```
 
-The benchmark sweeps 2D scalar Helmholtz wave numbers and Yukawa screening parameters. Rows compare each split order against the highest split order in the same run for that kernel parameter, giving a split-order convergence measurement while holding the pretabulated basis-table family fixed. Each row records split cache accounting. In `_row_from_result`, the `online_remainder_s` column is a conservative upper bound: it equals `split_warm_s` when `uses_online_remainder` is true, and is `0.0` otherwise, because the current wrangler instrumentation does not isolate smooth online-remainder work from the rest of the warm FMM/List-1 evaluation.
+The benchmark sweeps 2D scalar Helmholtz wave numbers and Yukawa screening parameters. Each row compares the full implemented split evaluator against a direct fixed-parameter near-field table at the same parameter and application level. It separately records direct-table and RKE-channel setup/load costs, payload, repeated full applications, isolated coefficient and residual diagnostics, cold/warm strategy totals, and a linear break-even model. `--direct-levels` controls the levels provisioned by the direct setup strategy, while `--nlevels` is the application level; `--repeat-count` is the number of applications per parameter, and `break_even_repeat_count` uses the same per-parameter unit.
 
 ## Adaptive Timing
 
@@ -87,12 +87,15 @@ The benchmark runs 2D Laplace evaluations on deterministically adapted meshes an
 python benchmarks/dmk_effective_density.py --mode smoke --slice-size 8
 ```
 
-The benchmark isolates a controlled 3D Laplace DMK minimal-smoothing model with
-multiplier `exp(-sigma_l^2 |k|^2 / 4) / |k|^2`, defines `rho_eff` by
-`K * rho_eff = K_sigma_l * rho`, applies Volumential's singular Laplace path to
-the analytic Gaussian-filtered density, and writes CSV/JSON/NPZ diagnostics. In
-the effective-density view, the density smoothing standard deviation is
+The benchmark isolates a controlled 3D Laplace DMK far-plus-residual effective
+density model. The far density is the analytic Gaussian-filtered source with
+multiplier `exp(-sigma_l^2 |k|^2 / 4)` and smoothing standard deviation
 `sigma_l / sqrt(2)`, where `sigma_l = box_side_length / sqrt(log(1/epsilon))`.
-Full mode uses an enlarged root box by default so truncation of the smoothed
-density is negligible while preserving the same leaf-side smoothing scale. Smoke
-mode defaults to a uniform `q=4`, `nlevels=2` run and remains lightweight.
+The residual uses the all-space fourth-order Taylor/asymptotic model for
+`erfc(r/sigma_l)/(4*pi*r)`, converts `u_R ~= c0 rho + c1 Delta rho + c2 Delta^2 rho`
+to an equivalent density by `rho_R_eff = -Delta u_R`, and applies Volumential's
+singular Laplace path to the total density. CSV/JSON/NPZ diagnostics report the
+Volumential error against the analytic asymptotic split and the residual split
+bias against the unsmoothed Gaussian reference. Smoke mode uses a lightweight
+uniform `q=4`, `nlevels=2`, root-half-width `0.5` mesh; full mode uses the
+resolved `q=4`, `nlevels=4`, root-half-width `1.0` configuration.

--- a/benchmarks/accuracy_preservation.py
+++ b/benchmarks/accuracy_preservation.py
@@ -476,8 +476,17 @@ def _add_convergence_rates(rows):
     h_groups = {}
     q_groups = {}
     for row in rows:
-        h_groups.setdefault((row["path"], row["q_order"]), []).append(row)
-        q_groups.setdefault((row["path"], row["n_levels"]), []).append(row)
+        fixed_orders = (
+            row["fmm_order"],
+            row["regular_quad_order"],
+            row["radial_quad_order"],
+        )
+        h_groups.setdefault(
+            (row["path"], row["q_order"], *fixed_orders), []
+        ).append(row)
+        q_groups.setdefault(
+            (row["path"], row["n_levels"], *fixed_orders), []
+        ).append(row)
 
     for group in h_groups.values():
         group.sort(key=lambda row: row["h_max"], reverse=True)

--- a/benchmarks/accuracy_preservation.py
+++ b/benchmarks/accuracy_preservation.py
@@ -8,12 +8,18 @@ problem and compares three evaluator paths on the same mesh:
 * per_level: direct per-level near-field tables,
 * direct_p2p: direct point-particle diagnostic through the same volume-FMM driver.
 
-The output reports exact-solution errors and pairwise path differences by order.
-The canonical/per-level table comparison is the per-level row's difference from
+The finite-box reference follows from Green's identity: the analytic full-space
+Gaussian solution is corrected by an overresolved boundary integral. The
+quadrature-weighted L2 norm is ``sqrt(sum_i w_i |v_i|**2)``. The output also
+retains unweighted nodal relative L2 errors and pairwise path differences. The
+canonical/per-level table comparison is the per-level row's difference from
 ``canonical_rescaled``; the direct P2P path is diagnostic and not a near-field
 table reference.
-Smoke mode is small enough for CI; full mode is intended for controlled paper
-runs on ``ipa``.
+
+Smoke mode is small enough for CI; full mode is intended for a controlled remote
+paper run. ``--q-orders`` and ``--n-levels`` form a Cartesian product so either
+q- or h-convergence can be measured while the FMM and table quadrature orders
+are held fixed with their corresponding CLI options.
 """
 
 from __future__ import annotations
@@ -41,15 +47,66 @@ class AccuracyCase:
     radial_quad_order: int
 
 
+ROOT_BOUNDS = (-0.5, 0.5)
+GAUSSIAN_COMPONENTS = (
+    (1.0, 120.0, (-0.08, 0.06, -0.05)),
+    (-0.65, 90.0, (0.09, -0.07, 0.08)),
+)
+
+
 SMOKE_CASES = (
-    AccuracyCase(q_order=2, n_levels=2, fmm_order=8, regular_quad_order=8, radial_quad_order=25),
-    AccuracyCase(q_order=3, n_levels=2, fmm_order=10, regular_quad_order=10, radial_quad_order=35),
+    AccuracyCase(
+        q_order=2,
+        n_levels=2,
+        fmm_order=8,
+        regular_quad_order=8,
+        radial_quad_order=25,
+    ),
+    AccuracyCase(
+        q_order=3,
+        n_levels=2,
+        fmm_order=10,
+        regular_quad_order=10,
+        radial_quad_order=35,
+    ),
 )
 
 FULL_CASES = (
-    AccuracyCase(q_order=2, n_levels=3, fmm_order=10, regular_quad_order=10, radial_quad_order=35),
-    AccuracyCase(q_order=3, n_levels=3, fmm_order=12, regular_quad_order=12, radial_quad_order=45),
-    AccuracyCase(q_order=4, n_levels=3, fmm_order=14, regular_quad_order=14, radial_quad_order=55),
+    AccuracyCase(
+        q_order=2,
+        n_levels=3,
+        fmm_order=14,
+        regular_quad_order=14,
+        radial_quad_order=55,
+    ),
+    AccuracyCase(
+        q_order=3,
+        n_levels=2,
+        fmm_order=14,
+        regular_quad_order=14,
+        radial_quad_order=55,
+    ),
+    AccuracyCase(
+        q_order=3,
+        n_levels=3,
+        fmm_order=14,
+        regular_quad_order=14,
+        radial_quad_order=55,
+    ),
+    AccuracyCase(
+        q_order=3,
+        n_levels=4,
+        fmm_order=14,
+        regular_quad_order=14,
+        radial_quad_order=55,
+    ),
+    AccuracyCase(
+        q_order=4,
+        n_levels=3,
+        fmm_order=14,
+        regular_quad_order=14,
+        radial_quad_order=55,
+    ),
 )
 
 FIELDS = (
@@ -58,71 +115,158 @@ FIELDS = (
     "problem",
     "dim",
     "kernel",
+    "kernel_normalization",
     "path",
     "reference_path",
     "reference_method",
+    "weighted_l2_definition",
     "q_order",
     "n_levels",
+    "h_max",
     "fmm_order",
     "regular_quad_order",
     "radial_quad_order",
+    "reference_quad_order",
+    "reference_check_quad_order",
     "n_targets",
     "wall_s",
+    "reference_boundary_weighted_l2",
+    "reference_boundary_linf",
+    "reference_quad_delta_weighted_l2",
+    "reference_quad_delta_linf",
     "rel_l2_vs_exact",
+    "rms_vs_exact",
+    "weighted_l2_vs_exact",
+    "weighted_rel_l2_vs_exact",
     "linf_vs_exact",
+    "h_observed_order_vs_exact",
+    "q_error_ratio_vs_previous",
+    "q_log_error_slope_vs_exact",
     "rel_l2_vs_direct",
+    "rms_vs_direct",
+    "weighted_l2_vs_direct",
+    "weighted_rel_l2_vs_direct",
     "linf_vs_direct",
     "rel_l2_vs_canonical",
+    "rms_vs_canonical",
+    "weighted_l2_vs_canonical",
+    "weighted_rel_l2_vs_canonical",
     "linf_vs_canonical",
 )
 
 
-def _to_obj_array(queue, arrays):
-    from pytools.obj_array import new_1d as obj_array_1d
-
-    return obj_array_1d(
-        [cl.array.to_device(queue, np.ascontiguousarray(a)) for a in arrays]
-    )
-
-
 def _build_manufactured_problem(dim):
-    x = pmbl.var("x")
-    y = pmbl.var("y")
-    z = pmbl.var("z")
+    if dim != 3:
+        raise ValueError("the manufactured problem is 3D")
+
+    variables = [pmbl.var(name) for name in ("x", "y", "z")]
     expp = pmbl.var("exp")
 
-    alpha_1 = 120.0
-    alpha_2 = 90.0
-    coeff_2 = -0.65
+    solution_expr = 0
+    source_expr = 0
+    for amplitude, alpha, center in GAUSSIAN_COMPONENTS:
+        radius_sq = sum(
+            (variable - center_i) ** 2
+            for variable, center_i in zip(variables, center, strict=True)
+        )
+        gaussian = amplitude * expp(-alpha * radius_sq)
+        solution_expr += gaussian
+        # LaplaceKernel(3) already has global scaling 1/(4*pi), so its Green's
+        # function must be convolved with f=-Delta u, without another 1/(4*pi).
+        source_expr += (2 * dim * alpha - 4 * alpha**2 * radius_sq) * gaussian
 
-    dx1 = x + 0.08
-    dy1 = y - 0.06
-    dz1 = z + 0.05
-    r1_sq = dx1**2 + dy1**2 + dz1**2
+    return source_expr, solution_expr, variables
 
-    dx2 = x - 0.09
-    dy2 = y + 0.07
-    dz2 = z - 0.08
-    r2_sq = dx2**2 + dy2**2 + dz2**2
 
-    g1 = expp(-alpha_1 * r1_sq)
-    g2 = expp(-alpha_2 * r2_sq)
+def _evaluate_manufactured_solution(points):
+    points = np.asarray(points, dtype=np.float64)
+    if points.ndim != 2 or points.shape[1] != 3:
+        raise ValueError("points must have shape (npoints, 3)")
 
-    solution_expr = g1 + coeff_2 * g2
-    source_expr = (
-        (2 * dim * alpha_1 - 4 * alpha_1**2 * r1_sq) * g1
-        + coeff_2 * (2 * dim * alpha_2 - 4 * alpha_2**2 * r2_sq) * g2
-    ) / (4.0 * np.pi)
+    values = np.zeros(points.shape[0], dtype=np.float64)
+    gradients = np.zeros_like(points)
+    for amplitude, alpha, center in GAUSSIAN_COMPONENTS:
+        offsets = points - np.asarray(center, dtype=np.float64)
+        component = amplitude * np.exp(-alpha * np.sum(offsets**2, axis=1))
+        values += component
+        gradients += (-2.0 * alpha * component)[:, np.newaxis] * offsets
+    return values, gradients
 
-    return source_expr, solution_expr, [x, y, z]
+
+def _finite_box_reference(targets, bbox, quad_order, *, chunk_size=256):
+    """Evaluate the finite-box potential using analytic Green representation.
+
+    For ``f=-Delta u`` and ``G=1/(4*pi*r)``, Green's second identity gives
+
+    ``integral_Omega G f = u + integral_boundary (u d_n G - G d_n u)``.
+
+    The six smooth face integrals are evaluated by overresolved tensor-product
+    Gauss-Legendre quadrature. Volume quadrature targets are strictly interior,
+    so the boundary integrands are nonsingular.
+    """
+
+    targets = np.asarray(targets, dtype=np.float64)
+    bbox = np.asarray(bbox, dtype=np.float64)
+    if targets.ndim != 2 or targets.shape[1] != 3:
+        raise ValueError("targets must have shape (npoints, 3)")
+    if bbox.shape != (3, 2):
+        raise ValueError("bbox must have shape (3, 2)")
+    if quad_order < 1:
+        raise ValueError("quad_order must be positive")
+
+    solution, _ = _evaluate_manufactured_solution(targets)
+    boundary_correction = np.zeros(targets.shape[0], dtype=np.float64)
+    nodes, weights = np.polynomial.legendre.leggauss(quad_order)
+    kernel_scale = 1.0 / (4.0 * np.pi)
+
+    for normal_axis in range(3):
+        tangential_axes = [axis for axis in range(3) if axis != normal_axis]
+        mapped_nodes = []
+        mapped_weights = []
+        for axis in tangential_axes:
+            lo, hi = bbox[axis]
+            mapped_nodes.append(0.5 * ((hi - lo) * nodes + hi + lo))
+            mapped_weights.append(0.5 * (hi - lo) * weights)
+        face_grid = np.meshgrid(*mapped_nodes, indexing="ij")
+        weight_grid = np.meshgrid(*mapped_weights, indexing="ij")
+        face_weights = np.prod(np.asarray(weight_grid), axis=0).ravel()
+
+        for side, normal_sign in ((0, -1.0), (1, 1.0)):
+            face_points = np.empty((quad_order**2, 3), dtype=np.float64)
+            face_points[:, normal_axis] = bbox[normal_axis, side]
+            for grid, axis in zip(face_grid, tangential_axes, strict=True):
+                face_points[:, axis] = grid.ravel()
+
+            face_solution, face_gradient = _evaluate_manufactured_solution(face_points)
+            normal_derivative = normal_sign * face_gradient[:, normal_axis]
+
+            for start in range(0, targets.shape[0], chunk_size):
+                stop = min(start + chunk_size, targets.shape[0])
+                displacement = (
+                    targets[start:stop, np.newaxis, :] - face_points[np.newaxis, :, :]
+                )
+                radius_sq = np.sum(displacement**2, axis=2)
+                green = kernel_scale / np.sqrt(radius_sq)
+                green_normal_derivative = (
+                    kernel_scale
+                    * normal_sign
+                    * displacement[:, :, normal_axis]
+                    / radius_sq**1.5
+                )
+                integrand = (
+                    face_solution[np.newaxis, :] * green_normal_derivative
+                    - green * normal_derivative[np.newaxis, :]
+                )
+                boundary_correction[start:stop] += integrand @ face_weights
+
+    return solution + boundary_correction, solution, boundary_correction
 
 
 def _build_geometry(ctx, queue, case):
     import volumential.meshgen as mg
 
     dim = 3
-    a = -0.5
-    b = 0.5
+    a, b = ROOT_BOUNDS
     mesh = mg.MeshGen3D(case.q_order, case.n_levels, a, b, queue=queue)
     q_points, q_weights, tree, traversal = mg.build_geometry_info(
         ctx,
@@ -132,7 +276,8 @@ def _build_geometry(ctx, queue, case):
         mesh,
         bbox=np.array([[a, b]] * dim, dtype=np.float64),
     )
-    return q_points, q_weights, tree, traversal
+    h_max = float(np.max(mesh.get_cell_measures()) ** (1.0 / dim))
+    return q_points, q_weights, tree, traversal, h_max
 
 
 def _build_tables(queue, tree, case, cache_dir, path):
@@ -251,54 +396,244 @@ def _norm_row(
     exact,
     direct,
     canonical,
+    weights,
+    h_max,
+    reference_quad_order,
+    reference_check_quad_order,
+    reference_boundary,
+    reference_quad_delta,
     wall_s,
 ):
-    exact_diff = values - exact
-    direct_diff = values - direct
-    canonical_diff = values - canonical
-    exact_norm = max(float(np.linalg.norm(exact)), 1.0e-300)
-    direct_norm = max(float(np.linalg.norm(direct)), 1.0e-300)
-    canonical_norm = max(float(np.linalg.norm(canonical)), 1.0e-300)
+    def metrics(diff, reference):
+        reference_norm = max(float(np.linalg.norm(reference)), 1.0e-300)
+        weighted_reference_norm = max(
+            float(np.sqrt(np.sum(weights * np.abs(reference) ** 2))),
+            1.0e-300,
+        )
+        weighted_error = float(np.sqrt(np.sum(weights * np.abs(diff) ** 2)))
+        return {
+            "rel_l2": float(np.linalg.norm(diff) / reference_norm),
+            "rms": float(np.sqrt(np.mean(np.abs(diff) ** 2))),
+            "weighted_l2": weighted_error,
+            "weighted_rel_l2": weighted_error / weighted_reference_norm,
+            "linf": float(np.max(np.abs(diff))),
+        }
+
+    exact_metrics = metrics(values - exact, exact)
+    direct_metrics = metrics(values - direct, direct)
+    canonical_metrics = metrics(values - canonical, canonical)
+
+    def weighted_l2(values):
+        return float(np.sqrt(np.sum(weights * np.abs(values) ** 2)))
+
     return {
         "case_id": f"poisson3d-q{case.q_order}-l{case.n_levels}",
         "mode": mode,
         "problem": "smooth-gaussian-poisson3d",
         "dim": 3,
         "kernel": "Laplace",
+        "kernel_normalization": "sumpy_global_scaling_1_over_4pi_r",
         "path": path,
         "reference_path": reference_path,
         "reference_method": reference_method,
+        "weighted_l2_definition": "sqrt(sum_i quadrature_weight_i * abs(value_i)**2)",
         "q_order": case.q_order,
         "n_levels": case.n_levels,
+        "h_max": h_max,
         "fmm_order": case.fmm_order,
         "regular_quad_order": case.regular_quad_order,
         "radial_quad_order": case.radial_quad_order,
+        "reference_quad_order": reference_quad_order,
+        "reference_check_quad_order": reference_check_quad_order,
         "n_targets": values.size,
         "wall_s": wall_s,
-        "rel_l2_vs_exact": float(np.linalg.norm(exact_diff) / exact_norm),
-        "linf_vs_exact": float(np.max(np.abs(exact_diff))),
-        "rel_l2_vs_direct": float(np.linalg.norm(direct_diff) / direct_norm),
-        "linf_vs_direct": float(np.max(np.abs(direct_diff))),
-        "rel_l2_vs_canonical": float(np.linalg.norm(canonical_diff) / canonical_norm),
-        "linf_vs_canonical": float(np.max(np.abs(canonical_diff))),
+        "reference_boundary_weighted_l2": weighted_l2(reference_boundary),
+        "reference_boundary_linf": float(np.max(np.abs(reference_boundary))),
+        "reference_quad_delta_weighted_l2": weighted_l2(reference_quad_delta),
+        "reference_quad_delta_linf": float(np.max(np.abs(reference_quad_delta))),
+        "rel_l2_vs_exact": exact_metrics["rel_l2"],
+        "rms_vs_exact": exact_metrics["rms"],
+        "weighted_l2_vs_exact": exact_metrics["weighted_l2"],
+        "weighted_rel_l2_vs_exact": exact_metrics["weighted_rel_l2"],
+        "linf_vs_exact": exact_metrics["linf"],
+        "h_observed_order_vs_exact": "",
+        "q_error_ratio_vs_previous": "",
+        "q_log_error_slope_vs_exact": "",
+        "rel_l2_vs_direct": direct_metrics["rel_l2"],
+        "rms_vs_direct": direct_metrics["rms"],
+        "weighted_l2_vs_direct": direct_metrics["weighted_l2"],
+        "weighted_rel_l2_vs_direct": direct_metrics["weighted_rel_l2"],
+        "linf_vs_direct": direct_metrics["linf"],
+        "rel_l2_vs_canonical": canonical_metrics["rel_l2"],
+        "rms_vs_canonical": canonical_metrics["rms"],
+        "weighted_l2_vs_canonical": canonical_metrics["weighted_l2"],
+        "weighted_rel_l2_vs_canonical": canonical_metrics["weighted_rel_l2"],
+        "linf_vs_canonical": canonical_metrics["linf"],
     }
 
 
-def run_benchmark(*, mode: str, cache_dir: Path):
+def _add_convergence_rates(rows):
+    h_groups = {}
+    q_groups = {}
+    for row in rows:
+        h_groups.setdefault((row["path"], row["q_order"]), []).append(row)
+        q_groups.setdefault((row["path"], row["n_levels"]), []).append(row)
+
+    for group in h_groups.values():
+        group.sort(key=lambda row: row["h_max"], reverse=True)
+        for coarse, fine in zip(group, group[1:], strict=False):
+            coarse_h = float(coarse["h_max"])
+            fine_h = float(fine["h_max"])
+            coarse_error = float(coarse["weighted_rel_l2_vs_exact"])
+            fine_error = float(fine["weighted_rel_l2_vs_exact"])
+            if coarse_h > fine_h and coarse_error > 0.0 and fine_error > 0.0:
+                fine["h_observed_order_vs_exact"] = float(
+                    np.log(coarse_error / fine_error) / np.log(coarse_h / fine_h)
+                )
+
+    for group in q_groups.values():
+        group.sort(key=lambda row: row["q_order"])
+        for previous, current in zip(group, group[1:], strict=False):
+            previous_q = int(previous["q_order"])
+            current_q = int(current["q_order"])
+            previous_error = float(previous["weighted_rel_l2_vs_exact"])
+            current_error = float(current["weighted_rel_l2_vs_exact"])
+            if current_q > previous_q and previous_error > 0.0 and current_error > 0.0:
+                ratio = current_error / previous_error
+                current["q_error_ratio_vs_previous"] = float(ratio)
+                current["q_log_error_slope_vs_exact"] = float(
+                    -np.log(ratio) / (current_q - previous_q)
+                )
+
+
+def _make_case(
+    q_order,
+    n_levels,
+    *,
+    mode,
+    fmm_order=None,
+    regular_quad_order=None,
+    radial_quad_order=None,
+):
+    if q_order < 1:
+        raise ValueError("q_order must be positive")
+    if n_levels < 1:
+        raise ValueError("n_levels must be positive")
+
+    if mode == "smoke":
+        default_fmm_order = 2 * q_order + 4
+        default_regular_order = 2 * q_order + 4
+        default_radial_order = 10 * q_order + 5
+    else:
+        default_fmm_order = 2 * q_order + 6
+        default_regular_order = 2 * q_order + 6
+        default_radial_order = 10 * q_order + 15
+
+    return AccuracyCase(
+        q_order=q_order,
+        n_levels=n_levels,
+        fmm_order=default_fmm_order if fmm_order is None else fmm_order,
+        regular_quad_order=(
+            default_regular_order if regular_quad_order is None else regular_quad_order
+        ),
+        radial_quad_order=(
+            default_radial_order if radial_quad_order is None else radial_quad_order
+        ),
+    )
+
+
+def _select_cases(
+    *,
+    mode,
+    q_orders=None,
+    n_levels=None,
+    fmm_order=None,
+    regular_quad_order=None,
+    radial_quad_order=None,
+):
+    preset = SMOKE_CASES if mode == "smoke" else FULL_CASES
+    if q_orders is None and n_levels is None:
+        selected = preset
+    else:
+        selected_q_orders = (
+            sorted({case.q_order for case in preset})
+            if q_orders is None
+            else list(dict.fromkeys(q_orders))
+        )
+        selected_n_levels = (
+            sorted({case.n_levels for case in preset})
+            if n_levels is None
+            else list(dict.fromkeys(n_levels))
+        )
+        selected = tuple(
+            _make_case(q_order, level, mode=mode)
+            for q_order in selected_q_orders
+            for level in selected_n_levels
+        )
+
+    if any(
+        order is not None
+        for order in (fmm_order, regular_quad_order, radial_quad_order)
+    ):
+        selected = tuple(
+            AccuracyCase(
+                q_order=case.q_order,
+                n_levels=case.n_levels,
+                fmm_order=case.fmm_order if fmm_order is None else fmm_order,
+                regular_quad_order=(
+                    case.regular_quad_order
+                    if regular_quad_order is None
+                    else regular_quad_order
+                ),
+                radial_quad_order=(
+                    case.radial_quad_order
+                    if radial_quad_order is None
+                    else radial_quad_order
+                ),
+            )
+            for case in selected
+        )
+    return selected
+
+
+def run_benchmark(
+    *,
+    mode: str,
+    cache_dir: Path,
+    cases=None,
+    reference_quad_order=None,
+):
     ctx = cl.create_some_context(interactive=False)
     queue = cl.CommandQueue(ctx)
-    cases = SMOKE_CASES if mode == "smoke" else FULL_CASES
+    if cases is None:
+        cases = SMOKE_CASES if mode == "smoke" else FULL_CASES
+    if reference_quad_order is None:
+        reference_quad_order = 24 if mode == "smoke" else 40
+    if reference_quad_order < 2:
+        raise ValueError("reference_quad_order must be at least 2")
+    reference_check_quad_order = max(1, reference_quad_order // 2)
+    bbox = np.array([ROOT_BOUNDS] * 3, dtype=np.float64)
 
     rows: list[dict[str, Any]] = []
     for case in cases:
-        q_points, q_weights, tree, traversal = _build_geometry(ctx, queue, case)
-        source_expr, solution_expr, variables = _build_manufactured_problem(3)
+        q_points, q_weights, tree, traversal, h_max = _build_geometry(ctx, queue, case)
+        source_expr, _, variables = _build_manufactured_problem(3)
         source_eval = Eval(3, source_expr, variables)
-        solution_eval = Eval(3, solution_expr, variables)
         q_coords = np.array([coords.get() for coords in q_points])
+        q_weights_host = q_weights.get(queue)
         source_vals = cl.array.to_device(queue, source_eval(queue, q_coords))
-        exact = solution_eval(queue, q_coords)
         source_strengths = source_vals * q_weights
+        exact, _, reference_boundary = _finite_box_reference(
+            q_coords.T,
+            bbox,
+            reference_quad_order,
+        )
+        reference_check, _, _ = _finite_box_reference(
+            q_coords.T,
+            bbox,
+            reference_check_quad_order,
+        )
+        reference_quad_delta = exact - reference_check
 
         canonical_table = _build_tables(queue, tree, case, cache_dir, "canonical")
         per_level_tables = _build_tables(queue, tree, case, cache_dir, "per_level")
@@ -334,49 +669,50 @@ def run_benchmark(*, mode: str, cache_dir: Path):
             direct_evaluation=True,
         )
 
+        common_norm_args = {
+            "mode": mode,
+            "case": case,
+            "reference_path": "finite_box_green_identity",
+            "reference_method": (
+                "analytic Gaussian u plus overresolved Gauss-Legendre "
+                "boundary correction"
+            ),
+            "exact": exact,
+            "direct": direct,
+            "canonical": canonical,
+            "weights": q_weights_host,
+            "h_max": h_max,
+            "reference_quad_order": reference_quad_order,
+            "reference_check_quad_order": reference_check_quad_order,
+            "reference_boundary": reference_boundary,
+            "reference_quad_delta": reference_quad_delta,
+        }
         rows.append(
             _norm_row(
-                mode=mode,
-                case=case,
                 path="canonical_rescaled",
-                reference_path="exact",
-                reference_method="manufactured analytic solution",
                 values=canonical,
-                exact=exact,
-                direct=direct,
-                canonical=canonical,
                 wall_s=canonical_wall_s,
+                **common_norm_args,
             )
         )
         rows.append(
             _norm_row(
-                mode=mode,
-                case=case,
                 path="per_level_tables",
-                reference_path="exact",
-                reference_method="manufactured analytic solution",
                 values=per_level,
-                exact=exact,
-                direct=direct,
-                canonical=canonical,
                 wall_s=per_level_wall_s,
+                **common_norm_args,
             )
         )
         rows.append(
             _norm_row(
-                mode=mode,
-                case=case,
                 path="direct_p2p",
-                reference_path="exact",
-                reference_method="manufactured analytic solution; P2P diagnostic path",
                 values=direct,
-                exact=exact,
-                direct=direct,
-                canonical=canonical,
                 wall_s=direct_wall_s,
+                **common_norm_args,
             )
         )
 
+    _add_convergence_rates(rows)
     return rows
 
 
@@ -388,9 +724,48 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
+def _positive_int(value):
+    value = int(value)
+    if value < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return value
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
+    parser.add_argument(
+        "--q-orders",
+        type=_positive_int,
+        nargs="+",
+        help="q orders; forms a Cartesian product with --n-levels",
+    )
+    parser.add_argument(
+        "--n-levels",
+        type=_positive_int,
+        nargs="+",
+        help="uniform mesh level counts; forms a Cartesian product with --q-orders",
+    )
+    parser.add_argument(
+        "--fmm-order",
+        type=_positive_int,
+        help="fixed FMM order for every selected h/q case",
+    )
+    parser.add_argument(
+        "--regular-quad-order",
+        type=_positive_int,
+        help="fixed regular near-field quadrature order for every selected case",
+    )
+    parser.add_argument(
+        "--radial-quad-order",
+        type=_positive_int,
+        help="fixed radial near-field quadrature order for every selected case",
+    )
+    parser.add_argument(
+        "--reference-quad-order",
+        type=_positive_int,
+        help="Gauss-Legendre order per boundary-face axis (default: 24/40)",
+    )
     parser.add_argument(
         "--out",
         type=Path,
@@ -402,7 +777,20 @@ def main() -> int:
         default=Path("build/benchmarks/accuracy-cache"),
     )
     args = parser.parse_args()
-    rows = run_benchmark(mode=args.mode, cache_dir=args.cache_dir)
+    cases = _select_cases(
+        mode=args.mode,
+        q_orders=args.q_orders,
+        n_levels=args.n_levels,
+        fmm_order=args.fmm_order,
+        regular_quad_order=args.regular_quad_order,
+        radial_quad_order=args.radial_quad_order,
+    )
+    rows = run_benchmark(
+        mode=args.mode,
+        cache_dir=args.cache_dir,
+        cases=cases,
+        reference_quad_order=args.reference_quad_order,
+    )
     write_csv(args.out, rows)
     return 0
 

--- a/benchmarks/adaptive_timing.py
+++ b/benchmarks/adaptive_timing.py
@@ -2,15 +2,18 @@
 """Emit adaptive end-to-end timing CSVs for Paper 1.
 
 The benchmark runs 2D Laplace volume-potential evaluations on meshes refined by
-a fixed Gaussian indicator. It records cold-cache and warm-cache timing stacks
-for geometry construction, table build/load, and FMM phases exposed by
-``drive_volume_fmm``.
+a fixed Gaussian indicator. It records graded-tree/List 1 diagnostics,
+cold-cache and warm-cache setup timing, and independent post-warmup FMM samples
+with median and spread statistics. Each case also performs one untimed comparison
+between the canonical scaled table and direct tables for every populated source
+level.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import json
 import time
 from pathlib import Path
 from typing import Any
@@ -31,6 +34,12 @@ FIELDS = (
     "n_targets",
     "min_leaf_level",
     "max_leaf_level",
+    "leaf_level_histogram_json",
+    "max_adjacent_leaf_level_difference",
+    "n_list1_interactions",
+    "n_cross_level_list1_interactions",
+    "cross_level_list1_fraction",
+    "list1_source_target_level_pair_histogram_json",
     "mesh_init_s",
     "adapt_s",
     "geometry_s",
@@ -38,7 +47,15 @@ FIELDS = (
     "table_build_s",
     "table_load_s",
     "table_payload_bytes",
+    "fmm_warmup_count",
+    "fmm_trial_count",
     "fmm_wall_s",
+    "fmm_wall_median_s",
+    "fmm_wall_iqr_s",
+    "fmm_wall_min_s",
+    "fmm_wall_max_s",
+    "fmm_wall_samples_s_json",
+    "fmm_phase_samples_s_json",
     "timing_form_multipoles_s",
     "timing_coarsen_multipoles_s",
     "timing_eval_direct_s",
@@ -47,11 +64,40 @@ FIELDS = (
     "timing_form_locals_s",
     "timing_refine_locals_s",
     "timing_eval_locals_s",
+    "path_mismatch_norm_definition",
+    "canonical_vs_per_level_weighted_rel_l2",
+    "canonical_vs_per_level_linf",
+    "populated_source_levels_json",
+    "canonical_table_count",
+    "canonical_table_build_s",
+    "canonical_table_payload_bytes",
+    "per_level_table_count",
+    "per_level_table_build_s",
+    "per_level_table_payload_bytes",
 )
 
 
 SMOKE_CASES = ((3, 2, 1),)
-FULL_CASES = ((3, 2, 2), (4, 2, 2), (4, 3, 2))
+FULL_CASES = ((3, 4, 2), (4, 4, 2), (4, 4, 3))
+
+# Each successive shell is strictly inside the previous one. On the full-case
+# level-3 base mesh, this leaves a one-level transition band around finer boxes.
+REFINEMENT_THRESHOLDS = (1.0e-3, 0.5, 0.9)
+SMOKE_WARMUP_COUNT = 1
+SMOKE_TRIAL_COUNT = 3
+FULL_WARMUP_COUNT = 2
+FULL_TRIAL_COUNT = 7
+
+FMM_TIMING_PHASES = (
+    "form_multipoles",
+    "coarsen_multipoles",
+    "eval_direct",
+    "multipole_to_local",
+    "eval_multipoles",
+    "form_locals",
+    "refine_locals",
+    "eval_locals",
+)
 
 
 def _device_supports_fp64(device) -> bool:
@@ -101,18 +147,38 @@ def _indicator(mesh) -> np.ndarray:
 
 
 def _build_adaptive_geometry(ctx, queue, q_order: int, initial_nlevels: int, adapt_steps: int):
+    from boxtree import refine_and_coarsen_tree_of_boxes
     import volumential.meshgen as mg
+
+    if adapt_steps > len(REFINEMENT_THRESHOLDS):
+        raise ValueError(
+            f"adapt_steps={adapt_steps} exceeds the supported nested refinement "
+            f"shell count ({len(REFINEMENT_THRESHOLDS)})"
+        )
 
     start = time.perf_counter()
     mesh = mg.MeshGen2D(q_order, initial_nlevels, -0.5, 0.5, queue=queue)  # pyright: ignore[reportArgumentType]
     mesh_init_s = time.perf_counter() - start
 
     start = time.perf_counter()
-    for _ in range(adapt_steps):
-        mesh.update_mesh(
-            _indicator(mesh),
-            top_fraction_of_cells=0.35,
-            bottom_fraction_of_cells=0.0,
+    for threshold in REFINEMENT_THRESHOLDS[:adapt_steps]:
+        tree_of_boxes = mesh.boxtree._tree
+        leaf_boxes = np.asarray(tree_of_boxes.leaf_boxes)
+        refine_boxes = leaf_boxes[_indicator(mesh) >= threshold]
+        if not len(refine_boxes):
+            raise RuntimeError(
+                f"Gaussian refinement shell {threshold} selected no leaf boxes"
+            )
+
+        refine_flags = np.zeros(tree_of_boxes.nboxes, dtype=bool)
+        refine_flags[refine_boxes] = True
+
+        # MeshGen's public update path also closes same-level colleagues, which
+        # turns these compact cases uniform. The nested shells are independently
+        # checked for 2:1 balance below, before any timing work is performed.
+        mesh.boxtree._tree = refine_and_coarsen_tree_of_boxes(
+            tree_of_boxes,
+            refine_flags=refine_flags,
         )
     adapt_s = time.perf_counter() - start
 
@@ -129,9 +195,108 @@ def _build_adaptive_geometry(ctx, queue, q_order: int, initial_nlevels: int, ada
     return mesh, q_points, q_weights, tree, traversal, mesh_init_s, adapt_s, geometry_s
 
 
-def _leaf_level_stats(mesh):
-    levels = mesh.boxtree.box_levels.get()[mesh.boxtree.active_boxes.get()]
-    return int(np.min(levels)), int(np.max(levels))
+def _leaf_diagnostics(mesh) -> dict[str, Any]:
+    tree_of_boxes = mesh.boxtree._tree
+    leaf_boxes = np.asarray(tree_of_boxes.leaf_boxes)
+    levels = np.asarray(tree_of_boxes.box_levels)[leaf_boxes]
+    unique_levels, level_counts = np.unique(levels, return_counts=True)
+    histogram = {
+        str(int(level)): int(count)
+        for level, count in zip(unique_levels, level_counts, strict=True)
+    }
+
+    centers = np.asarray(tree_of_boxes.box_centers)[:, leaf_boxes].T
+    side_lengths = float(tree_of_boxes.root_extent) * np.exp2(
+        -levels.astype(np.float64)
+    )
+    max_adjacent_difference = 0
+    for i in range(len(leaf_boxes)):
+        touching = np.all(
+            np.abs(centers[i + 1 :] - centers[i])
+            <= 0.5 * (side_lengths[i + 1 :] + side_lengths[i])[:, np.newaxis]
+            + 1.0e-14,
+            axis=1,
+        )
+        if np.any(touching):
+            max_adjacent_difference = max(
+                max_adjacent_difference,
+                int(np.max(np.abs(levels[i + 1 :][touching] - levels[i]))),
+            )
+
+    return {
+        "min_leaf_level": int(np.min(levels)),
+        "max_leaf_level": int(np.max(levels)),
+        "leaf_level_histogram_json": json.dumps(
+            histogram, sort_keys=True, separators=(",", ":")
+        ),
+        "max_adjacent_leaf_level_difference": max_adjacent_difference,
+    }
+
+
+def _to_host(queue, ary) -> np.ndarray:
+    if hasattr(ary, "get"):
+        return np.asarray(ary.get(queue))
+    return np.asarray(ary)
+
+
+def _list1_diagnostics(queue, tree, traversal) -> dict[str, Any]:
+    box_levels = _to_host(queue, tree.box_levels)
+    target_boxes = _to_host(queue, traversal.target_boxes)
+    starts = _to_host(queue, traversal.neighbor_source_boxes_starts)
+    source_boxes = _to_host(queue, traversal.neighbor_source_boxes_lists)
+
+    interactions_per_target = np.diff(starts)
+    target_levels = np.repeat(box_levels[target_boxes], interactions_per_target)
+    source_levels = box_levels[source_boxes]
+    if len(source_levels) != len(target_levels):
+        raise RuntimeError("List 1 starts/lists arrays have inconsistent lengths")
+
+    pair_histogram = {}
+    if len(source_levels):
+        pairs, counts = np.unique(
+            np.column_stack((source_levels, target_levels)),
+            axis=0,
+            return_counts=True,
+        )
+        pair_histogram = {
+            f"{int(source_level)}->{int(target_level)}": int(count)
+            for (source_level, target_level), count in zip(pairs, counts, strict=True)
+        }
+
+    cross_level_count = int(np.count_nonzero(source_levels != target_levels))
+    interaction_count = int(len(source_levels))
+    return {
+        "n_list1_interactions": interaction_count,
+        "n_cross_level_list1_interactions": cross_level_count,
+        "cross_level_list1_fraction": (
+            cross_level_count / interaction_count if interaction_count else 0.0
+        ),
+        "list1_source_target_level_pair_histogram_json": json.dumps(
+            pair_histogram, sort_keys=True, separators=(",", ":")
+        ),
+    }
+
+
+def _populated_source_levels(queue, tree, traversal) -> list[int]:
+    box_levels = _to_host(queue, tree.box_levels)
+    target_boxes = _to_host(queue, traversal.target_boxes)
+    source_boxes = _to_host(queue, traversal.neighbor_source_boxes_lists)
+    leaf_levels = np.unique(box_levels[target_boxes])
+    source_levels = np.unique(box_levels[source_boxes])
+    if not np.array_equal(leaf_levels, source_levels):
+        raise RuntimeError(
+            "populated leaf and List 1 source levels do not cover the same levels"
+        )
+    return [int(level) for level in source_levels]
+
+
+def _validate_adaptive_diagnostics(leaf_diagnostics, list1_diagnostics) -> None:
+    if leaf_diagnostics["min_leaf_level"] >= leaf_diagnostics["max_leaf_level"]:
+        raise RuntimeError("adaptive benchmark produced a uniform leaf level")
+    if leaf_diagnostics["max_adjacent_leaf_level_difference"] > 1:
+        raise RuntimeError("adaptive benchmark produced a tree that is not 2:1 balanced")
+    if list1_diagnostics["n_cross_level_list1_interactions"] <= 0:
+        raise RuntimeError("adaptive benchmark produced no cross-level List 1 work")
 
 
 def _build_config(q_order: int):
@@ -161,6 +326,61 @@ def _get_table(queue, cache_path: Path, q_order: int, *, force_recompute: bool):
         )
         timings = table_manager.last_get_table_timings
     return table, timings
+
+
+def _get_per_level_tables(
+    queue,
+    cache_path: Path,
+    q_order: int,
+    source_levels: list[int],
+    *,
+    tree_root_extent: float,
+):
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    if len(source_levels) < 2:
+        raise RuntimeError("per-level equivalence requires mixed source levels")
+    expected_levels = list(range(source_levels[0], source_levels[-1] + 1))
+    if source_levels != expected_levels:
+        raise RuntimeError(
+            "populated source levels must be consecutive for the multilevel table path"
+        )
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    if cache_path.exists():
+        cache_path.unlink()
+
+    tables = []
+    build_s = 0.0
+    payload_bytes = 0
+    with NearFieldInteractionTableManager(
+        str(cache_path), root_extent=tree_root_extent, queue=queue
+    ) as table_manager:
+        for level in source_levels:
+            table, _ = table_manager.get_table(
+                2,
+                "Laplace",
+                q_order,
+                source_box_level=level,
+                force_recompute=True,
+                queue=queue,
+                build_config=_build_config(q_order),
+            )
+            timings = table_manager.last_get_table_timings
+            if int(table.source_box_level) != level:
+                raise RuntimeError(
+                    f"requested direct table level {level}, got "
+                    f"{int(table.source_box_level)}"
+                )
+            tables.append(table)
+            build_s += _table_build_seconds(timings)
+            payload_bytes += int(_table_payload_bytes(timings))
+
+    return tables, {
+        "per_level_table_count": len(tables),
+        "per_level_table_build_s": build_s,
+        "per_level_table_payload_bytes": payload_bytes,
+    }
 
 
 def _source_values(queue, q_points):
@@ -236,7 +456,7 @@ def _run_fmm(ctx, queue, traversal, table, q_order: int, fmm_order: int, q_weigh
     timing_data: dict[str, Any] = {}
     queue.finish()
     start = time.perf_counter()
-    _ = drive_volume_fmm(
+    (potential,) = drive_volume_fmm(
         traversal,
         wrangler,
         source_vals * q_weights,
@@ -246,7 +466,64 @@ def _run_fmm(ctx, queue, traversal, table, q_order: int, fmm_order: int, q_weigh
         timing_data=timing_data,
     )
     queue.finish()
-    return time.perf_counter() - start, timing_data
+    return time.perf_counter() - start, timing_data, potential
+
+
+def _run_fmm_trials(
+    ctx,
+    queue,
+    traversal,
+    table,
+    q_order: int,
+    fmm_order: int,
+    q_weights,
+    q_points,
+    *,
+    warmup_count: int,
+    trial_count: int,
+):
+    for _ in range(warmup_count):
+        _run_fmm(
+            ctx, queue, traversal, table, q_order, fmm_order, q_weights, q_points
+        )
+
+    wall_samples = []
+    phase_samples = {phase: [] for phase in FMM_TIMING_PHASES}
+    last_potential = None
+    for _ in range(trial_count):
+        wall_s, timing_data, last_potential = _run_fmm(
+            ctx, queue, traversal, table, q_order, fmm_order, q_weights, q_points
+        )
+        wall_samples.append(wall_s)
+        for phase in FMM_TIMING_PHASES:
+            phase_s = _timing_seconds(timing_data.get(phase))
+            if isinstance(phase_s, float):
+                phase_samples[phase].append(phase_s)
+
+    assert last_potential is not None
+    return (
+        wall_samples,
+        {phase: samples for phase, samples in phase_samples.items() if samples},
+        last_potential.get(queue),
+    )
+
+
+def _sample_statistics(samples) -> dict[str, float]:
+    values = np.asarray(samples, dtype=np.float64)
+    if not len(values):
+        raise ValueError("at least one timing sample is required")
+    q25, q75 = np.percentile(values, (25, 75))
+    return {
+        "median": float(np.median(values)),
+        "iqr": float(q75 - q25),
+        "min": float(np.min(values)),
+        "max": float(np.max(values)),
+    }
+
+
+def _phase_median(phase_samples, phase: str) -> float | str:
+    samples = phase_samples.get(phase, ())
+    return _sample_statistics(samples)["median"] if samples else ""
 
 
 def _table_phase_seconds(timings, phase: str) -> float | str:
@@ -265,6 +542,57 @@ def _table_payload_bytes(timings) -> int | str:
     return int(details.get("payload_bytes", 0)) if details else ""
 
 
+def _table_build_seconds(timings) -> float:
+    if not timings:
+        return 0.0
+    details = timings.get("compute") or {}
+    return float(details.get("table_build_s", details.get("total_s", 0.0)))
+
+
+def _equivalence_diagnostics(
+    canonical_potential,
+    per_level_potential,
+    q_weights,
+    source_levels: list[int],
+    canonical_table_timings,
+    per_level_table_diagnostics,
+) -> dict[str, Any]:
+    if len(source_levels) < 2:
+        raise RuntimeError("canonical/per-level comparison requires mixed source levels")
+    if not (
+        np.all(np.isfinite(canonical_potential))
+        and np.all(np.isfinite(per_level_potential))
+    ):
+        raise RuntimeError("canonical/per-level comparison produced non-finite values")
+
+    weights = q_weights.get()
+    difference = canonical_potential - per_level_potential
+    weighted_error = float(np.sqrt(np.sum(weights * np.abs(difference) ** 2)))
+    weighted_reference = max(
+        float(np.sqrt(np.sum(weights * np.abs(per_level_potential) ** 2))),
+        1.0e-300,
+    )
+    return {
+        "path_mismatch_norm_definition": (
+            "weighted_rel_l2=sqrt(sum_i quadrature_weight_i*"
+            "abs(canonical_i-per_level_i)**2)/max(sqrt(sum_i "
+            "quadrature_weight_i*abs(per_level_i)**2),1e-300);"
+            "linf=max_i abs(canonical_i-per_level_i)"
+        ),
+        "canonical_vs_per_level_weighted_rel_l2": (
+            weighted_error / weighted_reference
+        ),
+        "canonical_vs_per_level_linf": float(np.max(np.abs(difference))),
+        "populated_source_levels_json": json.dumps(source_levels, separators=(",", ":")),
+        "canonical_table_count": 1,
+        "canonical_table_build_s": _table_build_seconds(canonical_table_timings),
+        "canonical_table_payload_bytes": _table_payload_bytes(
+            canonical_table_timings
+        ),
+        **per_level_table_diagnostics,
+    }
+
+
 def _row(
     *,
     mode: str,
@@ -278,10 +606,13 @@ def _row(
     adapt_s: float,
     geometry_s: float,
     table_timings,
-    fmm_wall_s: float,
-    fmm_timings,
+    leaf_diagnostics,
+    list1_diagnostics,
+    fmm_warmup_count: int,
+    fmm_wall_samples,
+    fmm_phase_samples,
 ) -> dict[str, Any]:
-    min_level, max_level = _leaf_level_stats(mesh)
+    wall_stats = _sample_statistics(fmm_wall_samples)
     return {
         "case_id": f"laplace2d-q{q_order}-l{initial_nlevels}-a{adapt_steps}",
         "mode": mode,
@@ -292,8 +623,8 @@ def _row(
         "n_active_boxes": int(mesh.n_active_cells()),
         "n_total_boxes": int(mesh.n_cells()),
         "n_targets": int(tree.ntargets),
-        "min_leaf_level": min_level,
-        "max_leaf_level": max_level,
+        **leaf_diagnostics,
+        **list1_diagnostics,
         "mesh_init_s": mesh_init_s,
         "adapt_s": adapt_s,
         "geometry_s": geometry_s,
@@ -301,35 +632,85 @@ def _row(
         "table_build_s": _table_phase_seconds(table_timings, "compute"),
         "table_load_s": _table_phase_seconds(table_timings, "load"),
         "table_payload_bytes": _table_payload_bytes(table_timings),
-        "fmm_wall_s": fmm_wall_s,
-        "timing_form_multipoles_s": _timing_seconds(fmm_timings.get("form_multipoles")),
-        "timing_coarsen_multipoles_s": _timing_seconds(fmm_timings.get("coarsen_multipoles")),
-        "timing_eval_direct_s": _timing_seconds(fmm_timings.get("eval_direct")),
-        "timing_multipole_to_local_s": _timing_seconds(fmm_timings.get("multipole_to_local")),
-        "timing_eval_multipoles_s": _timing_seconds(fmm_timings.get("eval_multipoles")),
-        "timing_form_locals_s": _timing_seconds(fmm_timings.get("form_locals")),
-        "timing_refine_locals_s": _timing_seconds(fmm_timings.get("refine_locals")),
-        "timing_eval_locals_s": _timing_seconds(fmm_timings.get("eval_locals")),
+        "fmm_warmup_count": fmm_warmup_count,
+        "fmm_trial_count": len(fmm_wall_samples),
+        # Keep the legacy wall/phase columns, now as medians over measured trials.
+        "fmm_wall_s": wall_stats["median"],
+        "fmm_wall_median_s": wall_stats["median"],
+        "fmm_wall_iqr_s": wall_stats["iqr"],
+        "fmm_wall_min_s": wall_stats["min"],
+        "fmm_wall_max_s": wall_stats["max"],
+        "fmm_wall_samples_s_json": json.dumps(
+            fmm_wall_samples, separators=(",", ":")
+        ),
+        "fmm_phase_samples_s_json": json.dumps(
+            fmm_phase_samples, sort_keys=True, separators=(",", ":")
+        ),
+        "timing_form_multipoles_s": _phase_median(
+            fmm_phase_samples, "form_multipoles"
+        ),
+        "timing_coarsen_multipoles_s": _phase_median(
+            fmm_phase_samples, "coarsen_multipoles"
+        ),
+        "timing_eval_direct_s": _phase_median(fmm_phase_samples, "eval_direct"),
+        "timing_multipole_to_local_s": _phase_median(
+            fmm_phase_samples, "multipole_to_local"
+        ),
+        "timing_eval_multipoles_s": _phase_median(
+            fmm_phase_samples, "eval_multipoles"
+        ),
+        "timing_form_locals_s": _phase_median(fmm_phase_samples, "form_locals"),
+        "timing_refine_locals_s": _phase_median(
+            fmm_phase_samples, "refine_locals"
+        ),
+        "timing_eval_locals_s": _phase_median(fmm_phase_samples, "eval_locals"),
     }
 
 
-def run_case(ctx, queue, *, mode: str, cache_dir: Path, q_order: int, initial_nlevels: int, adapt_steps: int):
+def run_case(
+    ctx,
+    queue,
+    *,
+    mode: str,
+    cache_dir: Path,
+    q_order: int,
+    initial_nlevels: int,
+    adapt_steps: int,
+    warmup_count: int,
+    trial_count: int,
+):
     cache_path = cache_dir / f"adaptive-laplace2d-q{q_order}.sqlite"
     if cache_path.exists():
         cache_path.unlink()
 
     fmm_order = max(8, 4 * q_order)
     rows = []
+    canonical_table_timings = None
+    canonical_potential = None
     for cache_state, force_recompute in (("cold", True), ("warm", False)):
         mesh, q_points, q_weights, tree, traversal, mesh_init_s, adapt_s, geometry_s = (
             _build_adaptive_geometry(ctx, queue, q_order, initial_nlevels, adapt_steps)
         )
+        leaf_diagnostics = _leaf_diagnostics(mesh)
+        list1_diagnostics = _list1_diagnostics(queue, tree, traversal)
+        _validate_adaptive_diagnostics(leaf_diagnostics, list1_diagnostics)
         table, table_timings = _get_table(
             queue, cache_path, q_order, force_recompute=force_recompute
         )
-        fmm_wall_s, fmm_timings = _run_fmm(
-            ctx, queue, traversal, table, q_order, fmm_order, q_weights, q_points
+        fmm_wall_samples, fmm_phase_samples, canonical_potential = _run_fmm_trials(
+            ctx,
+            queue,
+            traversal,
+            table,
+            q_order,
+            fmm_order,
+            q_weights,
+            q_points,
+            warmup_count=warmup_count,
+            trial_count=trial_count,
         )
+        if cache_state == "cold":
+            canonical_table_timings = table_timings
         rows.append(
             _row(
                 mode=mode,
@@ -343,18 +724,71 @@ def run_case(ctx, queue, *, mode: str, cache_dir: Path, q_order: int, initial_nl
                 adapt_s=adapt_s,
                 geometry_s=geometry_s,
                 table_timings=table_timings,
-                fmm_wall_s=fmm_wall_s,
-                fmm_timings=fmm_timings,
+                leaf_diagnostics=leaf_diagnostics,
+                list1_diagnostics=list1_diagnostics,
+                fmm_warmup_count=warmup_count,
+                fmm_wall_samples=fmm_wall_samples,
+                fmm_phase_samples=fmm_phase_samples,
             )
         )
+
+    assert canonical_table_timings is not None
+    assert canonical_potential is not None
+    source_levels = _populated_source_levels(queue, tree, traversal)
+    per_level_cache_path = cache_dir / (
+        f"adaptive-laplace2d-q{q_order}-l{initial_nlevels}-a{adapt_steps}-"
+        "per-level.sqlite"
+    )
+    per_level_tables, per_level_table_diagnostics = _get_per_level_tables(
+        queue,
+        per_level_cache_path,
+        q_order,
+        source_levels,
+        tree_root_extent=float(tree.root_extent),
+    )
+    _, _, per_level_potential_dev = _run_fmm(
+        ctx,
+        queue,
+        traversal,
+        per_level_tables,
+        q_order,
+        fmm_order,
+        q_weights,
+        q_points,
+    )
+    equivalence_diagnostics = _equivalence_diagnostics(
+        canonical_potential,
+        per_level_potential_dev.get(queue),
+        q_weights,
+        source_levels,
+        canonical_table_timings,
+        per_level_table_diagnostics,
+    )
+    for row in rows:
+        row.update(equivalence_diagnostics)
     return rows
 
 
-def run_benchmark(*, mode: str, backend: str, cache_dir: Path):
+def run_benchmark(
+    *,
+    mode: str,
+    backend: str,
+    cache_dir: Path,
+    warmup_count: int | None = None,
+    trial_count: int | None = None,
+):
     device = _select_opencl_device(backend)
     ctx = cl.Context([device])
     queue = cl.CommandQueue(ctx)
     cases = SMOKE_CASES if mode == "smoke" else FULL_CASES
+    if warmup_count is None:
+        warmup_count = SMOKE_WARMUP_COUNT if mode == "smoke" else FULL_WARMUP_COUNT
+    if trial_count is None:
+        trial_count = SMOKE_TRIAL_COUNT if mode == "smoke" else FULL_TRIAL_COUNT
+    if warmup_count < 0:
+        raise ValueError("warmup_count must be nonnegative")
+    if trial_count < 1:
+        raise ValueError("trial_count must be at least one")
     rows = []
     for q_order, initial_nlevels, adapt_steps in cases:
         rows.extend(
@@ -366,6 +800,8 @@ def run_benchmark(*, mode: str, backend: str, cache_dir: Path):
                 q_order=q_order,
                 initial_nlevels=initial_nlevels,
                 adapt_steps=adapt_steps,
+                warmup_count=warmup_count,
+                trial_count=trial_count,
             )
         )
     return rows
@@ -384,6 +820,18 @@ def main() -> int:
     parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
     parser.add_argument("--backend", default="auto")
     parser.add_argument(
+        "--warmups",
+        type=int,
+        default=None,
+        help="FMM warmup runs per cache state (default: 1 smoke, 2 full)",
+    )
+    parser.add_argument(
+        "--trials",
+        type=int,
+        default=None,
+        help="measured FMM runs per cache state (default: 3 smoke, 7 full)",
+    )
+    parser.add_argument(
         "--out",
         type=Path,
         default=Path("build/benchmarks/adaptive-timing.csv"),
@@ -394,7 +842,17 @@ def main() -> int:
         default=Path("build/benchmarks/adaptive-timing-cache"),
     )
     args = parser.parse_args()
-    rows = run_benchmark(mode=args.mode, backend=args.backend, cache_dir=args.cache_dir)
+    if args.warmups is not None and args.warmups < 0:
+        parser.error("--warmups must be nonnegative")
+    if args.trials is not None and args.trials < 1:
+        parser.error("--trials must be at least one")
+    rows = run_benchmark(
+        mode=args.mode,
+        backend=args.backend,
+        cache_dir=args.cache_dir,
+        warmup_count=args.warmups,
+        trial_count=args.trials,
+    )
     write_csv(args.out, rows)
     return 0
 

--- a/benchmarks/dmk_effective_density.py
+++ b/benchmarks/dmk_effective_density.py
@@ -253,6 +253,7 @@ def run_benchmark(
         cache_path=cache_dir
         / (
             f"dmk-effective-density-laplace3d-q{q_order}-"
+            f"regular{regular_quad_order}-radial{radial_quad_order}-"
             f"{_root_extent_tag(root_extent)}.sqlite"
         ),
         root_extent=root_extent,

--- a/benchmarks/dmk_effective_density.py
+++ b/benchmarks/dmk_effective_density.py
@@ -2,27 +2,26 @@
 """Run a controlled DMK-style effective-density diagnostic.
 
 This benchmark does not implement full adaptive DMK. It isolates one
-translation-invariant Gaussian kernel split for the 3D Laplace Green's function
+translation-invariant Gaussian split for the 3D Laplace Green's function
 
-    K(x) = 1 / (4*pi*|x|),      K_hat(k) = 1 / |k|^2,
+    K(x) = 1 / (4*pi*|x|),      K_hat(k) = 1 / |k|^2.
 
-using the finest-level regularized multiplier
+The far part uses the finest-level Gaussian multiplier
 
-    K_sigma_hat(k) = exp(-sigma_l^2 |k|^2 / 4) / |k|^2.
+    K_far_hat(k) = exp(-sigma_l^2 |k|^2 / 4) / |k|^2,
 
-The effective density is therefore defined by
+which corresponds to the analytic effective density ``gamma_s * rho`` with
+``s = sigma_l/sqrt(2)``. To avoid treating this smoothed-only operator as full
+DMK, the benchmark also adds the fixed fourth-order residual asymptotic model
 
-    K * rho_eff = K_sigma * rho,
-    rho_eff_hat(k) = exp(-sigma_l^2 |k|^2 / 4) rho_hat(k).
+    u_R ~= c0 rho + c1 Delta rho + c2 Delta^2 rho
 
-For a Gaussian source this filtered density is analytic: rho_eff is the source
-convolved with a normalized Gaussian of standard deviation sigma_l/sqrt(2). The
-diagnostic applies Volumential's singular 3D Laplace path to rho_eff on an
-enlarged bounding box and compares it against the analytic DMK-regularized
-potential. The unsmoothed analytic reference remains a secondary diagnostic for
-the intentional regularization bias. The source Gaussian variance, DMK-style split
-scale sigma_l, density smoothing length, and residual SOG approximation status are
-recorded separately in the emitted metadata.
+for ``erfc(r/sigma_l)/(4*pi*r)``. The residual contribution is converted to an
+equivalent density by ``rho_R_eff = -Delta u_R`` and added to the far effective
+density. Volumential's singular 3D Laplace path is then applied to the total
+effective density and compared primarily against the analytic asymptotic split
+potential, with the unsmoothed analytic Gaussian potential recorded as the
+physical reference.
 """
 
 from __future__ import annotations
@@ -54,6 +53,7 @@ from volumential.gaussian import (
     GaussianMixture,
     axis_aligned_slice_grid,
     dmk_gaussian_split_sigma,
+    evaluate_gaussian_laplacian_power,
     evaluate_gaussian_mixture,
     gaussian_filter_mixture,
     gaussian_mixture_tail_report,
@@ -73,7 +73,14 @@ SUMMARY_FIELDS = (
     "dim",
     "kernel",
     "kernel_normalization",
-    "dmk_regularized_kernel_multiplier",
+    "far_kernel_multiplier",
+    "residual_kernel_model",
+    "residual_asymptotic_order",
+    "residual_potential_coeff_rho",
+    "residual_potential_coeff_laplace_rho",
+    "residual_potential_coeff_bilaplace_rho",
+    "far_effective_density_multiplier",
+    "residual_effective_density_multiplier",
     "effective_density_multiplier",
     "primary_comparison",
     "source_alpha",
@@ -95,20 +102,25 @@ SUMMARY_FIELDS = (
     "min_leaf_level",
     "max_leaf_level",
     "source_omitted_abs_fraction",
-    "effective_omitted_abs_fraction",
+    "far_effective_omitted_abs_fraction",
     "quadrature_source_mass",
+    "quadrature_far_effective_mass",
+    "quadrature_residual_effective_mass",
     "quadrature_effective_mass",
     "table_get_s",
     "table_build_s",
     "table_load_s",
     "table_payload_bytes",
     "fmm_wall_s",
-    "rel_l2_volumential_vs_dmk_regularized",
-    "weighted_rel_l2_volumential_vs_dmk_regularized",
-    "linf_volumential_vs_dmk_regularized",
-    "rel_l2_regularized_bias_vs_unsmoothed",
-    "weighted_rel_l2_regularized_bias_vs_unsmoothed",
-    "linf_regularized_bias_vs_unsmoothed",
+    "rel_l2_volumential_vs_asymptotic_split",
+    "weighted_rel_l2_volumential_vs_asymptotic_split",
+    "linf_volumential_vs_asymptotic_split",
+    "rel_l2_far_regularized_bias_vs_unsmoothed",
+    "weighted_rel_l2_far_regularized_bias_vs_unsmoothed",
+    "linf_far_regularized_bias_vs_unsmoothed",
+    "rel_l2_asymptotic_split_bias_vs_unsmoothed",
+    "weighted_rel_l2_asymptotic_split_bias_vs_unsmoothed",
+    "linf_asymptotic_split_bias_vs_unsmoothed",
     "rel_l2_volumential_vs_unsmoothed",
     "weighted_rel_l2_volumential_vs_unsmoothed",
     "linf_volumential_vs_unsmoothed",
@@ -137,6 +149,26 @@ def _root_extent_tag(root_extent: float) -> str:
     return f"extent{root_extent:.12g}".replace("-", "m").replace(".", "p")
 
 
+def _residual_potential_coefficients(
+    split_sigma: float, asymptotic_order: int
+) -> tuple[float, float, float]:
+    """Return coefficients for the normalized 3D residual potential expansion.
+
+    The coefficients multiply ``rho``, ``Delta rho``, and ``Delta**2 rho`` in
+    the fourth-order Taylor model of ``erfc(r/sigma)/(4*pi*r)``. They are the
+    all-space spherical moments ``I0``, ``I2/6``, and ``I4/120``.
+    """
+
+    if asymptotic_order not in (0, 2, 4):
+        raise ValueError("asymptotic_order must be 0, 2, or 4")
+
+    sigma_sq = split_sigma**2
+    coeff_rho = sigma_sq / 4.0
+    coeff_laplace_rho = sigma_sq**2 / 32.0 if asymptotic_order >= 2 else 0.0
+    coeff_bilaplace_rho = sigma_sq**3 / 384.0 if asymptotic_order >= 4 else 0.0
+    return coeff_rho, coeff_laplace_rho, coeff_bilaplace_rho
+
+
 def run_benchmark(
     *,
     mode: str,
@@ -151,6 +183,7 @@ def run_benchmark(
     source_alpha: float,
     split_epsilon: float,
     split_sigma: float | None,
+    residual_asymptotic_order: int,
     force_recompute: bool,
     slice_size: int,
 ) -> dict[str, Any]:
@@ -180,23 +213,48 @@ def run_benchmark(
         split_sigma = dmk_gaussian_split_sigma(split_box_side_length, split_epsilon)
     effective_density_smoothing_std = split_sigma / np.sqrt(2.0)
 
-    effective_mixture = gaussian_filter_mixture(
+    far_effective_mixture = gaussian_filter_mixture(
         mixture, effective_density_smoothing_std
     )
     source = evaluate_gaussian_mixture(mixture, coords)
-    effective_density = evaluate_gaussian_mixture(effective_mixture, coords)
+    source_laplacian = evaluate_gaussian_laplacian_power(mixture, coords, order=1)
+    source_bilaplacian = evaluate_gaussian_laplacian_power(mixture, coords, order=2)
+    source_trilaplacian = evaluate_gaussian_laplacian_power(mixture, coords, order=3)
+    far_effective_density = evaluate_gaussian_mixture(far_effective_mixture, coords)
+    (
+        residual_coeff_rho,
+        residual_coeff_laplace_rho,
+        residual_coeff_bilaplace_rho,
+    ) = _residual_potential_coefficients(split_sigma, residual_asymptotic_order)
+    asymptotic_residual_potential = (
+        residual_coeff_rho * source
+        + residual_coeff_laplace_rho * source_laplacian
+        + residual_coeff_bilaplace_rho * source_bilaplacian
+    )
+    residual_effective_density = -(
+        residual_coeff_rho * source_laplacian
+        + residual_coeff_laplace_rho * source_bilaplacian
+        + residual_coeff_bilaplace_rho * source_trilaplacian
+    )
+    effective_density = far_effective_density + residual_effective_density
     kernel_scale = 1.0 / (4.0 * np.pi)
     analytic_reference = laplace3d_gaussian_potential(
         mixture, coords, kernel_scale=kernel_scale
     )
-    analytic_regularized = laplace3d_gaussian_potential(
-        effective_mixture, coords, kernel_scale=kernel_scale
+    analytic_far_regularized = laplace3d_gaussian_potential(
+        far_effective_mixture, coords, kernel_scale=kernel_scale
+    )
+    analytic_asymptotic_split = (
+        analytic_far_regularized + asymptotic_residual_potential
     )
 
     table, table_timings = _get_table(
         queue,
         cache_path=cache_dir
-        / f"dmk-effective-density-laplace3d-q{q_order}-{_root_extent_tag(root_extent)}.sqlite",
+        / (
+            f"dmk-effective-density-laplace3d-q{q_order}-"
+            f"{_root_extent_tag(root_extent)}.sqlite"
+        ),
         root_extent=root_extent,
         q_order=q_order,
         regular_quad_order=regular_quad_order,
@@ -216,22 +274,42 @@ def run_benchmark(
 
     min_leaf_level, max_leaf_level = _leaf_stats(leaf_arrays)
     source_tail = gaussian_mixture_tail_report(mixture, bbox)
-    effective_tail = gaussian_mixture_tail_report(effective_mixture, bbox)
-    error_vs_regularized = potential - analytic_regularized
-    regularized_bias = analytic_regularized - analytic_reference
+    far_effective_tail = gaussian_mixture_tail_report(far_effective_mixture, bbox)
+    error_vs_asymptotic_split = potential - analytic_asymptotic_split
+    far_regularized_bias = analytic_far_regularized - analytic_reference
+    asymptotic_split_bias = analytic_asymptotic_split - analytic_reference
     error_vs_unsmoothed = potential - analytic_reference
     case_id = f"dmk-effective-density-laplace3d-q{q_order}-l{nlevels}"
+    residual_density_terms = ["(sigma_l^2/4)*|k|^2"]
+    if residual_asymptotic_order >= 2:
+        residual_density_terms.append("-(sigma_l^4/32)*|k|^4")
+    if residual_asymptotic_order >= 4:
+        residual_density_terms.append("+(sigma_l^6/384)*|k|^6")
+    residual_effective_density_multiplier = " ".join(residual_density_terms)
+    far_effective_density_multiplier = "exp(-sigma_l^2*|k|^2/4)"
 
     row = {
         "case_id": case_id,
         "mode": mode,
-        "problem": "controlled-dmk-minimal-smoothing-effective-density",
+        "problem": "controlled-dmk-asymptotic-residual-effective-density",
         "dim": 3,
         "kernel": "Laplace",
         "kernel_normalization": "sumpy_global_scaling_1_over_4pi_r",
-        "dmk_regularized_kernel_multiplier": "exp(-sigma_l^2*|k|^2/4)/|k|^2",
-        "effective_density_multiplier": "exp(-sigma_l^2*|k|^2/4)",
-        "primary_comparison": "full_finite_box_laplace_rho_eff_vs_dmk_regularized_potential",
+        "far_kernel_multiplier": f"{far_effective_density_multiplier}/|k|^2",
+        "residual_kernel_model": "all_space_erfc_residual_taylor_asymptotic",
+        "residual_asymptotic_order": residual_asymptotic_order,
+        "residual_potential_coeff_rho": residual_coeff_rho,
+        "residual_potential_coeff_laplace_rho": residual_coeff_laplace_rho,
+        "residual_potential_coeff_bilaplace_rho": residual_coeff_bilaplace_rho,
+        "far_effective_density_multiplier": far_effective_density_multiplier,
+        "residual_effective_density_multiplier": residual_effective_density_multiplier,
+        "effective_density_multiplier": (
+            f"{far_effective_density_multiplier} + "
+            f"{residual_effective_density_multiplier}"
+        ),
+        "primary_comparison": (
+            "full_finite_box_laplace_total_rho_eff_vs_asymptotic_split_potential"
+        ),
         "source_alpha": source_alpha,
         "source_variance_per_axis": 1.0 / (2.0 * source_alpha),
         "split_epsilon": split_epsilon,
@@ -251,30 +329,47 @@ def run_benchmark(
         "min_leaf_level": min_leaf_level,
         "max_leaf_level": max_leaf_level,
         "source_omitted_abs_fraction": source_tail["omitted_abs_fraction"],
-        "effective_omitted_abs_fraction": effective_tail["omitted_abs_fraction"],
+        "far_effective_omitted_abs_fraction": far_effective_tail[
+            "omitted_abs_fraction"
+        ],
         "quadrature_source_mass": float(np.sum(weights * source)),
+        "quadrature_far_effective_mass": float(np.sum(weights * far_effective_density)),
+        "quadrature_residual_effective_mass": float(
+            np.sum(weights * residual_effective_density)
+        ),
         "quadrature_effective_mass": float(np.sum(weights * effective_density)),
         "table_get_s": table_timings.get("total_s", "") if table_timings else "",
         "table_build_s": _table_phase_seconds(table_timings, "compute"),
         "table_load_s": _table_phase_seconds(table_timings, "load"),
         "table_payload_bytes": _table_payload_bytes(table_timings),
         "fmm_wall_s": fmm_wall_s,
-        "rel_l2_volumential_vs_dmk_regularized": _safe_rel_l2(
-            error_vs_regularized, analytic_regularized
+        "rel_l2_volumential_vs_asymptotic_split": _safe_rel_l2(
+            error_vs_asymptotic_split, analytic_asymptotic_split
         ),
-        "weighted_rel_l2_volumential_vs_dmk_regularized": _safe_weighted_rel_l2(
-            error_vs_regularized, analytic_regularized, weights
+        "weighted_rel_l2_volumential_vs_asymptotic_split": _safe_weighted_rel_l2(
+            error_vs_asymptotic_split, analytic_asymptotic_split, weights
         ),
-        "linf_volumential_vs_dmk_regularized": float(
-            np.max(np.abs(error_vs_regularized))
+        "linf_volumential_vs_asymptotic_split": float(
+            np.max(np.abs(error_vs_asymptotic_split))
         ),
-        "rel_l2_regularized_bias_vs_unsmoothed": _safe_rel_l2(
-            regularized_bias, analytic_reference
+        "rel_l2_far_regularized_bias_vs_unsmoothed": _safe_rel_l2(
+            far_regularized_bias, analytic_reference
         ),
-        "weighted_rel_l2_regularized_bias_vs_unsmoothed": _safe_weighted_rel_l2(
-            regularized_bias, analytic_reference, weights
+        "weighted_rel_l2_far_regularized_bias_vs_unsmoothed": _safe_weighted_rel_l2(
+            far_regularized_bias, analytic_reference, weights
         ),
-        "linf_regularized_bias_vs_unsmoothed": float(np.max(np.abs(regularized_bias))),
+        "linf_far_regularized_bias_vs_unsmoothed": float(
+            np.max(np.abs(far_regularized_bias))
+        ),
+        "rel_l2_asymptotic_split_bias_vs_unsmoothed": _safe_rel_l2(
+            asymptotic_split_bias, analytic_reference
+        ),
+        "weighted_rel_l2_asymptotic_split_bias_vs_unsmoothed": _safe_weighted_rel_l2(
+            asymptotic_split_bias, analytic_reference, weights
+        ),
+        "linf_asymptotic_split_bias_vs_unsmoothed": float(
+            np.max(np.abs(asymptotic_split_bias))
+        ),
         "rel_l2_volumential_vs_unsmoothed": _safe_rel_l2(
             error_vs_unsmoothed, analytic_reference
         ),
@@ -288,12 +383,20 @@ def run_benchmark(
         coords,
         {
             "source": source,
+            "source_laplacian": source_laplacian,
+            "source_bilaplacian": source_bilaplacian,
+            "source_trilaplacian": source_trilaplacian,
+            "far_effective_density": far_effective_density,
+            "residual_effective_density": residual_effective_density,
             "effective_density": effective_density,
             "potential": potential,
-            "analytic_regularized": analytic_regularized,
+            "analytic_far_regularized": analytic_far_regularized,
+            "asymptotic_residual_potential": asymptotic_residual_potential,
+            "analytic_asymptotic_split": analytic_asymptotic_split,
             "analytic_reference": analytic_reference,
-            "error_vs_regularized": error_vs_regularized,
-            "regularized_bias": regularized_bias,
+            "error_vs_asymptotic_split": error_vs_asymptotic_split,
+            "far_regularized_bias": far_regularized_bias,
+            "asymptotic_split_bias": asymptotic_split_bias,
             "weights": weights,
         },
         axis=2,
@@ -306,62 +409,135 @@ def run_benchmark(
         shape=(slice_size, slice_size),
     )
     analytic_slice_source = evaluate_gaussian_mixture(mixture, analytic_slice.points)
-    analytic_slice_effective_density = evaluate_gaussian_mixture(
-        effective_mixture, analytic_slice.points
+    analytic_slice_source_laplacian = evaluate_gaussian_laplacian_power(
+        mixture, analytic_slice.points, order=1
+    )
+    analytic_slice_source_bilaplacian = evaluate_gaussian_laplacian_power(
+        mixture, analytic_slice.points, order=2
+    )
+    analytic_slice_source_trilaplacian = evaluate_gaussian_laplacian_power(
+        mixture, analytic_slice.points, order=3
+    )
+    analytic_slice_far_effective_density = evaluate_gaussian_mixture(
+        far_effective_mixture, analytic_slice.points
+    )
+    analytic_slice_residual_effective_density = -(
+        residual_coeff_rho * analytic_slice_source_laplacian
+        + residual_coeff_laplace_rho * analytic_slice_source_bilaplacian
+        + residual_coeff_bilaplace_rho * analytic_slice_source_trilaplacian
+    )
+    analytic_slice_effective_density = (
+        analytic_slice_far_effective_density
+        + analytic_slice_residual_effective_density
     )
     analytic_slice_reference = laplace3d_gaussian_potential(
         mixture, analytic_slice.points, kernel_scale=kernel_scale
     )
-    analytic_slice_regularized = laplace3d_gaussian_potential(
-        effective_mixture, analytic_slice.points, kernel_scale=kernel_scale
+    analytic_slice_far_regularized = laplace3d_gaussian_potential(
+        far_effective_mixture, analytic_slice.points, kernel_scale=kernel_scale
+    )
+    analytic_slice_asymptotic_residual_potential = (
+        residual_coeff_rho * analytic_slice_source
+        + residual_coeff_laplace_rho * analytic_slice_source_laplacian
+        + residual_coeff_bilaplace_rho * analytic_slice_source_bilaplacian
+    )
+    analytic_slice_asymptotic_split = (
+        analytic_slice_far_regularized
+        + analytic_slice_asymptotic_residual_potential
     )
 
     arrays = {
         "node_coords": coords,
         "node_weights": weights,
         "node_source": source,
+        "node_source_laplacian": source_laplacian,
+        "node_source_bilaplacian": source_bilaplacian,
+        "node_source_trilaplacian": source_trilaplacian,
+        "node_far_effective_density": far_effective_density,
+        "node_residual_effective_density": residual_effective_density,
         "node_effective_density": effective_density,
         "node_potential": potential,
-        "node_analytic_regularized": analytic_regularized,
-        "node_analytic_split": analytic_regularized,
+        "node_analytic_far_regularized": analytic_far_regularized,
+        "node_analytic_regularized": analytic_far_regularized,
+        "node_asymptotic_residual_potential": asymptotic_residual_potential,
+        "node_analytic_asymptotic_split": analytic_asymptotic_split,
+        "node_analytic_split": analytic_asymptotic_split,
         "node_analytic_reference": analytic_reference,
-        "node_error_vs_regularized": error_vs_regularized,
-        "node_error_vs_split": error_vs_regularized,
-        "node_regularized_bias_vs_reference": regularized_bias,
-        "node_split_bias_vs_reference": regularized_bias,
+        "node_error_vs_asymptotic_split": error_vs_asymptotic_split,
+        "node_error_vs_split": error_vs_asymptotic_split,
+        "node_far_regularized_bias_vs_reference": far_regularized_bias,
+        "node_asymptotic_split_bias_vs_reference": asymptotic_split_bias,
+        "node_split_bias_vs_reference": asymptotic_split_bias,
         "slice_node_coords": node_slice["coords"],
         "slice_node_indices": node_slice["indices"],
         "slice_node_axis_distances": node_slice["axis_distances"],
         "slice_node_source": node_slice["source"],
+        "slice_node_source_laplacian": node_slice["source_laplacian"],
+        "slice_node_source_bilaplacian": node_slice["source_bilaplacian"],
+        "slice_node_source_trilaplacian": node_slice["source_trilaplacian"],
+        "slice_node_far_effective_density": node_slice["far_effective_density"],
+        "slice_node_residual_effective_density": node_slice[
+            "residual_effective_density"
+        ],
         "slice_node_effective_density": node_slice["effective_density"],
         "slice_node_potential": node_slice["potential"],
-        "slice_node_analytic_regularized": node_slice["analytic_regularized"],
-        "slice_node_analytic_split": node_slice["analytic_regularized"],
+        "slice_node_analytic_far_regularized": node_slice[
+            "analytic_far_regularized"
+        ],
+        "slice_node_analytic_regularized": node_slice["analytic_far_regularized"],
+        "slice_node_asymptotic_residual_potential": node_slice[
+            "asymptotic_residual_potential"
+        ],
+        "slice_node_analytic_asymptotic_split": node_slice[
+            "analytic_asymptotic_split"
+        ],
+        "slice_node_analytic_split": node_slice["analytic_asymptotic_split"],
         "slice_node_analytic_reference": node_slice["analytic_reference"],
-        "slice_node_error_vs_regularized": node_slice["error_vs_regularized"],
-        "slice_node_error_vs_split": node_slice["error_vs_regularized"],
-        "slice_node_regularized_bias": node_slice["regularized_bias"],
-        "slice_node_split_bias": node_slice["regularized_bias"],
+        "slice_node_error_vs_asymptotic_split": node_slice[
+            "error_vs_asymptotic_split"
+        ],
+        "slice_node_error_vs_split": node_slice["error_vs_asymptotic_split"],
+        "slice_node_far_regularized_bias": node_slice["far_regularized_bias"],
+        "slice_node_asymptotic_split_bias": node_slice[
+            "asymptotic_split_bias"
+        ],
+        "slice_node_split_bias": node_slice["asymptotic_split_bias"],
         "slice_node_weights": node_slice["weights"],
         "analytic_slice_coords": analytic_slice.points,
         "analytic_slice_shape": np.asarray(analytic_slice.shape, dtype=np.int32),
         "analytic_slice_axis0": analytic_slice.axis_values[0],
         "analytic_slice_axis1": analytic_slice.axis_values[1],
         "analytic_slice_source": analytic_slice_source,
+        "analytic_slice_source_laplacian": analytic_slice_source_laplacian,
+        "analytic_slice_source_bilaplacian": analytic_slice_source_bilaplacian,
+        "analytic_slice_source_trilaplacian": analytic_slice_source_trilaplacian,
+        "analytic_slice_far_effective_density": analytic_slice_far_effective_density,
+        "analytic_slice_residual_effective_density": (
+            analytic_slice_residual_effective_density
+        ),
         "analytic_slice_effective_density": analytic_slice_effective_density,
         "analytic_slice_reference": analytic_slice_reference,
-        "analytic_slice_regularized": analytic_slice_regularized,
-        "analytic_slice_split": analytic_slice_regularized,
-        "analytic_slice_regularized_bias": (
-            analytic_slice_regularized - analytic_slice_reference
+        "analytic_slice_far_regularized": analytic_slice_far_regularized,
+        "analytic_slice_regularized": analytic_slice_far_regularized,
+        "analytic_slice_asymptotic_residual_potential": (
+            analytic_slice_asymptotic_residual_potential
         ),
-        "analytic_slice_split_bias": analytic_slice_regularized - analytic_slice_reference,
+        "analytic_slice_asymptotic_split": analytic_slice_asymptotic_split,
+        "analytic_slice_split": analytic_slice_asymptotic_split,
+        "analytic_slice_far_regularized_bias": (
+            analytic_slice_far_regularized - analytic_slice_reference
+        ),
+        "analytic_slice_asymptotic_split_bias": (
+            analytic_slice_asymptotic_split - analytic_slice_reference
+        ),
+        "analytic_slice_split_bias": analytic_slice_asymptotic_split
+        - analytic_slice_reference,
         **{f"tree_{name}": values for name, values in leaf_arrays.items()},
     }
     metadata = {
         "case_id": case_id,
         "mode": mode,
-        "problem": "controlled-dmk-minimal-smoothing-effective-density",
+        "problem": row["problem"],
         "primary_comparison": row["primary_comparison"],
         "operator_identity": {
             "fourier_convention": (
@@ -370,15 +546,36 @@ def run_benchmark(
             ),
             "laplace_kernel": "K(x)=1/(4*pi*|x|)",
             "laplace_multiplier": "1/|k|^2",
-            "dmk_regularized_kernel_multiplier": row[
-                "dmk_regularized_kernel_multiplier"
+            "far_kernel_multiplier": row["far_kernel_multiplier"],
+            "residual_kernel_model": row["residual_kernel_model"],
+            "far_effective_density_multiplier": row[
+                "far_effective_density_multiplier"
+            ],
+            "residual_effective_density_multiplier": row[
+                "residual_effective_density_multiplier"
             ],
             "effective_density_multiplier": row["effective_density_multiplier"],
-            "identity": "K * rho_eff = K_sigma_l * rho",
-            "rho_eff_formula": "rho_eff = gamma_sigma * rho",
+            "identity": (
+                "K * rho_eff_total = K_far * rho + u_R_asymp, "
+                "rho_eff_total = gamma_s*rho - Delta u_R_asymp"
+            ),
+            "rho_eff_formula": (
+                "rho_eff_total = gamma_s*rho - c0*Delta rho "
+                "- c1*Delta^2 rho - c2*Delta^3 rho"
+            ),
+            "residual_potential_formula": (
+                "u_R_asymp = c0*rho + c1*Delta rho + c2*Delta^2 rho"
+            ),
+            "residual_potential_coefficients": {
+                "c0_rho": residual_coeff_rho,
+                "c1_laplace_rho": residual_coeff_laplace_rho,
+                "c2_bilaplace_rho": residual_coeff_bilaplace_rho,
+                "moment_source": "all-space moments of erfc(r/sigma_l)/(4*pi*r)",
+                "values": "c0=sigma_l^2/4, c1=sigma_l^4/32, c2=sigma_l^6/384",
+            },
             "primary_diagnostic": (
-                "full finite-box singular Laplace VP of rho_eff is compared "
-                "against the analytic DMK-regularized potential"
+                "full finite-box singular Laplace VP of rho_eff_total is "
+                "compared against the analytic far-plus-asymptotic residual split"
             ),
             "gamma_sigma": (
                 "(2*pi*s_eff^2)^(-3/2) exp(-|x|^2/(2*s_eff^2)), "
@@ -397,9 +594,10 @@ def run_benchmark(
             "effective_density_smoothing_std": effective_density_smoothing_std,
             "effective_density_smoothing_rule": "s_eff = sigma / sqrt(2)",
             "residual_sog_terms": 0,
+            "residual_asymptotic_order": residual_asymptotic_order,
             "residual_sog_status": (
-                "not used; this diagnostic models the finest DMK regularized "
-                "operator as a global effective density"
+                "not used; this diagnostic applies only the local asymptotic "
+                "model of the erfc residual"
             ),
         },
         "kernel": {
@@ -410,14 +608,14 @@ def run_benchmark(
         },
         "fixture": {
             "source": mixture.as_metadata(),
-            "effective_density": effective_mixture.as_metadata(),
+            "far_effective_density": far_effective_mixture.as_metadata(),
             "source_variance_per_axis": row["source_variance_per_axis"],
             "effective_density_smoothing_std": effective_density_smoothing_std,
         },
         "bbox": bbox,
         "tail": {
             "source": source_tail,
-            "effective_density": effective_tail,
+            "far_effective_density": far_effective_tail,
         },
         "discretization": {
             "q_order": q_order,
@@ -437,12 +635,15 @@ def run_benchmark(
         "errors": {
             key: row[key]
             for key in (
-                "rel_l2_volumential_vs_dmk_regularized",
-                "weighted_rel_l2_volumential_vs_dmk_regularized",
-                "linf_volumential_vs_dmk_regularized",
-                "rel_l2_regularized_bias_vs_unsmoothed",
-                "weighted_rel_l2_regularized_bias_vs_unsmoothed",
-                "linf_regularized_bias_vs_unsmoothed",
+                "rel_l2_volumential_vs_asymptotic_split",
+                "weighted_rel_l2_volumential_vs_asymptotic_split",
+                "linf_volumential_vs_asymptotic_split",
+                "rel_l2_far_regularized_bias_vs_unsmoothed",
+                "weighted_rel_l2_far_regularized_bias_vs_unsmoothed",
+                "linf_far_regularized_bias_vs_unsmoothed",
+                "rel_l2_asymptotic_split_bias_vs_unsmoothed",
+                "weighted_rel_l2_asymptotic_split_bias_vs_unsmoothed",
+                "linf_asymptotic_split_bias_vs_unsmoothed",
                 "rel_l2_volumential_vs_unsmoothed",
                 "weighted_rel_l2_volumential_vs_unsmoothed",
                 "linf_volumential_vs_unsmoothed",
@@ -470,7 +671,8 @@ def run_benchmark(
             "git_commit": _git_commit(),
         },
         "stress_cases_designed_not_run": [
-            "cut or clipped Gaussian support to expose boundary-layer rho_eff artifacts",
+            "cut or clipped Gaussian support to expose boundary-layer "
+            "rho_eff artifacts",
             "signed high-frequency residual density rho - gamma_sigma*rho",
             "box-boundary source center shifts with fixed split sigma",
         ],
@@ -509,6 +711,13 @@ def main() -> int:
         default=None,
         help="override sigma; otherwise use box_side_length/sqrt(log(1/epsilon))",
     )
+    parser.add_argument(
+        "--residual-asymptotic-order",
+        type=int,
+        choices=(0, 2, 4),
+        default=4,
+        help="Taylor order for the erfc residual potential correction",
+    )
     parser.add_argument("--slice-size", type=int, default=64)
     parser.add_argument("--force-recompute", action="store_true")
     parser.add_argument(
@@ -520,6 +729,11 @@ def main() -> int:
         "--arrays-out",
         type=Path,
         default=Path("build/benchmarks/dmk-effective-density-arrays.npz"),
+    )
+    parser.add_argument(
+        "--skip-arrays",
+        action="store_true",
+        help="skip NPZ array export for metric-only high-resolution runs",
     )
     parser.add_argument(
         "--metadata-out",
@@ -537,14 +751,20 @@ def main() -> int:
     q_order = args.q_order if args.q_order is not None else 4
     nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 4)
     fmm_order = args.fmm_order if args.fmm_order is not None else (10 if smoke else 12)
-    root_radius = args.root_radius if args.root_radius is not None else (0.5 if smoke else 1.0)
+    root_radius = (
+        args.root_radius
+        if args.root_radius is not None
+        else (0.5 if smoke else 1.0)
+    )
     regular_quad_order = (
         args.regular_quad_order
         if args.regular_quad_order is not None
         else max(8, 4 * q_order)
     )
     radial_quad_order = (
-        args.radial_quad_order if args.radial_quad_order is not None else max(25, 10 * q_order)
+        args.radial_quad_order
+        if args.radial_quad_order is not None
+        else max(25, 10 * q_order)
     )
 
     result = run_benchmark(
@@ -560,6 +780,7 @@ def main() -> int:
         source_alpha=args.source_alpha,
         split_epsilon=args.split_epsilon,
         split_sigma=args.split_sigma,
+        residual_asymptotic_order=args.residual_asymptotic_order,
         force_recompute=args.force_recompute,
         slice_size=args.slice_size,
     )
@@ -570,11 +791,13 @@ def main() -> int:
     }
     metadata["outputs"] = {
         "summary_csv": str(args.out),
-        "arrays_npz": str(args.arrays_out),
+        "arrays_npz": "" if args.skip_arrays else str(args.arrays_out),
+        "arrays_skipped": args.skip_arrays,
         "metadata_json": str(args.metadata_out),
     }
     write_csv(args.out, result["rows"])
-    write_npz(args.arrays_out, **result["arrays"])
+    if not args.skip_arrays:
+        write_npz(args.arrays_out, **result["arrays"])
     write_json_metadata(args.metadata_out, metadata)
     return 0
 

--- a/benchmarks/performance_suite.py
+++ b/benchmarks/performance_suite.py
@@ -3,7 +3,7 @@
 
 This wrapper standardizes the benchmark commands used for scaling, cache,
 parameter, and adaptive timing evidence. Smoke mode is intended for quick local
-or CI checks. Full mode is intended for controlled machines such as ``ipa`` and
+or CI checks. Full mode is intended for a controlled remote compute host and
 should be wrapped by the paper repository's metadata capture tool when results
 are promoted.
 """

--- a/benchmarks/split_parameter_sweep.py
+++ b/benchmarks/split_parameter_sweep.py
@@ -2,21 +2,25 @@
 """Emit Helmholtz/Yukawa split-parameter sweep CSVs for Paper 1.
 
 The benchmark sweeps the Helmholtz wave number and Yukawa screening parameter
-while recording split-table accounting. For each kernel parameter, rows compare
-against the highest split order in the same run, giving a direct split-order
-convergence measurement without changing the pretabulated basis-table family.
+while recording split-table accounting. Rows compare against fixed-parameter
+direct near-field tables and separate direct-table setup/apply costs from RKE
+channel setup, coefficient, residual, and full split costs. Cold/warm strategy
+totals and break-even roots expose the parameter/level/repeat amortization model.
 
 Smoke mode is intended for CI/local validation. Full mode is intended for
-metadata-wrapped runs on controlled machines such as ``ipa``.
+metadata-wrapped runs on a controlled remote compute host.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
+import math
 import time
+from contextlib import contextmanager
 from dataclasses import asdict
 from pathlib import Path
+from types import MethodType
 from typing import Any
 
 import numpy as np
@@ -51,12 +55,63 @@ FIELDS = (
     "split_term_keys",
     "uses_online_coefficients",
     "uses_online_remainder",
+    "level_count",
+    "direct_levels",
+    "repeat_count",
+    "solve_count",
+    "direct_table_count",
+    "direct_table_payload_bytes",
+    "direct_table_cache_payload_bytes",
+    "direct_table_build_s",
+    "direct_table_quadrature_build_s",
+    "direct_table_load_s",
+    "rke_channel_build_s",
+    "rke_channel_quadrature_build_s",
+    "rke_channel_load_s",
+    "rke_channel_cache_payload_bytes",
+    "direct_table_apply_total_s",
+    "direct_table_apply_mean_s",
+    "split_full_apply_total_s",
+    "split_full_apply_mean_s",
+    "split_correction_total_s",
+    "split_correction_mean_s",
+    "split_correction_time_kind",
+    "smooth_residual_total_s",
+    "smooth_residual_mean_s",
+    "smooth_residual_time_kind",
+    "coefficient_eval_mean_s",
+    "coefficient_eval_time_kind",
+    "reference_solve_total_s",
+    "split_solve_total_s",
+    "direct_strategy_cold_total_s",
+    "rke_strategy_cold_total_s",
+    "direct_strategy_warm_total_s",
+    "rke_strategy_warm_total_s",
+    "direct_amortized_cold_s_per_solve",
+    "rke_amortized_cold_s_per_solve",
+    "direct_amortized_warm_s_per_solve",
+    "rke_amortized_warm_s_per_solve",
+    "modeled_cold_savings_s",
+    "direct_table_build_mean_s_per_parameter_level",
+    "direct_solve_mean_s_per_solve",
+    "split_solve_mean_s_per_solve",
+    "amortization_time_kind",
+    "break_even_parameter_count",
+    "break_even_level_count",
+    "break_even_repeat_count",
+    "break_even_time_kind",
+    "benchmark_total_s",
+    "benchmark_total_time_kind",
 )
 
 
-def _parse_csv_floats(raw: str) -> list[float]:
+def _parse_csv_floats(raw: str, *, allow_empty: bool = False) -> list[float]:
+    if allow_empty and raw.strip().lower() in {"", "none", "skip"}:
+        return []
     values = [float(part.strip()) for part in raw.split(",") if part.strip()]
     if not values:
+        if allow_empty:
+            return []
         raise ValueError("expected at least one float value")
     return values
 
@@ -70,9 +125,90 @@ def _parse_csv_ints(raw: str) -> list[int]:
     return values
 
 
+def _parse_csv_levels(raw: str) -> list[int]:
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("expected at least one source-box level")
+    if any(value < 0 for value in values):
+        raise ValueError("source-box levels must be >= 0")
+    if len(set(values)) != len(values):
+        raise ValueError("source-box levels must be unique")
+    return sorted(values)
+
+
+def _limit_parameter_values(values: list[float], count: int | None) -> list[float]:
+    if count is None or not values:
+        return values
+    if count < 1:
+        raise ValueError("parameter_count must be >= 1")
+    if count > len(values):
+        raise ValueError(
+            f"parameter_count={count} exceeds the {len(values)} supplied values"
+        )
+    return values[:count]
+
+
+def _table_payload_bytes(table) -> int:
+    if bool(getattr(table, "table_data_is_symmetry_reduced", False)):
+        if hasattr(table, "get_reduced_table_data"):
+            _, values = table.get_reduced_table_data()
+            return int(np.asarray(values).nbytes)
+        data = np.asarray(table.data)
+        return int(np.count_nonzero(np.isfinite(data)) * data.dtype.itemsize)
+    return int(np.asarray(table.data).nbytes)
+
+
+def _clear_sqlite_cache(path: Path) -> None:
+    for suffix in ("", "-shm", "-wal"):
+        Path(f"{path}{suffix}").unlink(missing_ok=True)
+
+
+@contextmanager
+def _capture_table_get_timings():
+    """Capture table-manager timings, including split-channel auto-builds."""
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    records = []
+    original_get_table = NearFieldInteractionTableManager.get_table
+
+    def timed_get_table(table_manager, *args, **kwargs):
+        result = original_get_table(table_manager, *args, **kwargs)
+        records.append(dict(table_manager.last_get_table_timings or {}))
+        return result
+
+    NearFieldInteractionTableManager.get_table = timed_get_table
+    try:
+        yield records
+    finally:
+        NearFieldInteractionTableManager.get_table = original_get_table
+
+
+def _summarize_table_get_timings(records: list[dict[str, Any]]) -> dict[str, Any]:
+    build_records = [record for record in records if record.get("is_recomputed")]
+    load_records = [record for record in records if not record.get("is_recomputed")]
+    return {
+        "build_s": float(
+            sum(record.get("total_s", 0.0) for record in build_records)
+        ),
+        "quadrature_build_s": float(
+            sum((record.get("compute") or {}).get("table_build_s", 0.0)
+                for record in build_records)
+        ),
+        "load_s": float(sum(record.get("total_s", 0.0) for record in load_records)),
+        "cache_payload_bytes": int(
+            sum((record.get("load") or {}).get("payload_bytes", 0)
+                for record in load_records)
+        ),
+        "build_count": len(build_records),
+        "load_count": len(load_records),
+    }
+
+
 def _device_supports_fp64(device) -> bool:
     extensions = set(getattr(device, "extensions", "").split())
-    return "cl_khr_fp64" in extensions or bool(getattr(device, "double_fp_config", 0))
+    return "cl_khr_fp64" in extensions or bool(
+        getattr(device, "double_fp_config", 0)
+    )
 
 
 def _select_opencl_device(cl, backend: str):
@@ -121,7 +257,9 @@ def _build_config(q_order: int):
     )
 
 
-def _get_laplace_2d_table(queue, cache_path: Path, q_order: int):
+def _get_laplace_2d_table(
+    queue, cache_path: Path, q_order: int, *, force_recompute: bool = False
+):
     from volumential.table_manager import NearFieldInteractionTableManager
 
     with NearFieldInteractionTableManager(
@@ -131,14 +269,22 @@ def _get_laplace_2d_table(queue, cache_path: Path, q_order: int):
             2,
             "Laplace",
             q_order,
-            force_recompute=False,
+            force_recompute=force_recompute,
             queue=queue,
             build_config=_build_config(q_order),
         )
     return table
 
 
-def _get_yukawa_2d_table(queue, cache_path: Path, q_order: int, lam: float, level: int):
+def _get_yukawa_2d_table(
+    queue,
+    cache_path: Path,
+    q_order: int,
+    lam: float,
+    level: int,
+    *,
+    force_recompute: bool = False,
+):
     from volumential.table_manager import NearFieldInteractionTableManager
 
     with NearFieldInteractionTableManager(
@@ -149,7 +295,7 @@ def _get_yukawa_2d_table(queue, cache_path: Path, q_order: int, lam: float, leve
             "Yukawa",
             q_order,
             source_box_level=int(level),
-            force_recompute=False,
+            force_recompute=force_recompute,
             queue=queue,
             build_config=_build_config(q_order),
             lam=float(lam),
@@ -158,36 +304,33 @@ def _get_yukawa_2d_table(queue, cache_path: Path, q_order: int, lam: float, leve
 
 
 def _build_helmholtz_2d_table(
-    queue, cache_path: Path, q_order: int, wave_number: float, level: int
+    queue,
+    cache_path: Path,
+    q_order: int,
+    wave_number: float,
+    level: int,
+    *,
+    force_recompute: bool = False,
 ):
     from sumpy.kernel import HelmholtzKernel
-
-    import volumential.nearfield_potential_table as npt
+    from volumential.table_manager import NearFieldInteractionTableManager
 
     kernel = HelmholtzKernel(2)
     kernel_kwargs = {kernel.helmholtz_k_name: float(wave_number)}
-    table = npt.NearFieldInteractionTable(
-        quad_order=q_order,
-        dim=2,
-        build_method="DuffyRadial",
-        kernel_func=npt.sumpy_kernel_to_lambda(kernel, parameter_values=kernel_kwargs),
-        kernel_type="helmholtz-direct",
-        sumpy_kernel=kernel,
-        source_box_extent=2.0 * (2 ** (-int(level))),
-        dtype=np.complex128,
-        progress_bar=False,
-    )
-    table.source_box_level = int(level)
-    table.table_root_extent = 2.0
-    table._table_cache_filename = str(cache_path)
-    table._table_cache_root_extent = 2.0
-    table.build_table_via_duffy_radial(
-        queue=queue,
-        radial_rule="tanh-sinh-fast",
-        regular_quad_order=max(8, 4 * q_order),
-        radial_quad_order=max(21, 10 * q_order),
-        **kernel_kwargs,
-    )
+    with NearFieldInteractionTableManager(
+        str(cache_path), root_extent=2.0, dtype=np.complex128, queue=queue
+    ) as table_manager:
+        table, _ = table_manager.get_table(
+            2,
+            "Helmholtz-Reference",
+            q_order,
+            source_box_level=int(level),
+            force_recompute=force_recompute,
+            queue=queue,
+            build_config=_build_config(q_order),
+            sumpy_knl=kernel,
+            **kernel_kwargs,
+        )
     return table
 
 
@@ -228,10 +371,12 @@ def _source_values(queue, q_points, dtype, source_values_host=None):
 
     if source_values_host is None:
         source_values_host = _gaussian_source_host(_coords_host(queue, q_points))
-    return cla.to_device(queue, np.ascontiguousarray(source_values_host.astype(dtype)))
+    return cla.to_device(
+        queue, np.ascontiguousarray(source_values_host.astype(dtype))
+    )
 
 
-def _run_path(
+def _build_path(
     *,
     ctx,
     queue,
@@ -246,6 +391,7 @@ def _run_path(
     source_values_host=None,
     split: bool,
     split_order: int,
+    split_term_tables=None,
 ):
     from functools import partial
 
@@ -255,7 +401,6 @@ def _run_path(
         FPNDExpansionWrangler,
         FPNDTreeIndependentDataForWrangler,
     )
-    from volumential.volume_fmm import drive_volume_fmm
 
     if kernel == "Helmholtz":
         out_kernel = HelmholtzKernel(2)
@@ -264,7 +409,9 @@ def _run_path(
     elif kernel == "Yukawa":
         out_kernel = YukawaKernel(2)
         kernel_kwargs = {out_kernel.yukawa_lambda_name: float(parameter)}
-        dtype = np.complex128 if split else np.float64
+        # The shared split evaluator currently emits complex intermediates for
+        # both kernel families. Keep direct and split paths on the same dtype.
+        dtype = np.complex128
     else:
         raise ValueError(f"unknown kernel: {kernel}")
 
@@ -300,30 +447,420 @@ def _run_path(
         self_extra_kwargs=self_extra_kwargs,
         helmholtz_split=split,
         helmholtz_split_order=split_order,
+        helmholtz_split_term_tables=split_term_tables,
     )
 
-    # Warm compilation/caches first, then time the second application.
-    _ = drive_volume_fmm(
-        traversal,
-        wrangler,
-        weighted_sources,
-        source_vals,
-        direct_evaluation=False,
-        list1_only=False,
-    )
+    return wrangler, weighted_sources, source_vals
+
+
+def _time_repeated(queue, repeat_count: int, operation):
+    _ = operation()
     queue.finish()
-
     start = time.perf_counter()
-    (potential,) = drive_volume_fmm(
-        traversal,
-        wrangler,
-        weighted_sources,
-        source_vals,
-        direct_evaluation=False,
-        list1_only=False,
-    )
+    result = None
+    for _ in range(repeat_count):
+        result = operation()
     queue.finish()
-    return potential.get(queue), time.perf_counter() - start, wrangler
+    total_s = time.perf_counter() - start
+    return result, total_s, total_s / repeat_count
+
+
+def _run_path(
+    *,
+    ctx,
+    queue,
+    traversal,
+    q_order: int,
+    fmm_order: int,
+    kernel: str,
+    parameter: float,
+    table,
+    source_weights,
+    q_points,
+    source_values_host=None,
+    split: bool,
+    split_order: int,
+    split_term_tables=None,
+    repeat_count: int,
+):
+    from volumential.volume_fmm import drive_volume_fmm
+
+    wrangler, weighted_sources, source_vals = _build_path(
+        ctx=ctx,
+        queue=queue,
+        traversal=traversal,
+        q_order=q_order,
+        fmm_order=fmm_order,
+        kernel=kernel,
+        parameter=parameter,
+        table=table,
+        source_weights=source_weights,
+        q_points=q_points,
+        source_values_host=source_values_host,
+        split=split,
+        split_order=split_order,
+        split_term_tables=split_term_tables,
+    )
+
+    def solve():
+        return drive_volume_fmm(
+            traversal,
+            wrangler,
+            weighted_sources,
+            source_vals,
+            direct_evaluation=False,
+            list1_only=False,
+        )
+
+    potentials, solve_total_s, solve_mean_s = _time_repeated(
+        queue, repeat_count, solve
+    )
+    (potential,) = potentials
+
+    reordered_source_vals = wrangler.reorder_sources(source_vals)
+    reordered_weighted_sources = wrangler.reorder_sources(weighted_sources)
+
+    def table_apply():
+        values, _ = wrangler.eval_direct(
+            traversal.target_boxes,
+            traversal.neighbor_source_boxes_starts,
+            traversal.neighbor_source_boxes_lists,
+            reordered_source_vals,
+        )
+        return values
+
+    _, table_apply_total_s, table_apply_mean_s = _time_repeated(
+        queue, repeat_count, table_apply
+    )
+
+    timing = {
+        "solve_total_s": solve_total_s,
+        "solve_mean_s": solve_mean_s,
+        "table_apply_total_s": table_apply_total_s,
+        "table_apply_mean_s": table_apply_mean_s,
+        "split_full_apply_total_s": 0.0,
+        "split_full_apply_mean_s": 0.0,
+        "split_correction_total_s": 0.0,
+        "split_correction_mean_s": 0.0,
+        "split_correction_time_kind": "not_applicable",
+        "smooth_residual_total_s": 0.0,
+        "smooth_residual_mean_s": 0.0,
+        "smooth_residual_time_kind": "not_applicable",
+        "coefficient_eval_mean_s": 0.0,
+        "coefficient_eval_time_kind": "not_applicable_no_retained_channels",
+    }
+
+    if split:
+        correction_args = (
+            traversal.target_boxes,
+            traversal.neighbor_source_boxes_starts,
+            traversal.neighbor_source_boxes_lists,
+            reordered_weighted_sources,
+        )
+
+        def split_correction():
+            correction, _ = wrangler.eval_direct_helmholtz_split_correction(
+                *correction_args,
+                src_func=reordered_source_vals,
+            )
+            return correction
+
+        def split_full_apply():
+            base_values = table_apply()
+            correction = split_correction()
+            return base_values[0] + correction[0]
+
+        _, split_full_total_s, split_full_mean_s = _time_repeated(
+            queue, repeat_count, split_full_apply
+        )
+        _, correction_total_s, correction_mean_s = _time_repeated(
+            queue, repeat_count, split_correction
+        )
+
+        method_name = "_helmholtz_split_extra_terms"
+        setattr(wrangler, method_name, MethodType(lambda self: [], wrangler))
+        try:
+            _, residual_total_s, residual_mean_s = _time_repeated(
+                queue, repeat_count, split_correction
+            )
+        finally:
+            delattr(wrangler, method_name)
+
+        timing.update(
+            {
+                "split_full_apply_total_s": split_full_total_s,
+                "split_full_apply_mean_s": split_full_mean_s,
+                "split_correction_total_s": correction_total_s,
+                "split_correction_mean_s": correction_mean_s,
+                "split_correction_time_kind": "isolated_list1_split_correction",
+                "smooth_residual_total_s": residual_total_s,
+                "smooth_residual_mean_s": residual_mean_s,
+                "smooth_residual_time_kind": (
+                    "isolated_implemented_residual_correction_without_"
+                    "retained_channels"
+                ),
+            }
+        )
+
+        if split_order > 1:
+            coefficient_repeats = 1000
+            _ = wrangler._helmholtz_split_extra_terms()
+            start = time.perf_counter()
+            for _ in range(coefficient_repeats):
+                _ = wrangler._helmholtz_split_extra_terms()
+            coefficient_total_s = time.perf_counter() - start
+            timing["coefficient_eval_mean_s"] = (
+                coefficient_total_s / coefficient_repeats
+            )
+            timing["coefficient_eval_time_kind"] = (
+                "isolated_warm_python_scalar_coefficients"
+            )
+
+    return potential.get(queue), timing, wrangler
+
+
+def _get_direct_table(
+    *,
+    kernel: str,
+    queue,
+    cache_path: Path,
+    q_order: int,
+    parameter: float,
+    level: int,
+):
+    if kernel == "Helmholtz":
+        return _build_helmholtz_2d_table(
+            queue,
+            cache_path,
+            q_order,
+            parameter,
+            level,
+        )
+    if kernel == "Yukawa":
+        return _get_yukawa_2d_table(
+            queue,
+            cache_path,
+            q_order,
+            parameter,
+            level,
+        )
+    raise ValueError(f"unknown kernel: {kernel}")
+
+
+def _prepare_direct_tables(
+    *,
+    kernel: str,
+    queue,
+    cache_dir: Path,
+    q_order: int,
+    parameter: float,
+    direct_levels: list[int],
+    active_level: int,
+):
+    parameter_tag = f"{parameter:.17g}".replace("-", "m").replace(".", "p")
+    cache_path = cache_dir / (
+        f"cost-direct-{kernel.lower()}-parameter{parameter_tag}-q{q_order}.sqlite"
+    )
+    _clear_sqlite_cache(cache_path)
+
+    with _capture_table_get_timings() as cold_records:
+        for level in direct_levels:
+            _get_direct_table(
+                kernel=kernel,
+                queue=queue,
+                cache_path=cache_path,
+                q_order=q_order,
+                parameter=parameter,
+                level=level,
+            )
+
+    warm_tables = {}
+    with _capture_table_get_timings() as warm_records:
+        for level in direct_levels:
+            warm_tables[level] = _get_direct_table(
+                kernel=kernel,
+                queue=queue,
+                cache_path=cache_path,
+                q_order=q_order,
+                parameter=parameter,
+                level=level,
+            )
+
+    cold = _summarize_table_get_timings(cold_records)
+    warm = _summarize_table_get_timings(warm_records)
+    if cold["build_count"] != len(direct_levels):
+        raise RuntimeError("direct-table cold pass did not build every requested level")
+    if warm["load_count"] != len(direct_levels) or warm["build_count"]:
+        raise RuntimeError("direct-table warm pass was not a pure cache load")
+    return warm_tables[active_level], {
+        "build_s": cold["build_s"],
+        "quadrature_build_s": cold["quadrature_build_s"],
+        "load_s": warm["load_s"],
+        "cache_payload_bytes": warm["cache_payload_bytes"],
+        "table_count": len(warm_tables),
+        "payload_bytes": sum(_table_payload_bytes(table)
+                             for table in warm_tables.values()),
+    }
+
+
+def _prepare_rke_channels(
+    *,
+    ctx,
+    queue,
+    traversal,
+    q_order: int,
+    fmm_order: int,
+    kernel: str,
+    parameter: float,
+    split_order: int,
+    source_weights,
+    q_points,
+    source_values_host,
+    cache_dir: Path,
+):
+    cache_path = cache_dir / (
+        f"cost-rke-{kernel.lower()}-q{q_order}-p{split_order}.sqlite"
+    )
+    _clear_sqlite_cache(cache_path)
+
+    with _capture_table_get_timings() as cold_records:
+        cold_base_table = _get_laplace_2d_table(queue, cache_path, q_order)
+        _build_path(
+            ctx=ctx,
+            queue=queue,
+            traversal=traversal,
+            q_order=q_order,
+            fmm_order=fmm_order,
+            kernel=kernel,
+            parameter=parameter,
+            table=cold_base_table,
+            source_weights=source_weights,
+            q_points=q_points,
+            source_values_host=source_values_host,
+            split=True,
+            split_order=split_order,
+        )
+
+    with _capture_table_get_timings() as warm_records:
+        warm_base_table = _get_laplace_2d_table(queue, cache_path, q_order)
+        warm_wrangler, _, _ = _build_path(
+            ctx=ctx,
+            queue=queue,
+            traversal=traversal,
+            q_order=q_order,
+            fmm_order=fmm_order,
+            kernel=kernel,
+            parameter=parameter,
+            table=warm_base_table,
+            source_weights=source_weights,
+            q_points=q_points,
+            source_values_host=source_values_host,
+            split=True,
+            split_order=split_order,
+        )
+
+    cold = _summarize_table_get_timings(cold_records)
+    warm = _summarize_table_get_timings(warm_records)
+    if cold["build_count"] < 1 or cold["build_count"] != warm["load_count"]:
+        raise RuntimeError("RKE cold-build and warm-load channel counts differ")
+    if warm["build_count"]:
+        raise RuntimeError("RKE warm pass unexpectedly rebuilt a channel table")
+    return (
+        warm_base_table,
+        dict(warm_wrangler.helmholtz_split_term_tables),
+        {
+            "build_s": cold["build_s"],
+            "quadrature_build_s": cold["quadrature_build_s"],
+            "load_s": warm["load_s"],
+            "cache_payload_bytes": warm["cache_payload_bytes"],
+        },
+    )
+
+
+def _positive_root(value: float) -> float | str:
+    if math.isfinite(value) and value > 0.0:
+        return float(value)
+    return ""
+
+
+def _amortization_accounting(
+    *,
+    parameter_count: int,
+    level_count: int,
+    repeat_count: int,
+    direct_build_s: float,
+    direct_load_s: float,
+    rke_build_s: float,
+    rke_load_s: float,
+    direct_solve_total_s: float,
+    split_solve_total_s: float,
+) -> dict[str, Any]:
+    solve_count = parameter_count * repeat_count
+    direct_apply_mean_s = direct_solve_total_s / solve_count
+    split_apply_mean_s = split_solve_total_s / solve_count
+    direct_build_per_parameter_level_s = direct_build_s / (
+        parameter_count * level_count
+    )
+
+    direct_cold_total_s = direct_build_s + direct_solve_total_s
+    rke_cold_total_s = rke_build_s + split_solve_total_s
+    direct_warm_total_s = direct_load_s + direct_solve_total_s
+    rke_warm_total_s = rke_load_s + split_solve_total_s
+
+    parameter_denominator = (
+        level_count * direct_build_per_parameter_level_s
+        + repeat_count * (direct_apply_mean_s - split_apply_mean_s)
+    )
+    level_root = (
+        rke_build_s
+        + parameter_count * repeat_count
+        * (split_apply_mean_s - direct_apply_mean_s)
+    ) / (parameter_count * direct_build_per_parameter_level_s)
+    repeat_denominator = parameter_count * (
+        direct_apply_mean_s - split_apply_mean_s
+    )
+
+    if parameter_denominator == 0.0:
+        parameter_root = math.inf
+    else:
+        parameter_root = rke_build_s / parameter_denominator
+    if repeat_denominator == 0.0:
+        repeat_root = math.inf
+    else:
+        repeat_root = (
+            rke_build_s
+            - parameter_count * level_count
+            * direct_build_per_parameter_level_s
+        ) / repeat_denominator
+
+    return {
+        "solve_count": solve_count,
+        "direct_strategy_cold_total_s": direct_cold_total_s,
+        "rke_strategy_cold_total_s": rke_cold_total_s,
+        "direct_strategy_warm_total_s": direct_warm_total_s,
+        "rke_strategy_warm_total_s": rke_warm_total_s,
+        "direct_amortized_cold_s_per_solve": direct_cold_total_s / solve_count,
+        "rke_amortized_cold_s_per_solve": rke_cold_total_s / solve_count,
+        "direct_amortized_warm_s_per_solve": direct_warm_total_s / solve_count,
+        "rke_amortized_warm_s_per_solve": rke_warm_total_s / solve_count,
+        "modeled_cold_savings_s": direct_cold_total_s - rke_cold_total_s,
+        "direct_table_build_mean_s_per_parameter_level": (
+            direct_build_per_parameter_level_s
+        ),
+        "direct_solve_mean_s_per_solve": direct_apply_mean_s,
+        "split_solve_mean_s_per_solve": split_apply_mean_s,
+        "amortization_time_kind": (
+            "measured_table_setup_plus_warm_full_solve;"
+            "linear_projection_uses_observed_mean_costs"
+        ),
+        "break_even_parameter_count": _positive_root(parameter_root),
+        "break_even_level_count": _positive_root(level_root),
+        "break_even_repeat_count": _positive_root(repeat_root),
+        "break_even_time_kind": (
+            "positive_root_of_cold_setup_plus_warm_full_solve_linear_model;"
+            "blank_means_no_positive_finite_root"
+        ),
+    }
 
 
 def _split_term_keys(accounting) -> str:
@@ -343,15 +880,22 @@ def _row_from_result(
     reference_path: str,
     reference_values,
     split_values,
-    reference_warm_s: float | str,
-    split_warm_s: float,
+    reference_timing: dict[str, Any],
+    split_timing: dict[str, Any],
     accounting,
+    direct_costs: dict[str, Any],
+    rke_costs: dict[str, Any],
+    amortization: dict[str, Any],
+    direct_levels: list[int],
+    repeat_count: int,
 ) -> dict[str, Any]:
     diff = split_values - reference_values
     reference_norm = max(float(np.linalg.norm(reference_values)), 1.0e-300)
     accounting_dict = asdict(accounting)
     return {
-        "case_id": f"{kernel.lower()}2d-{parameter_name}{parameter:g}-p{split_order}",
+        "case_id": (
+            f"{kernel.lower()}2d-{parameter_name}{parameter:g}-p{split_order}"
+        ),
         "mode": mode,
         "kernel": kernel,
         "dim": 2,
@@ -365,16 +909,44 @@ def _row_from_result(
         "reference_path": reference_path,
         "rel_l2_error": float(np.linalg.norm(diff) / reference_norm),
         "linf_error": float(np.max(np.abs(diff))),
-        "reference_warm_s": reference_warm_s,
-        "split_warm_s": float(split_warm_s),
-        "online_remainder_s": float(split_warm_s if accounting.uses_online_remainder else 0.0),
-        "online_remainder_time_kind": "warm_solve_upper_bound",
+        "reference_warm_s": reference_timing["solve_mean_s"],
+        "split_warm_s": split_timing["solve_mean_s"],
+        "online_remainder_s": split_timing["smooth_residual_mean_s"],
+        "online_remainder_time_kind": split_timing["smooth_residual_time_kind"],
         "split_term_keys": _split_term_keys(accounting),
         **{
             key: value
             for key, value in accounting_dict.items()
             if key not in {"split_enabled", "split_order", "split_term_keys"}
         },
+        "level_count": len(direct_levels),
+        "direct_levels": ";".join(str(level) for level in direct_levels),
+        "repeat_count": repeat_count,
+        "direct_table_count": direct_costs["table_count"],
+        "direct_table_payload_bytes": direct_costs["payload_bytes"],
+        "direct_table_cache_payload_bytes": direct_costs["cache_payload_bytes"],
+        "direct_table_build_s": direct_costs["build_s"],
+        "direct_table_quadrature_build_s": direct_costs["quadrature_build_s"],
+        "direct_table_load_s": direct_costs["load_s"],
+        "rke_channel_build_s": rke_costs["build_s"],
+        "rke_channel_quadrature_build_s": rke_costs["quadrature_build_s"],
+        "rke_channel_load_s": rke_costs["load_s"],
+        "rke_channel_cache_payload_bytes": rke_costs["cache_payload_bytes"],
+        "direct_table_apply_total_s": reference_timing["table_apply_total_s"],
+        "direct_table_apply_mean_s": reference_timing["table_apply_mean_s"],
+        "split_full_apply_total_s": split_timing["split_full_apply_total_s"],
+        "split_full_apply_mean_s": split_timing["split_full_apply_mean_s"],
+        "split_correction_total_s": split_timing["split_correction_total_s"],
+        "split_correction_mean_s": split_timing["split_correction_mean_s"],
+        "split_correction_time_kind": split_timing["split_correction_time_kind"],
+        "smooth_residual_total_s": split_timing["smooth_residual_total_s"],
+        "smooth_residual_mean_s": split_timing["smooth_residual_mean_s"],
+        "smooth_residual_time_kind": split_timing["smooth_residual_time_kind"],
+        "coefficient_eval_mean_s": split_timing["coefficient_eval_mean_s"],
+        "coefficient_eval_time_kind": split_timing["coefficient_eval_time_kind"],
+        "reference_solve_total_s": reference_timing["solve_total_s"],
+        "split_solve_total_s": split_timing["solve_total_s"],
+        **amortization,
     }
 
 
@@ -389,9 +961,12 @@ def run_benchmark(
     split_orders: list[int],
     helmholtz_k: list[float],
     yukawa_lam: list[float],
+    direct_levels: list[int],
+    repeat_count: int,
 ) -> list[dict[str, Any]]:
     import pyopencl as cl
 
+    benchmark_start = time.perf_counter()
     device = _select_opencl_device(cl, backend)
     ctx = cl.Context([device])
     queue = cl.CommandQueue(ctx)
@@ -400,76 +975,169 @@ def run_benchmark(
     )
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    split_table = _get_laplace_2d_table(
-        queue, cache_dir / f"split-laplace-q{q_order}.sqlite", q_order
-    )
     rows: list[dict[str, Any]] = []
+    coords_host = _coords_host(queue, q_points)
 
     sweep_specs = [
         ("Helmholtz", "k", helmholtz_k),
         ("Yukawa", "lambda", yukawa_lam),
     ]
-    parameter_count_by_kernel = {
-        "Helmholtz": len(helmholtz_k),
-        "Yukawa": len(yukawa_lam),
-    }
 
     for kernel, parameter_name, parameters in sweep_specs:
+        if not parameters:
+            continue
+
+        parameter_cases = []
+        direct_costs = {
+            "build_s": 0.0,
+            "quadrature_build_s": 0.0,
+            "load_s": 0.0,
+            "cache_payload_bytes": 0,
+            "table_count": 0,
+            "payload_bytes": 0,
+        }
+
         for parameter in parameters:
             if kernel == "Helmholtz":
-                source_values_host, _exact_values = _helmholtz_manufactured_source_and_exact(
-                    _coords_host(queue, q_points), parameter
+                source_values_host, _exact_values = (
+                    _helmholtz_manufactured_source_and_exact(
+                        coords_host, parameter
+                    )
                 )
             else:
-                source_values_host = _gaussian_source_host(_coords_host(queue, q_points))
+                source_values_host = _gaussian_source_host(coords_host)
+
+            direct_table, parameter_direct_costs = _prepare_direct_tables(
+                kernel=kernel,
+                queue=queue,
+                cache_dir=cache_dir,
+                q_order=q_order,
+                parameter=parameter,
+                direct_levels=direct_levels,
+                active_level=nlevels,
+            )
+            for key in direct_costs:
+                direct_costs[key] += parameter_direct_costs[key]
+
+            reference_values, reference_timing, _ = _run_path(
+                ctx=ctx,
+                queue=queue,
+                traversal=traversal,
+                q_order=q_order,
+                fmm_order=fmm_order,
+                kernel=kernel,
+                parameter=parameter,
+                table=direct_table,
+                source_weights=source_weights,
+                q_points=q_points,
+                source_values_host=source_values_host,
+                split=False,
+                split_order=1,
+                repeat_count=repeat_count,
+            )
+            parameter_cases.append(
+                {
+                    "parameter": parameter,
+                    "source_values_host": source_values_host,
+                    "reference_values": reference_values,
+                    "reference_timing": reference_timing,
+                }
+            )
+
+        direct_solve_total_s = sum(
+            case["reference_timing"]["solve_total_s"] for case in parameter_cases
+        )
+
+        for split_order in split_orders:
+            representative_case = parameter_cases[0]
+            split_table, split_term_tables, rke_costs = _prepare_rke_channels(
+                ctx=ctx,
+                queue=queue,
+                traversal=traversal,
+                q_order=q_order,
+                fmm_order=fmm_order,
+                kernel=kernel,
+                parameter=representative_case["parameter"],
+                split_order=split_order,
+                source_weights=source_weights,
+                q_points=q_points,
+                source_values_host=representative_case["source_values_host"],
+                cache_dir=cache_dir,
+            )
 
             split_results = []
-            for split_order in split_orders:
-                split_values, split_warm_s, split_wrangler = _run_path(
+            for case in parameter_cases:
+                split_values, split_timing, split_wrangler = _run_path(
                     ctx=ctx,
                     queue=queue,
                     traversal=traversal,
                     q_order=q_order,
                     fmm_order=fmm_order,
                     kernel=kernel,
-                    parameter=parameter,
+                    parameter=case["parameter"],
                     table=split_table,
                     source_weights=source_weights,
                     q_points=q_points,
-                    source_values_host=source_values_host,
+                    source_values_host=case["source_values_host"],
                     split=True,
                     split_order=split_order,
+                    split_term_tables=split_term_tables,
+                    repeat_count=repeat_count,
                 )
                 accounting = split_wrangler.get_helmholtz_split_cache_accounting(
-                    parameter_count=parameter_count_by_kernel[kernel]
+                    parameter_count=len(parameters)
                 )
                 split_results.append(
-                    (split_order, split_values, split_warm_s, accounting)
+                    (case, split_values, split_timing, accounting)
                 )
 
-            reference_split_order, reference_values, reference_warm_s, _ = max(
-                split_results, key=lambda result: result[0]
+            split_solve_total_s = sum(
+                split_timing["solve_total_s"]
+                for _, _, split_timing, _ in split_results
             )
-            reference_path = f"split_order_{reference_split_order}"
-            for split_order, split_values, split_warm_s, accounting in split_results:
+            amortization = _amortization_accounting(
+                parameter_count=len(parameters),
+                level_count=len(direct_levels),
+                repeat_count=repeat_count,
+                direct_build_s=direct_costs["build_s"],
+                direct_load_s=direct_costs["load_s"],
+                rke_build_s=rke_costs["build_s"],
+                rke_load_s=rke_costs["load_s"],
+                direct_solve_total_s=direct_solve_total_s,
+                split_solve_total_s=split_solve_total_s,
+            )
+
+            for case, split_values, split_timing, accounting in split_results:
                 rows.append(
                     _row_from_result(
                         mode=mode,
                         kernel=kernel,
                         parameter_name=parameter_name,
-                        parameter=parameter,
+                        parameter=case["parameter"],
                         split_order=split_order,
                         q_order=q_order,
                         nlevels=nlevels,
                         fmm_order=fmm_order,
-                        reference_path=reference_path,
-                        reference_values=reference_values,
+                        reference_path="direct_fixed_parameter_table",
+                        reference_values=case["reference_values"],
                         split_values=split_values,
-                        reference_warm_s=reference_warm_s,
-                        split_warm_s=split_warm_s,
+                        reference_timing=case["reference_timing"],
+                        split_timing=split_timing,
                         accounting=accounting,
+                        direct_costs=direct_costs,
+                        rke_costs=rke_costs,
+                        amortization=amortization,
+                        direct_levels=direct_levels,
+                        repeat_count=repeat_count,
                     )
                 )
+
+    benchmark_total_s = time.perf_counter() - benchmark_start
+    for row in rows:
+        row["benchmark_total_s"] = benchmark_total_s
+        row["benchmark_total_time_kind"] = (
+            "driver_wall_including_all_cases_setup_and_isolated_diagnostics"
+        )
 
     return rows
 
@@ -502,15 +1170,80 @@ def main() -> int:
     parser.add_argument("--split-orders")
     parser.add_argument("--helmholtz-k")
     parser.add_argument("--yukawa-lambda")
+    parser.add_argument(
+        "--parameter-count",
+        type=int,
+        help="use the first COUNT values from each non-empty parameter list",
+    )
+    level_group = parser.add_mutually_exclusive_group()
+    level_group.add_argument(
+        "--level-count",
+        type=int,
+        help="number of direct-table levels ending at --nlevels",
+    )
+    level_group.add_argument(
+        "--direct-levels",
+        help=(
+            "comma-separated direct-table source-box levels; "
+            "must include --nlevels"
+        ),
+    )
+    parser.add_argument(
+        "--repeat-count",
+        type=int,
+        help="number of timed applications per parameter",
+    )
     args = parser.parse_args()
 
     smoke = args.mode == "smoke"
     q_order = args.q_order if args.q_order is not None else (2 if smoke else 4)
     nlevels = args.nlevels if args.nlevels is not None else (2 if smoke else 3)
-    fmm_order = args.fmm_order if args.fmm_order is not None else (8 if smoke else 16)
-    split_orders = _parse_csv_ints(args.split_orders or ("1,2" if smoke else "1,2,3"))
-    helmholtz_k = _parse_csv_floats(args.helmholtz_k or ("4" if smoke else "4,8,12"))
-    yukawa_lam = _parse_csv_floats(args.yukawa_lambda or ("4" if smoke else "4,8,12"))
+    fmm_order = (
+        args.fmm_order if args.fmm_order is not None else (8 if smoke else 16)
+    )
+    split_orders = _parse_csv_ints(
+        args.split_orders or ("1,2" if smoke else "1,2,3")
+    )
+    helmholtz_k = _parse_csv_floats(
+        args.helmholtz_k
+        if args.helmholtz_k is not None
+        else ("4" if smoke else "4,8,12"),
+        allow_empty=True,
+    )
+    yukawa_lam = _parse_csv_floats(
+        args.yukawa_lambda
+        if args.yukawa_lambda is not None
+        else ("4" if smoke else "4,8,12"),
+        allow_empty=True,
+    )
+    helmholtz_k = _limit_parameter_values(helmholtz_k, args.parameter_count)
+    yukawa_lam = _limit_parameter_values(yukawa_lam, args.parameter_count)
+
+    repeat_count = (
+        args.repeat_count if args.repeat_count is not None else (1 if smoke else 5)
+    )
+    if repeat_count < 1:
+        parser.error("--repeat-count must be >= 1")
+
+    if args.direct_levels:
+        direct_levels = _parse_csv_levels(args.direct_levels)
+    else:
+        level_count = (
+            args.level_count
+            if args.level_count is not None
+            else (1 if smoke else nlevels + 1)
+        )
+        if not 1 <= level_count <= nlevels + 1:
+            parser.error("--level-count must be between 1 and nlevels + 1")
+        direct_levels = list(range(nlevels - level_count + 1, nlevels + 1))
+    if nlevels not in direct_levels:
+        parser.error(
+            "--direct-levels must include --nlevels for the direct reference"
+        )
+    if not helmholtz_k and not yukawa_lam:
+        parser.error(
+            "at least one of --helmholtz-k or --yukawa-lambda must be non-empty"
+        )
 
     rows = run_benchmark(
         mode=args.mode,
@@ -522,6 +1255,8 @@ def main() -> int:
         split_orders=split_orders,
         helmholtz_k=helmholtz_k,
         yukawa_lam=yukawa_lam,
+        direct_levels=direct_levels,
+        repeat_count=repeat_count,
     )
     write_csv(args.out, rows)
     return 0

--- a/benchmarks/split_parameter_sweep.py
+++ b/benchmarks/split_parameter_sweep.py
@@ -966,6 +966,11 @@ def run_benchmark(
 ) -> list[dict[str, Any]]:
     import pyopencl as cl
 
+    if repeat_count < 1:
+        raise ValueError("repeat_count must be >= 1")
+    if nlevels not in direct_levels:
+        raise ValueError("direct_levels must include nlevels")
+
     benchmark_start = time.perf_counter()
     device = _select_opencl_device(cl, backend)
     ctx = cl.Context([device])

--- a/benchmarks/table_equivalence_cache.py
+++ b/benchmarks/table_equivalence_cache.py
@@ -7,7 +7,7 @@ the expected scale factor is applied, and records cold-build/warm-load cache
 timings exposed by :mod:`volumential.table_manager`.
 
 Smoke mode is intended for CI/local validation. Full mode is intended for paper
-artifact generation on a controlled machine such as ``ipa``.
+artifact generation on a controlled remote compute host.
 """
 
 from __future__ import annotations

--- a/examples/branched_flow_helmholtz2d.py
+++ b/examples/branched_flow_helmholtz2d.py
@@ -714,6 +714,25 @@ def _default_config(smoke):
 
 
 def _validate_config(config):
+    if config.q_order <= 0:
+        raise ValueError("q_order must be positive")
+    if config.nlevels <= 0:
+        raise ValueError("nlevels must be positive")
+    if not config.root_half_extent > 0.0:
+        raise ValueError("root_half_extent must be positive")
+    if not config.wave_number > 0.0:
+        raise ValueError("wave_number must be positive")
+    if not config.core_x_min < config.core_x_max:
+        raise ValueError("core_x_min must be less than core_x_max")
+    if not config.core_y_min < config.core_y_max:
+        raise ValueError("core_y_min must be less than core_y_max")
+    if not config.transition_width > 0.0:
+        raise ValueError("transition_width must be positive")
+    if not config.gmres_tolerance > 0.0:
+        raise ValueError("gmres_tolerance must be positive")
+    if config.gmres_maxiter <= 0:
+        raise ValueError("gmres_maxiter must be positive")
+
     root_min = -config.root_half_extent
     root_max = config.root_half_extent
     support_bounds = (
@@ -1402,6 +1421,7 @@ def _parse_arguments():
     parser.add_argument("--fmm-order-padding", type=int)
     parser.add_argument("--fmm-backend", choices=("sumpy", "fmmlib"))
     parser.add_argument("--wave-number", type=float)
+    parser.add_argument("--incident-angle-degrees", type=float)
     parser.add_argument("--root-half-extent", type=float)
     parser.add_argument("--core-x-min", type=float)
     parser.add_argument("--core-x-max", type=float)
@@ -1451,6 +1471,7 @@ def _config_from_arguments(arguments):
         "fmm_order_padding": arguments.fmm_order_padding,
         "fmm_backend": arguments.fmm_backend,
         "wave_number": arguments.wave_number,
+        "incident_angle_degrees": arguments.incident_angle_degrees,
         "root_half_extent": arguments.root_half_extent,
         "core_x_min": arguments.core_x_min,
         "core_x_max": arguments.core_x_max,

--- a/examples/branched_flow_helmholtz2d.py
+++ b/examples/branched_flow_helmholtz2d.py
@@ -1,0 +1,1505 @@
+"""Free-space 2D Helmholtz branched flow in a smooth random medium.
+
+The refractive-index perturbation is generated on a rectangular core and
+multiplied by a C-infinity window that decays to zero in an outer rectangular
+transition layer.  The resulting compactly supported contrast is solved with
+the constant-background Lippmann--Schwinger equation
+
+    sigma - m V_k[sigma] = m u_inc,
+    u = u_inc + V_k[sigma],
+
+where ``m = k**2 * (n**2 - 1)`` and ``V_k`` is the outgoing free-space
+Helmholtz volume potential.  No artificial outer boundary, BIE, or PML is
+used.
+
+The optional fixed right preconditioners leave this global operator unchanged.
+They apply a target-restricted List-1 correction using either the background
+wave number or a Lagrange palette of fixed-wave-number tables that approximates
+the source-frozen local kernel.
+
+Use ``--smoke`` for a small local validation.  The default configuration is a
+large publication-pilot workload and should be run on approved remote
+compute resources.  It uses the optional ``pyfmmlib`` backend; install the
+``fmmlib`` project extra before running it.
+"""
+
+from __future__ import annotations
+
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import argparse
+import csv
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass
+from functools import partial
+from pathlib import Path
+import time
+
+import numpy as np
+import pyopencl as cl
+import pyopencl.array as cla
+
+import volumential.meshgen as mg
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    q_order: int
+    nlevels: int
+    fmm_order: int
+    fmm_order_mode: str
+    fmm_order_padding: int
+    fmm_backend: str
+    wave_number: float
+    root_half_extent: float
+    core_x_min: float
+    core_x_max: float
+    core_y_min: float
+    core_y_max: float
+    transition_width: float
+    correlation_length: float
+    refractive_rms: float
+    incident_angle_degrees: float
+    random_seed: int
+    gaussian_bumps: int
+    medium_generator: str
+    medium_grid_points_per_correlation: int
+    medium_filter_truncate: float
+    medium_realization: str
+    medium_reference_half_extent: float
+    medium_normalization_samples: int
+    gmres_tolerance: float
+    gmres_restart: int
+    gmres_maxiter: int
+    preconditioner: str
+    preconditioner_palette_size: int
+    preconditioner_damping: float
+    preconditioner_ordering: str
+    preconditioner_degree: int
+    smoke: bool
+
+
+def _device_supports_fp64(device):
+    has_khr_fp64 = "cl_khr_fp64" in getattr(device, "extensions", "").split()
+    has_double_config = bool(getattr(device, "double_fp_config", 0))
+    return has_khr_fp64 or has_double_config
+
+
+def _select_opencl_device(cl_module):
+    try:
+        platforms = cl_module.get_platforms()
+    except cl_module.LogicError as exc:
+        raise RuntimeError(f"OpenCL platforms unavailable: {exc}") from exc
+
+    native_gpu_platforms = [
+        platform
+        for platform in platforms
+        if "portable computing language" not in platform.name.lower()
+    ]
+    for platform in native_gpu_platforms:
+        for dev in platform.get_devices():
+            if dev.type & cl_module.device_type.GPU and _device_supports_fp64(dev):
+                return dev
+
+    for platform in platforms:
+        for dev in platform.get_devices():
+            if dev.type & cl_module.device_type.GPU and _device_supports_fp64(dev):
+                return dev
+
+    for platform in platforms:
+        for dev in platform.get_devices():
+            if dev.type & cl_module.device_type.CPU and _device_supports_fp64(dev):
+                return dev
+
+    raise RuntimeError("No OpenCL GPU/CPU device with fp64 support found")
+
+
+def _smooth_ramp(values):
+    """Return a C-infinity ramp from zero at 0 to one at 1."""
+    values = np.asarray(values, dtype=np.float64)
+    result = np.empty_like(values)
+    result[values <= 0.0] = 0.0
+    result[values >= 1.0] = 1.0
+
+    interior = (values > 0.0) & (values < 1.0)
+    t = values[interior]
+    left = np.exp(-1.0 / t)
+    right = np.exp(-1.0 / (1.0 - t))
+    result[interior] = left / (left + right)
+    return result
+
+
+def _axis_window(values, core_min, core_max, transition_width):
+    if not core_min < core_max:
+        raise ValueError("core_min must be less than core_max")
+    if not transition_width > 0.0:
+        raise ValueError("transition_width must be positive")
+
+    left = _smooth_ramp((values - (core_min - transition_width))
+                        / transition_width)
+    right = _smooth_ramp(((core_max + transition_width) - values)
+                         / transition_width)
+    return left * right
+
+
+def _box_window(x, y, config):
+    return (
+        _axis_window(
+            x, config.core_x_min, config.core_x_max, config.transition_width
+        )
+        * _axis_window(
+            y, config.core_y_min, config.core_y_max, config.transition_width
+        )
+    )
+
+
+def _filtered_grid_raw_field(x, y, config):
+    from scipy.interpolate import RectBivariateSpline
+    from scipy.ndimage import gaussian_filter
+
+    spacing = (
+        config.correlation_length / config.medium_grid_points_per_correlation
+    )
+    filter_radius = int(np.ceil(
+        config.medium_filter_truncate
+        * config.medium_grid_points_per_correlation
+    ))
+    if config.medium_realization == "nested":
+        half_extent = config.medium_reference_half_extent
+    else:
+        half_extent = config.root_half_extent
+    halo_points = filter_radius + 2
+    index_min = int(np.floor(-half_extent / spacing)) - halo_points
+    index_max = int(np.ceil(half_extent / spacing)) + halo_points
+    grid_axis = spacing * np.arange(index_min, index_max + 1)
+
+    rng = np.random.Generator(
+        np.random.PCG64(np.random.SeedSequence(config.random_seed))
+    )
+    white = rng.standard_normal((grid_axis.size, grid_axis.size))
+    filtered = gaussian_filter(
+        white,
+        sigma=config.medium_grid_points_per_correlation,
+        radius=filter_radius,
+        mode="constant",
+        cval=0.0,
+        output=np.float64,
+    )
+    interpolator = RectBivariateSpline(
+        grid_axis,
+        grid_axis,
+        filtered,
+        kx=3,
+        ky=3,
+        s=0.0,
+    )
+    raw = interpolator.ev(y, x)
+
+    if config.medium_realization == "nested":
+        reference = config.medium_reference_half_extent
+        core_x = (grid_axis >= -0.8 * reference) & (
+            grid_axis <= 0.375 * reference
+        )
+        core_y = (grid_axis >= -0.625 * reference) & (
+            grid_axis <= 0.625 * reference
+        )
+        reference_values = filtered[np.ix_(core_y, core_x)]
+        return raw, float(np.mean(reference_values)), float(np.std(reference_values))
+
+    return raw, None, None
+
+
+def _random_refractive_perturbation(x, y, weights, window, config):
+    if config.medium_generator == "filtered-grid":
+        raw, fixed_mean, fixed_rms = _filtered_grid_raw_field(x, y, config)
+    else:
+        raw, fixed_mean, fixed_rms = _gaussian_bump_raw_field(x, y, config)
+
+    core = (
+        (x >= config.core_x_min)
+        & (x <= config.core_x_max)
+        & (y >= config.core_y_min)
+        & (y <= config.core_y_max)
+    )
+    if not np.any(core):
+        raise RuntimeError("The discretization has no points in the medium core")
+
+    if fixed_mean is not None and fixed_rms is not None:
+        mean = fixed_mean
+        rms = fixed_rms
+    else:
+        core_weights = weights[core]
+        core_raw = raw[core]
+        weight_sum = np.sum(core_weights)
+        mean = np.sum(core_weights * core_raw) / weight_sum
+        rms = np.sqrt(
+            np.sum(core_weights * (core_raw - mean) ** 2) / weight_sum
+        )
+
+    if not rms > 0.0:
+        raise RuntimeError("Random refractive field has zero RMS")
+    return config.refractive_rms * window * (raw - mean) / rms
+
+
+def _gaussian_bump_raw_field(x, y, config):
+    rng = np.random.default_rng(config.random_seed)
+    if config.medium_realization == "nested":
+        center_x_min = -0.8 * config.medium_reference_half_extent
+        center_x_max = 0.375 * config.medium_reference_half_extent
+        center_y_min = -0.625 * config.medium_reference_half_extent
+        center_y_max = 0.625 * config.medium_reference_half_extent
+    else:
+        center_x_min = config.core_x_min
+        center_x_max = config.core_x_max
+        center_y_min = config.core_y_min
+        center_y_max = config.core_y_max
+
+    centers_x = rng.uniform(
+        center_x_min,
+        center_x_max,
+        size=config.gaussian_bumps,
+    )
+    centers_y = rng.uniform(
+        center_y_min,
+        center_y_max,
+        size=config.gaussian_bumps,
+    )
+    amplitudes = rng.normal(size=config.gaussian_bumps)
+
+    raw = np.zeros_like(x)
+    variance_factor = 0.5 / config.correlation_length**2
+    for center_x, center_y, amplitude in zip(
+        centers_x, centers_y, amplitudes, strict=True
+    ):
+        radius_squared = (x - center_x) ** 2 + (y - center_y) ** 2
+        raw += amplitude * np.exp(-variance_factor * radius_squared)
+
+    if config.medium_realization == "nested":
+        normalization_rng = np.random.default_rng(
+            np.random.SeedSequence([config.random_seed, 0x4E455354])
+        )
+        sample_x = normalization_rng.uniform(
+            center_x_min,
+            center_x_max,
+            size=config.medium_normalization_samples,
+        )
+        sample_y = normalization_rng.uniform(
+            center_y_min,
+            center_y_max,
+            size=config.medium_normalization_samples,
+        )
+        sample_raw = np.zeros(config.medium_normalization_samples)
+        for center_x, center_y, amplitude in zip(
+            centers_x, centers_y, amplitudes, strict=True
+        ):
+            sample_radius_squared = (
+                (sample_x - center_x) ** 2 + (sample_y - center_y) ** 2
+            )
+            sample_raw += amplitude * np.exp(
+                -variance_factor * sample_radius_squared
+            )
+        return raw, float(np.mean(sample_raw)), float(np.std(sample_raw))
+
+    return raw, None, None
+
+
+def _get_near_field_table(queue, table_filename, config, wave_number=None):
+    from volumential.nearfield_potential_table import DuffyBuildConfig
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    regular_quad_order = max(8, 4 * config.q_order)
+    radial_quad_order = max(21, 10 * config.q_order)
+    manager_kwargs = {
+        "root_extent": 2.0 * config.root_half_extent,
+        "dtype": np.float64,
+        "queue": queue,
+    }
+    table_kwargs = {}
+    kernel_name = "Laplace"
+    if config.fmm_backend == "fmmlib":
+        from sumpy.kernel import HelmholtzKernel
+
+        kernel = HelmholtzKernel(2)
+        if wave_number is None:
+            wave_number = config.wave_number
+        manager_kwargs["dtype"] = np.complex128
+        kernel_name = "Helmholtz-Reference"
+        table_kwargs = {
+            "source_box_level": config.nlevels - 1,
+            "sumpy_knl": kernel,
+            kernel.helmholtz_k_name: wave_number,
+        }
+
+    with NearFieldInteractionTableManager(
+        table_filename,
+        **manager_kwargs,
+    ) as table_manager:
+        table, _ = table_manager.get_table(
+            2,
+            kernel_name,
+            config.q_order,
+            queue=queue,
+            build_config=DuffyBuildConfig(
+                radial_rule="tanh-sinh-fast",
+                regular_quad_order=regular_quad_order,
+                radial_quad_order=radial_quad_order,
+            ),
+            **table_kwargs,
+        )
+
+    return table
+
+
+def _device_norm(queue, vector):
+    return float(np.sqrt(abs(cla.vdot(vector, vector, queue=queue).get(queue))))
+
+
+def _fmm_level_order(config, tree, level):
+    if config.fmm_order_mode == "fixed":
+        return config.fmm_order
+
+    box_extent = tree.root_extent * 2.0 ** (-level)
+    box_radius = box_extent / np.sqrt(2.0)
+    phase_order = int(np.ceil(abs(config.wave_number) * box_radius))
+    return max(config.fmm_order, phase_order + config.fmm_order_padding)
+
+
+def _chebyshev_lobatto_nodes(lower, upper, count):
+    if count < 2:
+        raise ValueError("Chebyshev-Lobatto interpolation requires at least 2 nodes")
+    if not lower < upper:
+        raise ValueError("interpolation interval must have positive width")
+
+    angles = np.linspace(np.pi, 0.0, count)
+    reference_nodes = np.cos(angles)
+    return 0.5 * (
+        lower + upper + (upper - lower) * reference_nodes
+    )
+
+
+def _lagrange_interpolation_weights(values, nodes):
+    values = np.asarray(values, dtype=np.float64)
+    nodes = np.asarray(nodes, dtype=np.float64)
+    if nodes.ndim != 1 or nodes.size == 0:
+        raise ValueError("interpolation nodes must be a nonempty vector")
+    if np.unique(nodes).size != nodes.size:
+        raise ValueError("interpolation nodes must be distinct")
+
+    weights = []
+    for index, node in enumerate(nodes):
+        weight = np.ones_like(values)
+        for other_index, other_node in enumerate(nodes):
+            if other_index != index:
+                weight *= (values - other_node) / (node - other_node)
+        weights.append(weight)
+    return np.asarray(weights)
+
+
+def _restrict_neighbor_csr(
+    target_boxes,
+    neighbor_starts,
+    neighbor_lists,
+    active_box_flags,
+):
+    target_boxes = np.asarray(target_boxes)
+    neighbor_starts = np.asarray(neighbor_starts)
+    neighbor_lists = np.asarray(neighbor_lists)
+    active_box_flags = np.asarray(active_box_flags, dtype=bool)
+    if neighbor_starts.shape != (target_boxes.size + 1,):
+        raise ValueError("neighbor CSR starts do not match target boxes")
+    if neighbor_starts[-1] != neighbor_lists.size:
+        raise ValueError("neighbor CSR terminal offset does not match its lists")
+    if target_boxes.size and np.max(target_boxes) >= active_box_flags.size:
+        raise ValueError("active-box flags do not cover all target boxes")
+
+    selected_positions = np.flatnonzero(active_box_flags[target_boxes])
+    restricted_targets = target_boxes[selected_positions]
+    restricted_starts = np.zeros(selected_positions.size + 1, dtype=np.int32)
+    chunks = []
+    for output_index, input_index in enumerate(selected_positions):
+        start = int(neighbor_starts[input_index])
+        stop = int(neighbor_starts[input_index + 1])
+        chunks.append(neighbor_lists[start:stop])
+        restricted_starts[output_index + 1] = (
+            restricted_starts[output_index] + stop - start
+        )
+
+    if chunks:
+        restricted_lists = np.concatenate(chunks)
+    else:
+        restricted_lists = np.empty(0, dtype=neighbor_lists.dtype)
+    return restricted_targets, restricted_starts, restricted_lists
+
+
+def _extract_single_potential(potentials):
+    if isinstance(potentials, np.ndarray) and potentials.dtype == object:
+        if len(potentials) != 1:
+            raise ValueError("expected one potential output")
+        return potentials[0]
+    return potentials
+
+
+def _apply_fixed_polynomial(linear_map, vector, degree, damping):
+    result = vector
+    term = vector
+    for _ in range(degree):
+        term = linear_map(term)
+        result = result + damping * term
+    return result
+
+
+class _VolumeIntegralOperator:
+    def __init__(
+        self,
+        queue,
+        traversal,
+        wrangler,
+        source_weights,
+        contrast,
+    ):
+        self.queue = queue
+        self.traversal = traversal
+        self.wrangler = wrangler
+        self.source_weights = source_weights
+        self.contrast = contrast
+        self.shape = (len(contrast), len(contrast))
+        self.application_count = 0
+        self.application_seconds = 0.0
+
+    def volume_potential(self, density):
+        from volumential.volume_fmm import drive_volume_fmm
+
+        self.queue.finish()
+        start = time.perf_counter()
+        potentials = drive_volume_fmm(
+            self.traversal,
+            self.wrangler,
+            density * self.source_weights,
+            density,
+            direct_evaluation=False,
+            list1_only=False,
+        )
+        if isinstance(potentials, np.ndarray) and potentials.dtype != object:
+            potential = potentials
+        else:
+            (potential,) = potentials
+        if not isinstance(potential, cla.Array):
+            potential = cla.to_device(
+                self.queue,
+                np.ascontiguousarray(potential),
+            )
+        self.queue.finish()
+        self.application_count += 1
+        self.application_seconds += time.perf_counter() - start
+        return potential
+
+    def __call__(self, density):
+        return density - self.contrast * self.volume_potential(density)
+
+
+class _NearFieldPotential:
+    """Apply one fixed-wave-number List-1 table on target-owned boxes."""
+
+    def __init__(
+        self,
+        queue,
+        wrangler,
+        target_boxes,
+        neighbor_starts,
+        neighbor_lists,
+    ):
+        self.queue = queue
+        self.wrangler = wrangler
+        self.target_boxes = target_boxes
+        self.neighbor_starts = neighbor_starts
+        self.neighbor_lists = neighbor_lists
+
+    def __call__(self, source_values):
+        tree_values = self.wrangler.reorder_sources(source_values)
+        potentials, _ = self.wrangler.eval_direct(
+            self.target_boxes,
+            self.neighbor_starts,
+            self.neighbor_lists,
+            tree_values,
+        )
+        potentials = self.wrangler.reorder_potentials(potentials)
+        potentials = self.wrangler.finalize_potentials(potentials)
+        potential = _extract_single_potential(potentials)
+        if not isinstance(potential, cla.Array):
+            potential = cla.to_device(
+                self.queue,
+                np.ascontiguousarray(potential),
+            )
+        return potential
+
+
+class _List1PolynomialPreconditioner:
+    """Apply a fixed polynomial in a target- or source-ordered List-1 map."""
+
+    def __init__(
+        self,
+        queue,
+        contrast,
+        active_mask,
+        near_potentials,
+        interpolation_weights,
+        damping,
+        ordering,
+        degree,
+    ):
+        if len(near_potentials) != len(interpolation_weights):
+            raise ValueError("each local wave number needs interpolation weights")
+        if not near_potentials:
+            raise ValueError("at least one local potential is required")
+        self.queue = queue
+        self.contrast = contrast
+        self.active_mask = active_mask
+        self.near_potentials = near_potentials
+        self.interpolation_weights = interpolation_weights
+        self.damping = damping
+        self.ordering = ordering
+        self.degree = degree
+        self.shape = (len(contrast), len(contrast))
+        self.application_count = 0
+        self.application_seconds = 0.0
+
+    def _apply_local_potential(self, source_values):
+        result = cla.zeros_like(source_values)
+        for near_potential, interpolation_weight in zip(
+            self.near_potentials,
+            self.interpolation_weights,
+            strict=True,
+        ):
+            result = result + near_potential(
+                interpolation_weight * source_values
+            )
+        return result
+
+    def __call__(self, residual):
+        self.queue.finish()
+        start = time.perf_counter()
+
+        def apply_term(term):
+            if self.ordering == "target":
+                return self.contrast * self._apply_local_potential(term)
+            return self.active_mask * self._apply_local_potential(
+                self.contrast * term
+            )
+
+        result = _apply_fixed_polynomial(
+            apply_term,
+            residual,
+            self.degree,
+            self.damping,
+        )
+        self.queue.finish()
+        self.application_count += 1
+        self.application_seconds += time.perf_counter() - start
+        return result
+
+
+class _RightPreconditionedOperator:
+    def __init__(self, operator, preconditioner):
+        if operator.shape != preconditioner.shape:
+            raise ValueError("operator and right preconditioner shapes must match")
+        self.operator = operator
+        self.preconditioner = preconditioner
+        self.shape = operator.shape
+
+    def __call__(self, transformed_density):
+        return self.operator(self.preconditioner(transformed_density))
+
+    def recover(self, transformed_density):
+        return self.preconditioner(transformed_density)
+
+
+def _default_config(smoke):
+    if smoke:
+        return RunConfig(
+            q_order=3,
+            nlevels=4,
+            fmm_order=10,
+            fmm_order_mode="fixed",
+            fmm_order_padding=0,
+            fmm_backend="sumpy",
+            wave_number=4.0,
+            root_half_extent=1.0,
+            core_x_min=-0.55,
+            core_x_max=0.20,
+            core_y_min=-0.40,
+            core_y_max=0.40,
+            transition_width=0.12,
+            correlation_length=0.28,
+            refractive_rms=0.03,
+            incident_angle_degrees=0.0,
+            random_seed=17,
+            gaussian_bumps=12,
+            medium_generator="gaussian-bumps",
+            medium_grid_points_per_correlation=8,
+            medium_filter_truncate=6.0,
+            medium_realization="local",
+            medium_reference_half_extent=8.0,
+            medium_normalization_samples=16384,
+            gmres_tolerance=1.0e-6,
+            gmres_restart=12,
+            gmres_maxiter=40,
+            preconditioner="none",
+            preconditioner_palette_size=5,
+            preconditioner_damping=1.0,
+            preconditioner_ordering="target",
+            preconditioner_degree=1,
+            smoke=True,
+        )
+
+    return RunConfig(
+        q_order=4,
+        nlevels=9,
+        fmm_order=40,
+        fmm_order_mode="helmholtz",
+        fmm_order_padding=20,
+        fmm_backend="fmmlib",
+        wave_number=12.0,
+        root_half_extent=8.0,
+        core_x_min=-6.40,
+        core_x_max=3.00,
+        core_y_min=-5.00,
+        core_y_max=5.00,
+        transition_width=0.50,
+        correlation_length=0.55,
+        refractive_rms=0.05,
+        incident_angle_degrees=0.0,
+        random_seed=17,
+        gaussian_bumps=2048,
+        medium_generator="gaussian-bumps",
+        medium_grid_points_per_correlation=8,
+        medium_filter_truncate=6.0,
+        medium_realization="local",
+        medium_reference_half_extent=8.0,
+        medium_normalization_samples=16384,
+        gmres_tolerance=1.0e-8,
+        gmres_restart=20,
+        gmres_maxiter=120,
+        preconditioner="none",
+        preconditioner_palette_size=5,
+        preconditioner_damping=1.0,
+        preconditioner_ordering="target",
+        preconditioner_degree=1,
+        smoke=False,
+    )
+
+
+def _validate_config(config):
+    root_min = -config.root_half_extent
+    root_max = config.root_half_extent
+    support_bounds = (
+        config.core_x_min - config.transition_width,
+        config.core_x_max + config.transition_width,
+        config.core_y_min - config.transition_width,
+        config.core_y_max + config.transition_width,
+    )
+    if min(support_bounds[0], support_bounds[2]) <= root_min:
+        raise ValueError("The transition layer must remain inside the root box")
+    if max(support_bounds[1], support_bounds[3]) >= root_max:
+        raise ValueError("The transition layer must remain inside the root box")
+    if config.correlation_length <= 0.0:
+        raise ValueError("correlation_length must be positive")
+    if config.refractive_rms <= 0.0:
+        raise ValueError("refractive_rms must be positive")
+    if config.fmm_backend not in {"sumpy", "fmmlib"}:
+        raise ValueError("fmm_backend must be 'sumpy' or 'fmmlib'")
+    if config.fmm_order_mode not in {"fixed", "helmholtz"}:
+        raise ValueError("fmm_order_mode must be 'fixed' or 'helmholtz'")
+    if config.fmm_order <= 0:
+        raise ValueError("fmm_order must be positive")
+    if config.fmm_order_padding < 0:
+        raise ValueError("fmm_order_padding must be nonnegative")
+    if config.preconditioner not in {"none", "constant", "source-frozen"}:
+        raise ValueError(
+            "preconditioner must be 'none', 'constant', or 'source-frozen'"
+        )
+    if config.preconditioner != "none" and config.fmm_backend != "fmmlib":
+        raise ValueError("List-1 preconditioning currently requires FMMLib tables")
+    if (
+        config.preconditioner == "source-frozen"
+        and config.preconditioner_palette_size < 2
+    ):
+        raise ValueError("preconditioner_palette_size must be at least 2")
+    if not 0.0 <= config.preconditioner_damping <= 1.0:
+        raise ValueError("preconditioner_damping must lie in [0, 1]")
+    if config.preconditioner_ordering not in {"source", "target"}:
+        raise ValueError("preconditioner_ordering must be 'source' or 'target'")
+    if config.preconditioner_degree < 1:
+        raise ValueError("preconditioner_degree must be at least 1")
+    if config.gmres_restart <= 0:
+        raise ValueError("gmres_restart must be positive")
+    if config.medium_realization not in {"local", "nested"}:
+        raise ValueError("medium_realization must be 'local' or 'nested'")
+    if config.medium_reference_half_extent <= 0.0:
+        raise ValueError("medium_reference_half_extent must be positive")
+    if config.medium_normalization_samples <= 0:
+        raise ValueError("medium_normalization_samples must be positive")
+    if config.medium_generator not in {"gaussian-bumps", "filtered-grid"}:
+        raise ValueError(
+            "medium_generator must be 'gaussian-bumps' or 'filtered-grid'"
+        )
+    if config.medium_grid_points_per_correlation < 4:
+        raise ValueError("medium_grid_points_per_correlation must be at least 4")
+    if config.medium_filter_truncate < 4.0:
+        raise ValueError("medium_filter_truncate must be at least 4")
+    if (
+        config.medium_generator == "filtered-grid"
+        and config.medium_realization == "nested"
+        and config.medium_reference_half_extent < config.root_half_extent
+    ):
+        raise ValueError("nested filtered-grid reference must contain the root box")
+
+
+def _write_outputs(
+    output_dir,
+    config,
+    arrays,
+    metadata,
+    residual_norms,
+):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(output_dir / "fields.npz", **arrays)
+
+    with (output_dir / "metadata.json").open("w", encoding="utf-8") as outf:
+        json.dump(metadata, outf, indent=2, sort_keys=True)
+        outf.write("\n")
+
+    with (output_dir / "gmres_residuals.csv").open(
+        "w", encoding="utf-8", newline=""
+    ) as outf:
+        writer = csv.writer(outf)
+        writer.writerow(["iteration", "relative_residual"])
+        for iteration, residual in enumerate(residual_norms):
+            writer.writerow([iteration, f"{residual:.17e}"])
+
+
+def _write_plot(output_dir, arrays):
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        logger.info("matplotlib is unavailable; skipping plot generation")
+        return
+
+    x = arrays["x"]
+    y = arrays["y"]
+    perturbation = arrays["refractive_index"] - 1.0
+    intensity = arrays["intensity"]
+    field_real = arrays["total_field"].real
+    x_axis = np.unique(x)
+    y_axis = np.unique(y)
+    x_indices = np.searchsorted(x_axis, x)
+    y_indices = np.searchsorted(y_axis, y)
+
+    def as_grid(field):
+        grid = np.empty((y_axis.size, x_axis.size), dtype=field.dtype)
+        grid[y_indices, x_indices] = field
+        return grid
+
+    figure, axes = plt.subplots(
+        3, 1, figsize=(9.0, 15.0), sharex=True, sharey=True
+    )
+    fields = [perturbation, intensity, field_real]
+    titles = ["refractive-index perturbation", "normalized intensity", "Re(u)"]
+    color_maps = ["RdBu_r", "magma", "RdBu_r"]
+
+    for axis, field, title, color_map in zip(
+        axes, fields, titles, color_maps, strict=True
+    ):
+        if title == "normalized intensity":
+            color_min = 0.0
+            color_max = np.quantile(field, 0.995)
+        else:
+            scale = np.quantile(np.abs(field), 0.995)
+            color_min = -scale
+            color_max = scale
+        image = axis.imshow(
+            as_grid(field),
+            origin="lower",
+            extent=[x_axis[0], x_axis[-1], y_axis[0], y_axis[-1]],
+            cmap=color_map,
+            vmin=color_min,
+            vmax=color_max,
+            interpolation="nearest",
+            aspect="equal",
+        )
+        axis.set_title(title)
+        axis.set_ylabel("y")
+        figure.colorbar(image, ax=axis, fraction=0.025, pad=0.01)
+
+    axes[-1].set_xlabel("x")
+    figure.tight_layout()
+    figure.savefig(output_dir / "branched_flow.png", dpi=220)
+    plt.close(figure)
+
+
+def run(config, output_dir):
+    from importlib.util import find_spec
+
+    from pytential.linalg.gmres import gmres
+    from sumpy.expansion import DefaultExpansionFactory
+    from sumpy.kernel import HelmholtzKernel
+
+    from volumential.expansion_wrangler_fpnd import (
+        FPNDExpansionWrangler,
+        FPNDTreeIndependentDataForWrangler,
+    )
+
+    _validate_config(config)
+    if config.fmm_backend == "fmmlib" and find_spec("pyfmmlib") is None:
+        raise RuntimeError(
+            "The FMMLib backend requires pyfmmlib; install volumential[fmmlib]"
+        )
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = _select_opencl_device(cl)
+    context = cl.Context([device])
+    queue = cl.CommandQueue(context)
+
+    root_min = -config.root_half_extent
+    root_max = config.root_half_extent
+    mesh = mg.MeshGen2D(
+        config.q_order,
+        config.nlevels,
+        root_min,
+        root_max,
+        queue=queue,
+    )
+    q_points, source_weights, tree, traversal = mg.build_geometry_info(
+        context,
+        queue,
+        2,
+        config.q_order,
+        mesh,
+        bbox=np.array([[root_min, root_max]] * 2, dtype=np.float64),
+    )
+
+    coordinates = np.array([axis.get(queue) for axis in q_points])
+    x = coordinates[0]
+    y = coordinates[1]
+    weights_host = source_weights.get(queue)
+
+    window = _box_window(x, y, config)
+    delta_n = _random_refractive_perturbation(
+        x, y, weights_host, window, config
+    )
+    refractive_index = 1.0 + delta_n
+    if np.min(refractive_index) <= 0.0:
+        raise RuntimeError("The generated refractive index is not positive")
+
+    contrast_host = config.wave_number**2 * (refractive_index**2 - 1.0)
+    angle = np.deg2rad(config.incident_angle_degrees)
+    incident_host = np.exp(
+        1j
+        * config.wave_number
+        * (np.cos(angle) * x + np.sin(angle) * y)
+    )
+
+    contrast = cla.to_device(
+        queue, np.ascontiguousarray(contrast_host.astype(np.complex128))
+    )
+    incident = cla.to_device(
+        queue, np.ascontiguousarray(incident_host.astype(np.complex128))
+    )
+
+    table = _get_near_field_table(
+        queue,
+        output_dir / "near_field_table.sqlite",
+        config,
+    )
+
+    kernel = HelmholtzKernel(2)
+    expansion_factory = DefaultExpansionFactory()
+    local_expansion_class = expansion_factory.get_local_expansion_class(kernel)
+    multipole_expansion_class = (
+        expansion_factory.get_multipole_expansion_class(kernel)
+    )
+    self_extra_kwargs = {}
+    if tree.sources_are_targets:
+        self_extra_kwargs["target_to_source"] = np.arange(
+            tree.ntargets, dtype=np.int32
+        )
+
+    wrangler_kwargs = {
+        "queue": queue,
+        "near_field_table": table,
+        "dtype": np.complex128,
+        "fmm_level_to_order": (
+            lambda kernel, kernel_args, tree, level: _fmm_level_order(
+                config, tree, level
+            )
+        ),
+        "quad_order": config.q_order,
+        "kernel_extra_kwargs": {kernel.helmholtz_k_name: config.wave_number},
+        "self_extra_kwargs": self_extra_kwargs,
+    }
+    if config.fmm_backend == "sumpy":
+        tree_independent = FPNDTreeIndependentDataForWrangler(
+            context,
+            partial(multipole_expansion_class, kernel),
+            partial(local_expansion_class, kernel),
+            [kernel],
+            exclude_self=True,
+        )
+        wrangler = FPNDExpansionWrangler(
+            tree_indep=tree_independent,
+            traversal=traversal,
+            helmholtz_split=True,
+            **wrangler_kwargs,
+        )
+    else:
+        from volumential.expansion_wrangler_fpnd import (
+            FPNDFMMLibExpansionWrangler,
+            FPNDFMMLibTreeIndependentDataForWrangler,
+        )
+
+        tree_independent = FPNDFMMLibTreeIndependentDataForWrangler(
+            context,
+            partial(multipole_expansion_class, kernel),
+            partial(local_expansion_class, kernel),
+            [kernel],
+            exclude_self=True,
+        )
+        wrangler = FPNDFMMLibExpansionWrangler(
+            tree_indep=tree_independent,
+            tree=tree,
+            traversal=traversal,
+            **wrangler_kwargs,
+        )
+
+    operator = _VolumeIntegralOperator(
+        queue,
+        traversal,
+        wrangler,
+        source_weights,
+        contrast,
+    )
+    preconditioner = None
+    preconditioner_metadata = {
+        "kind": config.preconditioner,
+        "formula": (
+            (
+                "B_sigma = I + omega sum_(j=1)^p (M_m Q_near)^j"
+                if config.preconditioner_ordering == "target"
+                else "B_sigma = I + omega sum_(j=1)^p (chi_m Q_near M_m)^j"
+            )
+            if config.preconditioner != "none" else "identity"
+        ),
+        "representation": (
+            "fixed-k-table-lagrange-list1"
+            if config.preconditioner == "source-frozen"
+            else "fixed-k-table-list1"
+            if config.preconditioner == "constant"
+            else "none"
+        ),
+        "damping": config.preconditioner_damping,
+        "ordering": config.preconditioner_ordering,
+        "degree": config.preconditioner_degree,
+        "palette_wave_numbers": [],
+        "active_target_boxes": 0,
+        "setup_seconds": 0.0,
+    }
+    if config.preconditioner != "none":
+        preconditioner_setup_start = time.perf_counter()
+        active_host = contrast_host != 0.0
+        active_mask = cla.to_device(
+            queue,
+            np.ascontiguousarray(active_host.astype(np.float64)),
+        )
+
+        if config.preconditioner == "constant":
+            palette_wave_numbers = np.array([config.wave_number])
+            interpolation_weights_host = np.ones((1, x.size))
+        else:
+            local_wave_number = config.wave_number * refractive_index
+            active_wave_numbers = local_wave_number[active_host]
+            palette_wave_numbers = _chebyshev_lobatto_nodes(
+                float(np.min(active_wave_numbers)),
+                float(np.max(active_wave_numbers)),
+                config.preconditioner_palette_size,
+            )
+            interpolation_weights_host = _lagrange_interpolation_weights(
+                local_wave_number,
+                palette_wave_numbers,
+            )
+
+        local_tree_independent = FPNDTreeIndependentDataForWrangler(
+            context,
+            partial(multipole_expansion_class, kernel),
+            partial(local_expansion_class, kernel),
+            [kernel],
+            exclude_self=True,
+        )
+        local_wranglers = []
+        for local_k in palette_wave_numbers:
+            if np.isclose(local_k, config.wave_number, rtol=0.0, atol=1.0e-14):
+                local_table = table
+            else:
+                local_table = _get_near_field_table(
+                    queue,
+                    output_dir / "near_field_table.sqlite",
+                    config,
+                    wave_number=float(local_k),
+                )
+            local_wranglers.append(
+                FPNDExpansionWrangler(
+                    tree_indep=local_tree_independent,
+                    queue=queue,
+                    traversal=traversal,
+                    near_field_table=local_table,
+                    dtype=np.complex128,
+                    fmm_level_to_order=(
+                        lambda kernel, kernel_args, tree, level: _fmm_level_order(
+                            config, tree, level
+                        )
+                    ),
+                    quad_order=config.q_order,
+                    kernel_extra_kwargs={
+                        kernel.helmholtz_k_name: float(local_k),
+                    },
+                    self_extra_kwargs=self_extra_kwargs,
+                    helmholtz_split=False,
+                )
+            )
+
+        ordered_active = local_wranglers[0].reorder_sources(active_mask)
+        if isinstance(ordered_active, cla.Array):
+            ordered_active_host = ordered_active.get(queue)
+        else:
+            ordered_active_host = np.asarray(ordered_active)
+
+        tree = traversal.tree
+        target_boxes_host = traversal.target_boxes.get(queue)
+        neighbor_starts_host = traversal.neighbor_source_boxes_starts.get(queue)
+        neighbor_lists_host = traversal.neighbor_source_boxes_lists.get(queue)
+        box_target_starts = tree.box_target_starts.get(queue)
+        box_target_counts = tree.box_target_counts_nonchild.get(queue)
+        active_box_flags = np.zeros(tree.box_centers.shape[1], dtype=bool)
+        for target_box in target_boxes_host:
+            start = int(box_target_starts[target_box])
+            stop = start + int(box_target_counts[target_box])
+            active_box_flags[target_box] = np.any(
+                ordered_active_host[start:stop] != 0.0
+            )
+
+        (
+            restricted_target_boxes,
+            restricted_neighbor_starts,
+            restricted_neighbor_lists,
+        ) = _restrict_neighbor_csr(
+            target_boxes_host,
+            neighbor_starts_host,
+            neighbor_lists_host,
+            active_box_flags,
+        )
+        restricted_target_boxes = cla.to_device(
+            queue,
+            np.ascontiguousarray(restricted_target_boxes),
+        )
+        restricted_neighbor_starts = cla.to_device(
+            queue,
+            np.ascontiguousarray(restricted_neighbor_starts),
+        )
+        restricted_neighbor_lists = cla.to_device(
+            queue,
+            np.ascontiguousarray(restricted_neighbor_lists),
+        )
+
+        near_potentials = [
+            _NearFieldPotential(
+                queue,
+                local_wrangler,
+                restricted_target_boxes,
+                restricted_neighbor_starts,
+                restricted_neighbor_lists,
+            )
+            for local_wrangler in local_wranglers
+        ]
+        interpolation_weights = [
+            cla.to_device(queue, np.ascontiguousarray(weight))
+            for weight in interpolation_weights_host
+        ]
+        preconditioner = _List1PolynomialPreconditioner(
+            queue,
+            contrast,
+            active_mask,
+            near_potentials,
+            interpolation_weights,
+            config.preconditioner_damping,
+            config.preconditioner_ordering,
+            config.preconditioner_degree,
+        )
+        queue.finish()
+        preconditioner_metadata.update({
+            "palette_wave_numbers": [
+                float(local_k) for local_k in palette_wave_numbers
+            ],
+            "active_target_boxes": int(restricted_target_boxes.size),
+            "setup_seconds": float(
+                time.perf_counter() - preconditioner_setup_start
+            ),
+        })
+
+    right_hand_side = contrast * incident
+    rhs_norm = _device_norm(queue, right_hand_side)
+    if not rhs_norm > 0.0:
+        raise RuntimeError("The Lippmann--Schwinger right-hand side is zero")
+
+    solve_start = time.perf_counter()
+    solve_operator = operator
+    if preconditioner is not None:
+        solve_operator = _RightPreconditionedOperator(operator, preconditioner)
+    result = gmres(
+        solve_operator,
+        right_hand_side,
+        restart=config.gmres_restart,
+        tol=config.gmres_tolerance,
+        maxiter=config.gmres_maxiter,
+        hard_failure=False,
+        stall_iterations=0,
+        require_monotonicity=False,
+        inner_product=lambda a, b: cla.vdot(a, b, queue=queue).get(queue).item(),
+    )
+    queue.finish()
+    solve_seconds = time.perf_counter() - solve_start
+
+    if preconditioner is None:
+        sigma = result.solution
+    else:
+        sigma = solve_operator.recover(result.solution)
+    true_residual = operator(sigma) - right_hand_side
+    relative_true_residual = _device_norm(queue, true_residual) / rhs_norm
+    scattered = operator.volume_potential(sigma)
+    total = incident + scattered
+
+    sigma_host = sigma.get(queue)
+    scattered_host = scattered.get(queue)
+    total_host = total.get(queue)
+    intensity = np.abs(total_host) ** 2
+    incident_intensity = np.mean(np.abs(incident_host) ** 2)
+    intensity /= incident_intensity
+
+    transition = (window > 0.0) & (window < 1.0)
+    active = window > 0.0
+    core = (
+        (x >= config.core_x_min)
+        & (x <= config.core_x_max)
+        & (y >= config.core_y_min)
+        & (y <= config.core_y_max)
+    )
+    core_weight_sum = np.sum(weights_host[core])
+    core_perturbation_mean = float(
+        np.sum(weights_host[core] * delta_n[core]) / core_weight_sum
+    )
+    core_perturbation_rms = float(
+        np.sqrt(
+            np.sum(weights_host[core] * delta_n[core] ** 2)
+            / core_weight_sum
+        )
+    )
+    residual_norms = [float(value) / rhs_norm for value in result.residual_norms]
+    arrays = {
+        "x": x,
+        "y": y,
+        "quadrature_weights": weights_host,
+        "window": window,
+        "refractive_index": refractive_index,
+        "contrast": contrast_host,
+        "incident_field": incident_host,
+        "density": sigma_host,
+        "scattered_field": scattered_host,
+        "total_field": total_host,
+        "intensity": intensity,
+    }
+    metadata = {
+        "config": asdict(config),
+        "equation": "sigma - m V_k[sigma] = m u_inc",
+        "kernel": "outgoing 2D Helmholtz i/4 H_0^(1)(k r)",
+        "boundary_treatment": "none; free-space outgoing Green function",
+        "support": {
+            "core": [
+                config.core_x_min,
+                config.core_x_max,
+                config.core_y_min,
+                config.core_y_max,
+            ],
+            "outer": [
+                config.core_x_min - config.transition_width,
+                config.core_x_max + config.transition_width,
+                config.core_y_min - config.transition_width,
+                config.core_y_max + config.transition_width,
+            ],
+            "transition_width": config.transition_width,
+            "window": "C-infinity tensor-product box ramp",
+        },
+        "discretization": {
+            "points": int(x.size),
+            "active_points": int(np.count_nonzero(active)),
+            "transition_points": int(np.count_nonzero(transition)),
+            "leaf_side_length": (
+                2.0 * config.root_half_extent / 2 ** (config.nlevels - 1)
+            ),
+            "local_kh": (
+                config.wave_number
+                * 2.0
+                * config.root_half_extent
+                / 2 ** (config.nlevels - 1)
+            ),
+            "nominal_points_per_wavelength": (
+                2.0
+                * np.pi
+                * config.q_order
+                * 2 ** (config.nlevels - 1)
+                / (config.wave_number * 2.0 * config.root_half_extent)
+            ),
+            "fmm_level_orders": [
+                _fmm_level_order(config, tree, level)
+                for level in range(tree.nlevels)
+            ],
+        },
+        "medium": {
+            "generator": config.medium_generator,
+            "realization": config.medium_realization,
+            "refractive_index_sha256": hashlib.sha256(
+                np.ascontiguousarray(refractive_index).view(np.uint8)
+            ).hexdigest(),
+            "minimum_refractive_index": float(np.min(refractive_index)),
+            "maximum_refractive_index": float(np.max(refractive_index)),
+            "core_refractive_perturbation_mean": core_perturbation_mean,
+            "core_refractive_perturbation_rms": core_perturbation_rms,
+            "filtered_grid": (
+                {
+                    "grid_spacing": (
+                        config.correlation_length
+                        / config.medium_grid_points_per_correlation
+                    ),
+                    "filter_sigma_grid_points": (
+                        config.medium_grid_points_per_correlation
+                    ),
+                    "filter_radius_grid_points": int(np.ceil(
+                        config.medium_filter_truncate
+                        * config.medium_grid_points_per_correlation
+                    )),
+                    "covariance_model": (
+                        "approximately exp(-r^2/(4*correlation_length^2))"
+                    ),
+                }
+                if config.medium_generator == "filtered-grid" else None
+            ),
+            "core_length_wavelengths": float(
+                (config.core_x_max - config.core_x_min)
+                * config.wave_number
+                / (2.0 * np.pi)
+            ),
+            "correlation_length_wavelengths": float(
+                config.correlation_length * config.wave_number / (2.0 * np.pi)
+            ),
+            "transition_width_wavelengths": float(
+                config.transition_width * config.wave_number / (2.0 * np.pi)
+            ),
+            "maximum_window_outside_outer_box": float(np.max(window[~active]))
+                if np.any(~active) else 0.0,
+        },
+        "gmres": {
+            "success": bool(result.success),
+            "state": result.state,
+            "iteration_count": int(result.iteration_count),
+            "reported_residual_norms": residual_norms,
+            "relative_true_residual": float(relative_true_residual),
+        },
+        "timing": {
+            "solve_seconds": float(solve_seconds),
+            "volume_applications": int(operator.application_count),
+            "volume_application_seconds": float(operator.application_seconds),
+        },
+        "preconditioner": {
+            **preconditioner_metadata,
+            "application_count": (
+                int(preconditioner.application_count)
+                if preconditioner is not None else 0
+            ),
+            "local_potential_application_count": (
+                int(
+                    preconditioner.application_count
+                    * config.preconditioner_degree
+                    * len(preconditioner.near_potentials)
+                )
+                if preconditioner is not None else 0
+            ),
+            "application_seconds": (
+                float(preconditioner.application_seconds)
+                if preconditioner is not None else 0.0
+            ),
+        },
+    }
+
+    _write_outputs(output_dir, config, arrays, metadata, residual_norms)
+    _write_plot(output_dir, arrays)
+
+    if config.smoke:
+        if not result.success:
+            raise RuntimeError(f"Branched-flow smoke GMRES failed: {result.state}")
+        if relative_true_residual > 5.0e-5:
+            raise RuntimeError(
+                "Branched-flow smoke true residual exceeded tolerance band: "
+                f"{relative_true_residual:.3e}"
+            )
+        outer = (
+            (x <= config.core_x_min - config.transition_width)
+            | (x >= config.core_x_max + config.transition_width)
+            | (y <= config.core_y_min - config.transition_width)
+            | (y >= config.core_y_max + config.transition_width)
+        )
+        if np.max(np.abs(contrast_host[outer])) != 0.0:
+            raise RuntimeError("Compact-support smoke check failed")
+
+    return metadata
+
+
+def _parse_arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("build/branched-flow-helmholtz2d"),
+    )
+    parser.add_argument("--q-order", type=int)
+    parser.add_argument("--nlevels", type=int)
+    parser.add_argument("--fmm-order", type=int)
+    parser.add_argument("--fmm-order-mode", choices=("fixed", "helmholtz"))
+    parser.add_argument("--fmm-order-padding", type=int)
+    parser.add_argument("--fmm-backend", choices=("sumpy", "fmmlib"))
+    parser.add_argument("--wave-number", type=float)
+    parser.add_argument("--root-half-extent", type=float)
+    parser.add_argument("--core-x-min", type=float)
+    parser.add_argument("--core-x-max", type=float)
+    parser.add_argument("--core-y-min", type=float)
+    parser.add_argument("--core-y-max", type=float)
+    parser.add_argument("--transition-width", type=float)
+    parser.add_argument("--refractive-rms", type=float)
+    parser.add_argument("--correlation-length", type=float)
+    parser.add_argument("--random-seed", type=int)
+    parser.add_argument("--gaussian-bumps", type=int)
+    parser.add_argument(
+        "--medium-generator",
+        choices=("gaussian-bumps", "filtered-grid"),
+    )
+    parser.add_argument("--medium-grid-points-per-correlation", type=int)
+    parser.add_argument("--medium-filter-truncate", type=float)
+    parser.add_argument(
+        "--medium-realization",
+        choices=("local", "nested"),
+    )
+    parser.add_argument("--medium-reference-half-extent", type=float)
+    parser.add_argument("--medium-normalization-samples", type=int)
+    parser.add_argument("--gmres-tolerance", type=float)
+    parser.add_argument("--gmres-restart", type=int)
+    parser.add_argument("--gmres-maxiter", type=int)
+    parser.add_argument(
+        "--preconditioner",
+        choices=("none", "constant", "source-frozen"),
+    )
+    parser.add_argument("--preconditioner-palette-size", type=int)
+    parser.add_argument("--preconditioner-damping", type=float)
+    parser.add_argument(
+        "--preconditioner-ordering",
+        choices=("source", "target"),
+    )
+    parser.add_argument("--preconditioner-degree", type=int)
+    return parser.parse_args()
+
+
+def _config_from_arguments(arguments):
+    config = _default_config(arguments.smoke)
+    overrides = {
+        "q_order": arguments.q_order,
+        "nlevels": arguments.nlevels,
+        "fmm_order": arguments.fmm_order,
+        "fmm_order_mode": arguments.fmm_order_mode,
+        "fmm_order_padding": arguments.fmm_order_padding,
+        "fmm_backend": arguments.fmm_backend,
+        "wave_number": arguments.wave_number,
+        "root_half_extent": arguments.root_half_extent,
+        "core_x_min": arguments.core_x_min,
+        "core_x_max": arguments.core_x_max,
+        "core_y_min": arguments.core_y_min,
+        "core_y_max": arguments.core_y_max,
+        "transition_width": arguments.transition_width,
+        "refractive_rms": arguments.refractive_rms,
+        "correlation_length": arguments.correlation_length,
+        "random_seed": arguments.random_seed,
+        "gaussian_bumps": arguments.gaussian_bumps,
+        "medium_generator": arguments.medium_generator,
+        "medium_grid_points_per_correlation": (
+            arguments.medium_grid_points_per_correlation
+        ),
+        "medium_filter_truncate": arguments.medium_filter_truncate,
+        "medium_realization": arguments.medium_realization,
+        "medium_reference_half_extent": arguments.medium_reference_half_extent,
+        "medium_normalization_samples": arguments.medium_normalization_samples,
+        "gmres_tolerance": arguments.gmres_tolerance,
+        "gmres_restart": arguments.gmres_restart,
+        "gmres_maxiter": arguments.gmres_maxiter,
+        "preconditioner": arguments.preconditioner,
+        "preconditioner_palette_size": arguments.preconditioner_palette_size,
+        "preconditioner_damping": arguments.preconditioner_damping,
+        "preconditioner_ordering": arguments.preconditioner_ordering,
+        "preconditioner_degree": arguments.preconditioner_degree,
+    }
+    values = asdict(config)
+    values.update(
+        {key: value for key, value in overrides.items() if value is not None}
+    )
+    return RunConfig(**values)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    arguments = _parse_arguments()
+    config = _config_from_arguments(arguments)
+    metadata = run(config, arguments.output_dir)
+    print(json.dumps({
+        "output_dir": str(arguments.output_dir),
+        "points": metadata["discretization"]["points"],
+        "local_kh": metadata["discretization"]["local_kh"],
+        "gmres_iterations": metadata["gmres"]["iteration_count"],
+        "relative_true_residual": metadata["gmres"]["relative_true_residual"],
+        "solve_seconds": metadata["timing"]["solve_seconds"],
+        "preconditioner": metadata["preconditioner"],
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+fmmlib = ["pyfmmlib>=2024.1"]
 gmsh_support = ["gmsh_interop"]
 test = ["filelock", "gmsh_interop", "pytest"]
 doc = ["sphinx", "sphinx_rtd_theme"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,7 +36,7 @@ from volumential.table_manager import NearFieldInteractionTableManager as NFTMan
 
 
 XFAIL_OPENCL_PLATFORMS = {
-    # Intel OpenCL CPU backend on ipa has been observed to core-dump on
+    # This Intel OpenCL CPU backend has been observed to core-dump on
     # volumential nearfield/FMM test paths; keep this visible as an xfail
     # until upstream/backend stability is confirmed.
     "Intel(R) OpenCL": "known Intel OpenCL backend crash (core dump) on volumential nearfield path",

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -1,0 +1,72 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_benchmark(name):
+    path = _REPOSITORY_ROOT / "benchmarks" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _accuracy_row(*, q_order, fmm_order, error):
+    return {
+        "path": "canonical_rescaled",
+        "q_order": q_order,
+        "n_levels": 2,
+        "fmm_order": fmm_order,
+        "regular_quad_order": fmm_order,
+        "radial_quad_order": 2 * fmm_order + 1,
+        "h_max": 0.25,
+        "weighted_rel_l2_vs_exact": error,
+        "h_observed_order_vs_exact": "",
+        "q_error_ratio_vs_previous": "",
+        "q_log_error_slope_vs_exact": "",
+    }
+
+
+def test_q_convergence_rates_require_fixed_solver_orders():
+    module = _load_benchmark("accuracy_preservation")
+    changed_order = _accuracy_row(q_order=2, fmm_order=8, error=0.5)
+    fixed_order_coarse = _accuracy_row(q_order=3, fmm_order=10, error=0.25)
+    fixed_order_fine = _accuracy_row(q_order=4, fmm_order=10, error=0.125)
+    rows = [changed_order, fixed_order_coarse, fixed_order_fine]
+
+    module._add_convergence_rates(rows)
+
+    assert fixed_order_coarse["q_error_ratio_vs_previous"] == ""
+    assert fixed_order_fine["q_error_ratio_vs_previous"] == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize(("repeat_count", "direct_levels", "message"), [
+    (0, [2], "repeat_count"),
+    (1, [0, 1], "direct_levels"),
+])
+def test_split_benchmark_validates_direct_call_invariants(
+    tmp_path, repeat_count, direct_levels, message
+):
+    module = _load_benchmark("split_parameter_sweep")
+
+    with pytest.raises(ValueError, match=message):
+        module.run_benchmark(
+            mode="smoke",
+            backend="cpu",
+            cache_dir=tmp_path,
+            q_order=2,
+            nlevels=2,
+            fmm_order=8,
+            split_orders=[1],
+            helmholtz_k=[4.0],
+            yukawa_lam=[],
+            direct_levels=direct_levels,
+            repeat_count=repeat_count,
+        )

--- a/test/test_branched_flow_example.py
+++ b/test/test_branched_flow_example.py
@@ -1,0 +1,352 @@
+import importlib.util
+from dataclasses import replace
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+_EXAMPLE_PATH = (
+    Path(__file__).resolve().parents[1] / "examples" / "branched_flow_helmholtz2d.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "branched_flow_helmholtz2d", _EXAMPLE_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_EXAMPLE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _EXAMPLE
+_SPEC.loader.exec_module(_EXAMPLE)
+
+_axis_window = _EXAMPLE._axis_window
+_apply_fixed_polynomial = _EXAMPLE._apply_fixed_polynomial
+_box_window = _EXAMPLE._box_window
+_chebyshev_lobatto_nodes = _EXAMPLE._chebyshev_lobatto_nodes
+_default_config = _EXAMPLE._default_config
+_fmm_level_order = _EXAMPLE._fmm_level_order
+_lagrange_interpolation_weights = _EXAMPLE._lagrange_interpolation_weights
+_random_refractive_perturbation = _EXAMPLE._random_refractive_perturbation
+_restrict_neighbor_csr = _EXAMPLE._restrict_neighbor_csr
+_RightPreconditionedOperator = _EXAMPLE._RightPreconditionedOperator
+_validate_config = _EXAMPLE._validate_config
+
+
+def test_smooth_box_window_has_exact_compact_support():
+    config = _default_config(smoke=True)
+    axis = np.linspace(-config.root_half_extent, config.root_half_extent, 257)
+    x, y = np.meshgrid(axis, axis)
+    x = x.ravel()
+    y = y.ravel()
+
+    window = _box_window(x, y, config)
+    outer = (
+        (x <= config.core_x_min - config.transition_width)
+        | (x >= config.core_x_max + config.transition_width)
+        | (y <= config.core_y_min - config.transition_width)
+        | (y >= config.core_y_max + config.transition_width)
+    )
+    core = (
+        (x >= config.core_x_min)
+        & (x <= config.core_x_max)
+        & (y >= config.core_y_min)
+        & (y <= config.core_y_max)
+    )
+
+    assert np.all(window[outer] == 0.0)
+    assert np.all(window[core] == 1.0)
+    assert np.all((window >= 0.0) & (window <= 1.0))
+
+
+def test_axis_window_is_monotone_through_each_transition():
+    config = _default_config(smoke=True)
+    left_axis = np.linspace(
+        config.core_x_min - config.transition_width,
+        config.core_x_min,
+        101,
+    )
+    right_axis = np.linspace(
+        config.core_x_max,
+        config.core_x_max + config.transition_width,
+        101,
+    )
+
+    left = _axis_window(
+        left_axis,
+        config.core_x_min,
+        config.core_x_max,
+        config.transition_width,
+    )
+    right = _axis_window(
+        right_axis,
+        config.core_x_min,
+        config.core_x_max,
+        config.transition_width,
+    )
+
+    assert left[0] == 0.0
+    assert left[-1] == 1.0
+    assert np.all(np.diff(left) >= 0.0)
+    assert right[0] == 1.0
+    assert right[-1] == 0.0
+    assert np.all(np.diff(right) <= 0.0)
+
+
+def test_random_medium_has_requested_core_rms_and_compact_support():
+    config = _default_config(smoke=True)
+    axis = np.linspace(-config.root_half_extent, config.root_half_extent, 129)
+    x, y = np.meshgrid(axis, axis)
+    x = x.ravel()
+    y = y.ravel()
+    weights = np.ones_like(x)
+    window = _box_window(x, y, config)
+
+    perturbation = _random_refractive_perturbation(
+        x,
+        y,
+        weights,
+        window,
+        config,
+    )
+    core = (
+        (x >= config.core_x_min)
+        & (x <= config.core_x_max)
+        & (y >= config.core_y_min)
+        & (y <= config.core_y_max)
+    )
+    outer = window == 0.0
+
+    np.testing.assert_allclose(
+        np.sqrt(np.mean(perturbation[core] ** 2)),
+        config.refractive_rms,
+        rtol=1.0e-13,
+    )
+    assert np.all(perturbation[outer] == 0.0)
+
+
+def test_nested_medium_matches_on_overlapping_core_points():
+    base = replace(
+        _default_config(smoke=True),
+        medium_realization="nested",
+        medium_normalization_samples=1024,
+    )
+    larger = replace(
+        base,
+        core_x_min=-1.2,
+        core_x_max=0.8,
+        core_y_min=-0.9,
+        core_y_max=0.9,
+    )
+    axis = np.linspace(-0.15, 0.15, 17)
+    x, y = np.meshgrid(axis, axis)
+    x = x.ravel()
+    y = y.ravel()
+    weights = np.ones_like(x)
+
+    base_values = _random_refractive_perturbation(
+        x,
+        y,
+        weights,
+        _box_window(x, y, base),
+        base,
+    )
+    larger_values = _random_refractive_perturbation(
+        x,
+        y,
+        weights,
+        _box_window(x, y, larger),
+        larger,
+    )
+
+    np.testing.assert_array_equal(base_values, larger_values)
+
+
+def test_filtered_grid_medium_is_reproducible_and_order_independent():
+    config = replace(
+        _default_config(smoke=True),
+        medium_generator="filtered-grid",
+    )
+    axis = np.linspace(-config.root_half_extent, config.root_half_extent, 65)
+    x, y = np.meshgrid(axis, axis)
+    x = x.ravel()
+    y = y.ravel()
+    weights = np.linspace(0.5, 1.5, x.size)
+    window = _box_window(x, y, config)
+    values = _random_refractive_perturbation(
+        x, y, weights, window, config
+    )
+    repeated = _random_refractive_perturbation(
+        x, y, weights, window, config
+    )
+
+    np.testing.assert_array_equal(values, repeated)
+    core = (
+        (x >= config.core_x_min)
+        & (x <= config.core_x_max)
+        & (y >= config.core_y_min)
+        & (y <= config.core_y_max)
+    )
+    core_weight_sum = np.sum(weights[core])
+    weighted_mean = np.sum(weights[core] * values[core]) / core_weight_sum
+    weighted_rms = np.sqrt(
+        np.sum(weights[core] * values[core] ** 2) / core_weight_sum
+    )
+    assert abs(weighted_mean) < 1.0e-14
+    np.testing.assert_allclose(weighted_rms, config.refractive_rms, rtol=1.0e-14)
+    assert np.all(values[window == 0.0] == 0.0)
+
+    permutation = np.random.default_rng(9).permutation(x.size)
+    permuted = _random_refractive_perturbation(
+        x[permutation],
+        y[permutation],
+        weights[permutation],
+        window[permutation],
+        config,
+    )
+    np.testing.assert_allclose(
+        permuted,
+        values[permutation],
+        rtol=5.0e-14,
+        atol=1.0e-17,
+    )
+    changed_seed = _random_refractive_perturbation(
+        x,
+        y,
+        weights,
+        window,
+        replace(config, random_seed=config.random_seed + 1),
+    )
+    assert not np.array_equal(values, changed_seed)
+
+
+def test_publication_default_resolves_declared_local_parameter():
+    config = _default_config(smoke=False)
+    _validate_config(config)
+    leaf_side_length = (
+        2.0 * config.root_half_extent / 2 ** (config.nlevels - 1)
+    )
+    assert config.wave_number * leaf_side_length == 0.75
+    assert config.fmm_backend == "fmmlib"
+    assert config.fmm_order == 40
+    assert config.fmm_order_mode == "helmholtz"
+    assert config.fmm_order_padding == 20
+    assert config.refractive_rms == 0.05
+    assert config.gaussian_bumps == 2048
+    assert config.medium_generator == "gaussian-bumps"
+    assert config.preconditioner == "none"
+    assert config.preconditioner_ordering == "target"
+    assert config.preconditioner_degree == 1
+    domain_width_wavelengths = (
+        config.wave_number * 2.0 * config.root_half_extent / (2.0 * np.pi)
+    )
+    core_length_wavelengths = (
+        config.wave_number * (config.core_x_max - config.core_x_min) / (2.0 * np.pi)
+    )
+    assert domain_width_wavelengths > 30.0
+    assert core_length_wavelengths > 17.0
+
+
+def test_helmholtz_fmm_order_increases_on_coarse_levels():
+    config = _default_config(smoke=False)
+    calibration_tree = type("Tree", (), {"root_extent": 8.0})()
+    calibration_orders = [
+        _fmm_level_order(config, calibration_tree, level) for level in range(8)
+    ]
+
+    assert calibration_orders == [88, 54, 40, 40, 40, 40, 40, 40]
+
+    default_tree = type("Tree", (), {"root_extent": 16.0})()
+    default_orders = [
+        _fmm_level_order(config, default_tree, level) for level in range(9)
+    ]
+    assert default_orders == [156, 88, 54, 40, 40, 40, 40, 40, 40]
+
+
+def test_source_frozen_palette_interpolates_quadratics_exactly():
+    nodes = _chebyshev_lobatto_nodes(8.0, 12.0, 3)
+    values = np.linspace(8.0, 12.0, 17)
+    weights = _lagrange_interpolation_weights(values, nodes)
+
+    np.testing.assert_allclose(np.sum(weights, axis=0), 1.0, atol=1.0e-15)
+    np.testing.assert_allclose(
+        np.sum(weights * nodes[:, np.newaxis] ** 2, axis=0),
+        values**2,
+        atol=5.0e-14,
+    )
+
+
+def test_neighbor_csr_restriction_preserves_selected_rows():
+    targets = np.array([4, 7, 9], dtype=np.int32)
+    starts = np.array([0, 2, 5, 6], dtype=np.int32)
+    lists = np.array([1, 4, 2, 7, 8, 9], dtype=np.int32)
+    active = np.zeros(10, dtype=bool)
+    active[[4, 9]] = True
+
+    restricted_targets, restricted_starts, restricted_lists = (
+        _restrict_neighbor_csr(targets, starts, lists, active)
+    )
+
+    np.testing.assert_array_equal(restricted_targets, [4, 9])
+    np.testing.assert_array_equal(restricted_starts, [0, 2, 3])
+    np.testing.assert_array_equal(restricted_lists, [1, 4, 9])
+
+
+def test_right_preconditioned_operator_applies_factors_in_right_order():
+    matrix = np.array([[2.0, 1.0], [0.0, 3.0]])
+    right_factor = np.array([[1.0, -1.0], [0.5, 2.0]])
+
+    class MatrixOperator:
+        shape = (2, 2)
+
+        def __init__(self, array):
+            self.array = array
+
+        def __call__(self, vector):
+            return self.array @ vector
+
+    wrapped = _RightPreconditionedOperator(
+        MatrixOperator(matrix),
+        MatrixOperator(right_factor),
+    )
+    vector = np.array([0.25, -2.0])
+
+    np.testing.assert_allclose(wrapped(vector), matrix @ right_factor @ vector)
+    np.testing.assert_allclose(wrapped.recover(vector), right_factor @ vector)
+
+
+def test_fixed_polynomial_matches_matrix_powers():
+    matrix = np.array([[0.2, -0.1], [0.3, 0.15]])
+    vector = np.array([1.5, -0.25])
+    degree = 3
+    damping = 0.7
+
+    actual = _apply_fixed_polynomial(
+        lambda operand: matrix @ operand,
+        vector,
+        degree,
+        damping,
+    )
+    expected = vector.copy()
+    power_action = vector.copy()
+    for _ in range(degree):
+        power_action = matrix @ power_action
+        expected += damping * power_action
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_preconditioner_configuration_validation():
+    config = _default_config(smoke=False)
+    _validate_config(replace(config, preconditioner="source-frozen"))
+
+    try:
+        _validate_config(replace(config, preconditioner_damping=1.1))
+    except ValueError as exc:
+        assert "damping" in str(exc)
+    else:
+        raise AssertionError("invalid damping was accepted")
+
+    try:
+        _validate_config(replace(config, preconditioner_degree=0))
+    except ValueError as exc:
+        assert "degree" in str(exc)
+    else:
+        raise AssertionError("invalid polynomial degree was accepted")

--- a/test/test_branched_flow_example.py
+++ b/test/test_branched_flow_example.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sys
 
 import numpy as np
+import pytest
 
 
 _EXAMPLE_PATH = (
@@ -24,6 +25,8 @@ _chebyshev_lobatto_nodes = _EXAMPLE._chebyshev_lobatto_nodes
 _default_config = _EXAMPLE._default_config
 _fmm_level_order = _EXAMPLE._fmm_level_order
 _lagrange_interpolation_weights = _EXAMPLE._lagrange_interpolation_weights
+_config_from_arguments = _EXAMPLE._config_from_arguments
+_parse_arguments = _EXAMPLE._parse_arguments
 _random_refractive_perturbation = _EXAMPLE._random_refractive_perturbation
 _restrict_neighbor_csr = _EXAMPLE._restrict_neighbor_csr
 _RightPreconditionedOperator = _EXAMPLE._RightPreconditionedOperator
@@ -350,3 +353,31 @@ def test_preconditioner_configuration_validation():
         assert "degree" in str(exc)
     else:
         raise AssertionError("invalid polynomial degree was accepted")
+
+
+@pytest.mark.parametrize(("changes", "message"), [
+    ({"q_order": 0}, "q_order"),
+    ({"nlevels": 0}, "nlevels"),
+    ({"root_half_extent": 0.0}, "root_half_extent"),
+    ({"wave_number": 0.0}, "wave_number"),
+    ({"core_x_min": 0.25}, "core_x_min"),
+    ({"core_y_min": 0.5}, "core_y_min"),
+    ({"transition_width": 0.0}, "transition_width"),
+    ({"gmres_tolerance": 0.0}, "gmres_tolerance"),
+    ({"gmres_maxiter": 0}, "gmres_maxiter"),
+])
+def test_solver_configuration_validation(changes, message):
+    with pytest.raises(ValueError, match=message):
+        _validate_config(replace(_default_config(smoke=True), **changes))
+
+
+def test_incident_angle_cli_override(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["branched-flow", "--smoke", "--incident-angle-degrees", "17.5"],
+    )
+
+    config = _config_from_arguments(_parse_arguments())
+
+    assert config.incident_angle_degrees == 17.5

--- a/test/test_gaussian.py
+++ b/test/test_gaussian.py
@@ -9,6 +9,7 @@ from volumential.gaussian import (
     GaussianMixture,
     axis_aligned_slice_grid,
     dmk_gaussian_split_sigma,
+    evaluate_gaussian_laplacian_power,
     evaluate_gaussian_mixture,
     gaussian_filter_mixture,
     gaussian_mixture_tail_report,
@@ -43,6 +44,60 @@ def test_evaluate_gaussian_mixture_accepts_point_or_axis_major_points():
     np.testing.assert_allclose(values, axis_major_values)
     np.testing.assert_allclose(values[0], 2.0 + 0.5 * math.exp(-4.0))
     np.testing.assert_allclose(values[1], 2.0 * math.exp(-1.0) + 0.5)
+
+
+def test_evaluate_gaussian_laplacian_power_matches_closed_forms():
+    amplitude = 1.25
+    alpha = 3.0
+    dim = 3
+    mixture = GaussianMixture(
+        "single",
+        (GaussianComponent(amplitude, (0.0, 0.0, 0.0), alpha),),
+    )
+    points = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    radius_sq = np.sum(points**2, axis=1)
+    gaussian = amplitude * np.exp(-alpha * radius_sq)
+
+    np.testing.assert_allclose(
+        evaluate_gaussian_laplacian_power(mixture, points, order=0),
+        gaussian,
+    )
+    np.testing.assert_allclose(
+        evaluate_gaussian_laplacian_power(mixture, points, order=1),
+        gaussian * (-2.0 * alpha * dim + 4.0 * alpha**2 * radius_sq),
+    )
+    np.testing.assert_allclose(
+        evaluate_gaussian_laplacian_power(mixture, points, order=2),
+        gaussian
+        * (
+            4.0 * alpha**2 * dim * (dim + 2.0)
+            - 16.0 * alpha**3 * (dim + 2.0) * radius_sq
+            + 16.0 * alpha**4 * radius_sq**2
+        ),
+    )
+    np.testing.assert_allclose(
+        evaluate_gaussian_laplacian_power(mixture, points, order=3),
+        gaussian
+        * (
+            -8.0 * alpha**3 * dim * (dim + 2.0) * (dim + 4.0)
+            + 48.0 * alpha**4 * (dim + 2.0) * (dim + 4.0) * radius_sq
+            - 96.0 * alpha**5 * (dim + 4.0) * radius_sq**2
+            + 64.0 * alpha**6 * radius_sq**3
+        ),
+    )
+
+
+def test_evaluate_gaussian_laplacian_power_rejects_invalid_order():
+    mixture = GaussianMixture(
+        "single",
+        (GaussianComponent(1.0, (0.0, 0.0, 0.0), 1.0),),
+    )
+
+    with pytest.raises(ValueError, match="non-negative"):
+        evaluate_gaussian_laplacian_power(mixture, np.zeros((1, 3)), order=-1)
+
+    with pytest.raises(ValueError, match="0, 1, 2, or 3"):
+        evaluate_gaussian_laplacian_power(mixture, np.zeros((1, 3)), order=4)
 
 
 def test_laplace3d_gaussian_potential_matches_center_limit_and_kernel_scale():

--- a/test/test_volume_fmm.py
+++ b/test/test_volume_fmm.py
@@ -7011,6 +7011,25 @@ def test_volume_fmm_list1_multi_source_superposition():
     assert np.allclose(result, np.array([66.0]))
 
 
+def test_volume_fmm_rejects_mismatched_source_field_counts():
+    from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
+    from volumential.volume_fmm import drive_volume_fmm
+
+    class _MockWrangler(ExpansionWranglerInterface):
+        dtype = np.float64
+
+    traversal = SimpleNamespace(
+        tree=SimpleNamespace(nsources=3, ntargets=3),
+    )
+    src0 = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    src1 = np.array([10.0, 20.0, 30.0], dtype=np.float64)
+    src_weights = np.empty(2, dtype=object)
+    src_weights[:] = [src0, src1]
+
+    with pytest.raises(ValueError, match="same field count"):
+        drive_volume_fmm(traversal, _MockWrangler(), src_weights, src0)
+
+
 def test_volume_fmm_reorders_src_func_with_source_permutation():
     from volumential.expansion_wrangler_interface import ExpansionWranglerInterface
     from volumential.volume_fmm import drive_volume_fmm

--- a/uv.lock
+++ b/uv.lock
@@ -560,6 +560,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pyfmmlib"
+version = "2024.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/fa/12a8175f2235a3ec0f3f71fd2ec152b5b098cd5def8ced64e7b6fea033ad/pyfmmlib-2024.1.1.tar.gz", hash = "sha256:1c48575c133499b6ec0130d866694bccbda52c842f2fb9f9277b1ccfc19323ac", size = 6098646, upload-time = "2024-02-26T22:00:05.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/7b/692717d7c99ff71a261fce476fa17c3a218234ab0babade50a9d5cd6f107/pyfmmlib-2024.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:945320beb4fb5de12a3deb9d3d1fec10b7363e516903511b8594dad07849fac3", size = 1646329, upload-time = "2024-02-26T21:59:46.952Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/8f20240a5f28c8632e617c24df524d5847ca8afd5594de342d884e45f351/pyfmmlib-2024.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fa7b91880f6cf3b32498c3e4d55e0578a0fa8d6e0f6d032a2c514dc0e52563d", size = 1711910, upload-time = "2024-02-26T21:59:49.293Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3e/86cc9b7fd4a0f8dda371715c28636cddb9b3205b829e8c6b7a586a97b25d/pyfmmlib-2024.1.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:a9187b99c53f96263388eb9ff8952cd0b4a880ac90b1e6bb180fb64ca64096e8", size = 1432469, upload-time = "2024-02-26T21:59:51.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4d/73fb6c27fceebea67971e23209a3988898ab17a0f063d9af73fb3893ca35/pyfmmlib-2024.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0e5942ee78ee7dba236a0b24f5d7b18d4ea105efef5992c18117e75455fa2228", size = 1401218, upload-time = "2024-02-26T21:59:52.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/89/0ed89c3e10ebb6ca853c62cdc54b1831dfab8f987c54c16da619d58e828f/pyfmmlib-2024.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc17efff6f2285e077c607fd72843812efcc5838ed8c6fef71c16cb7b2a3eaec", size = 1613101, upload-time = "2024-02-26T21:59:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b0/7fca8e3dda86d71a6926b18cdb2260b99d80f1ca6dcfbfea788af53ffaea/pyfmmlib-2024.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48c6fffa08dde37356de792a02465eb63171a42bed4ea8c0f7ca7a1b7a891e3a", size = 1693321, upload-time = "2024-02-26T21:59:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/80/06/bc8ef403c5036e5d6c10162b232ceefaf618d3dacbd36bdc3141dab0420c/pyfmmlib-2024.1.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:a62ff83467dd4938ee4bd850c2126d398aec491cc94b2bab0a0e7933b4873825", size = 1399863, upload-time = "2024-02-26T21:59:59.251Z" },
+    { url = "https://files.pythonhosted.org/packages/24/6c/390bd746f94cde7295d9b6ff6443ab330c3cdab40d0bbe152f1a42737295/pyfmmlib-2024.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cd438ce70c2d29db4b8f9ef2e9d623bcb5ec4df9a14cffb331b4ced3efcacb5f", size = 1381740, upload-time = "2024-02-26T22:00:01.709Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -838,23 +857,23 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -869,23 +888,23 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -1053,6 +1072,9 @@ doc = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
 ]
+fmmlib = [
+    { name = "pyfmmlib" },
+]
 gmsh-support = [
     { name = "gmsh-interop" },
 ]
@@ -1072,6 +1094,7 @@ requires-dist = [
     { name = "loopy", git = "https://github.com/inducer/loopy.git" },
     { name = "meshmode", git = "https://github.com/inducer/meshmode.git" },
     { name = "modepy", git = "https://github.com/inducer/modepy.git" },
+    { name = "pyfmmlib", marker = "extra == 'fmmlib'", specifier = ">=2024.1" },
     { name = "pymbolic", git = "https://github.com/inducer/pymbolic.git" },
     { name = "pyopencl" },
     { name = "pytential", git = "https://github.com/inducer/pytential.git" },
@@ -1082,4 +1105,4 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
     { name = "sumpy", git = "https://github.com/inducer/sumpy.git" },
 ]
-provides-extras = ["gmsh-support", "test", "doc"]
+provides-extras = ["fmmlib", "gmsh-support", "test", "doc"]

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -32,7 +32,11 @@ import numpy as np
 
 import pyopencl as cl
 import pyopencl.array
-from boxtree.pyfmmlib_integration import FMMLibExpansionWrangler
+from boxtree.pyfmmlib_integration import (
+    FMMLibExpansionWrangler,
+    FMMLibTreeIndependentDataForWrangler,
+    Kernel as FMMLibKernel,
+)
 from pytools import memoize_method
 from pytools.obj_array import new_1d as obj_array_1d
 from sumpy.array_context import PyOpenCLArrayContext
@@ -5476,6 +5480,7 @@ class FPNDSumpyExpansionWrangler(ExpansionWranglerInterface, SumpyExpansionWrang
 
 class FPNDFMMLibTreeIndependentDataForWrangler(
     TreeIndependentDataForWranglerInterface,
+    FMMLibTreeIndependentDataForWrangler,
 ):
     """Objects of this type serve as a place to keep the code needed
     for ExpansionWrangler if it is using fmmlib to perform multipole
@@ -5502,6 +5507,29 @@ class FPNDFMMLibTreeIndependentDataForWrangler(
 
         self.target_kernels = target_kernels
         self.exclude_self = True
+
+        base_kernels = [kernel.get_base_kernel() for kernel in target_kernels]
+        if not base_kernels:
+            raise ValueError("target_kernels must not be empty")
+        if not all(type(kernel) is type(base_kernels[0]) for kernel in base_kernels):
+            raise ValueError("FMMLib target kernels must share one base kernel type")
+
+        base_kernel = base_kernels[0]
+        if isinstance(base_kernel, LaplaceKernel):
+            fmmlib_kernel = FMMLibKernel.LAPLACE
+        elif isinstance(base_kernel, HelmholtzKernel):
+            fmmlib_kernel = FMMLibKernel.HELMHOLTZ
+        else:
+            raise ValueError("FMMLib supports only Laplace and Helmholtz kernels")
+
+        ifgrad = any(isinstance(kernel, AxisTargetDerivative)
+                     for kernel in target_kernels)
+        FMMLibTreeIndependentDataForWrangler.__init__(
+            self,
+            base_kernel.dim,
+            fmmlib_kernel,
+            ifgrad=ifgrad,
+        )
 
     def get_wrangler(
         self,
@@ -5570,8 +5598,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         self.tree_indep = tree_indep
         self.queue = queue
 
-        tree = tree.get(queue)
-        self.tree = tree
+        self.device_tree = tree
 
         self.dtype = dtype
         self.quad_order = quad_order
@@ -5687,7 +5714,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         ].source_box_extent
         table_starting_level = int(
             np.round(
-                np.log(self.tree.root_extent / self.root_table_source_box_extent)
+                np.log(tree.root_extent / self.root_table_source_box_extent)
                 / np.log(2)
             )
         )
@@ -5716,9 +5743,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 if not isinstance(self.n_tables, dict) and self.n_tables > 1:
                     if (
                         not abs(
-                            int(self.tree.root_extent / table_root_extent)
+                            int(tree.root_extent / table_root_extent)
                             * table_root_extent
-                            - self.tree.root_extent
+                            - tree.root_extent
                         )
                         < 1e-15
                     ):
@@ -5757,6 +5784,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         if list1_extra_kwargs is None:
             list1_extra_kwargs = {}
 
+        self.source_extra_kwargs = source_extra_kwargs
+        self.kernel_extra_kwargs = kernel_extra_kwargs
+        self.self_extra_kwargs = self_extra_kwargs
         self.list1_extra_kwargs = list1_extra_kwargs
         self._table_layout_validation_cache = set()
         self._nearfield_device_payload_cache = OrderedDict()
@@ -5790,27 +5820,31 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                     level,
                 )
 
+        if "traversal" not in kwargs:
+            raise TypeError("FMMLib wrangler requires traversal")
+
+        from boxtree.array_context import (
+            PyOpenCLArrayContext as BoxtreePyOpenCLArrayContext,
+        )
+
+        self._fmmlib_actx = BoxtreePyOpenCLArrayContext(queue)
+        host_traversal = self._fmmlib_actx.to_numpy(kwargs["traversal"])
+
         rotation_data = None
-        if "traversal" in kwargs:
-            # add rotation data if traversal is passed as a keyword argument
+        if tree.dimensions == 3:
             from boxtree.pyfmmlib_integration import FMMLibRotationData
 
-            rotation_data = FMMLibRotationData(self.queue, kwargs["traversal"])
-        else:
-            logger.warning(
-                "Rotation data is not utilized since traversal is "
-                "not known to FPNDFMMLibExpansionWrangler."
-            )
+            rotation_data = FMMLibRotationData(self._fmmlib_actx, host_traversal)
 
         FMMLibExpansionWrangler.__init__(
             self,
-            tree,
+            tree_indep,
+            host_traversal,
             helmholtz_k=helmholtz_k,
             dipole_vec=dipole_vec,
             dipoles_already_reordered=True,
-            fmm_level_to_nterms=inner_fmm_level_to_nterms,
+            fmm_level_to_order=inner_fmm_level_to_nterms,
             rotation_data=rotation_data,
-            ifgrad=ifgrad,
         )
 
     # }}} End constructor
@@ -5818,16 +5852,17 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
     # {{{ scale factor for fmmlib
 
     def get_scale_factor(self):
-        if self.eqn_letter == "l" and self.dim == 2:
+        eqn_letter = self.tree_indep.eqn_letter
+        if eqn_letter == "l" and self.dim == 2:
             scale_factor = -1 / (2 * np.pi)
-        elif self.eqn_letter == "h" and self.dim == 2:
+        elif eqn_letter == "h" and self.dim == 2:
             scale_factor = 1
-        elif self.eqn_letter in ["l", "h"] and self.dim == 3:
+        elif eqn_letter in ["l", "h"] and self.dim == 3:
             scale_factor = 1 / (4 * np.pi)
         else:
             raise NotImplementedError(
                 "scale factor for pyfmmlib %s for %d dimensions"
-                % (self.eqn_letter, self.dim)
+                % (eqn_letter, self.dim)
             )
 
         return scale_factor
@@ -5860,23 +5895,35 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
 
     def finalize_potentials(self, potentials):
         # return potentials
-        return FMMLibExpansionWrangler.finalize_potentials(self, potentials)
+        return FMMLibExpansionWrangler.finalize_potentials(
+            self, self._fmmlib_actx, potentials
+        )
 
     # }}} End data vector utilities
 
     # {{{ formation & coarsening of multipoles
 
     def form_multipoles(self, level_start_source_box_nrs, source_boxes, src_weights):
-        return FMMLibExpansionWrangler.form_multipoles(
-            self, level_start_source_box_nrs, source_boxes, src_weights
+        result = FMMLibExpansionWrangler.form_multipoles(
+            self,
+            self._fmmlib_actx,
+            level_start_source_box_nrs,
+            source_boxes,
+            src_weights,
         )
+        return result, None
 
     def coarsen_multipoles(
         self, level_start_source_parent_box_nrs, source_parent_boxes, mpoles
     ):
-        return FMMLibExpansionWrangler.coarsen_multipoles(
-            self, level_start_source_parent_box_nrs, source_parent_boxes, mpoles
+        result = FMMLibExpansionWrangler.coarsen_multipoles(
+            self,
+            self._fmmlib_actx,
+            level_start_source_parent_box_nrs,
+            source_parent_boxes,
+            mpoles,
         )
+        return result, None
 
     # }}} End formation & coarsening of multipoles
 
@@ -5896,6 +5943,20 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         # do not include quadrature weights (purely function
         # expansiona coefficients)
 
+        tree = self.device_tree
+        output_is_device = isinstance(out_pot, cl.array.Array)
+
+        def to_device(array):
+            if isinstance(array, cl.array.Array):
+                return array
+            return cl.array.to_device(self.queue, np.ascontiguousarray(array))
+
+        out_pot = to_device(out_pot)
+        target_boxes = to_device(target_boxes)
+        neighbor_source_boxes_starts = to_device(neighbor_source_boxes_starts)
+        neighbor_source_boxes_lists = to_device(neighbor_source_boxes_lists)
+        mode_coefs = to_device(mode_coefs)
+
         if 0:
             print("Returns range for list1")
             out_pot[:] = np.arange(len(out_pot))
@@ -5914,9 +5975,9 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             # this checks that the boxes at the coarsest level
             # and allows for some round-off error
             min_lev = np.min(
-                self.tree.box_levels.get(self.queue)[target_boxes.get(self.queue)]
+                tree.box_levels.get(self.queue)[target_boxes.get(self.queue)]
             )
-            largest_cell_extent = self.tree.root_extent * 0.5**min_lev
+            largest_cell_extent = tree.root_extent * 0.5**min_lev
             if not self.near_field_table[kname][0].source_box_extent >= (
                 largest_cell_extent - 1e-15
             ):
@@ -6047,26 +6108,26 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 "table_entry_scales": payload["table_entry_scales_dev"],
             }
         particle_local_ids = _compute_box_local_ids(
-            self.queue, self.tree, self.near_field_table[kname][0].n_q_points
+            self.queue, tree, self.near_field_table[kname][0].n_q_points
         )
 
         _validate_table_box_particle_layout_cached(
             self.queue,
-            self.tree,
+            tree,
             target_boxes,
             neighbor_source_boxes_lists,
             self.near_field_table[kname][0].n_q_points,
             self._table_layout_validation_cache,
         )
 
-        aligned_nboxes = self.tree.box_centers.shape[1]
+        aligned_nboxes = tree.box_centers.shape[1]
         source_counts_nonchild = np.zeros(aligned_nboxes, dtype=np.int32)
         target_counts_nonchild = np.zeros(aligned_nboxes, dtype=np.int32)
-        source_counts_nonchild[: len(self.tree.box_target_counts_nonchild)] = (
-            self.tree.box_target_counts_nonchild.get(self.queue)
+        source_counts_nonchild[: len(tree.box_target_counts_nonchild)] = (
+            tree.box_target_counts_nonchild.get(self.queue)
         )
-        target_counts_nonchild[: len(self.tree.box_target_counts_nonchild)] = (
-            self.tree.box_target_counts_nonchild.get(self.queue)
+        target_counts_nonchild[: len(tree.box_target_counts_nonchild)] = (
+            tree.box_target_counts_nonchild.get(self.queue)
         )
         source_counts_nonchild = cl.array.to_device(self.queue, source_counts_nonchild)
         target_counts_nonchild = cl.array.to_device(self.queue, target_counts_nonchild)
@@ -6074,19 +6135,19 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         res, evt = near_field(
             self.queue,
             result=out_pot,
-            box_centers=self.tree.box_centers,
-            box_levels=self.tree.box_levels,
+            box_centers=tree.box_centers,
+            box_levels=tree.box_levels,
             box_source_counts_nonchild=source_counts_nonchild,
-            box_source_starts=self.tree.box_target_starts,
+            box_source_starts=tree.box_target_starts,
             box_target_counts_nonchild=target_counts_nonchild,
-            box_target_starts=self.tree.box_target_starts,
+            box_target_starts=tree.box_target_starts,
             case_indices=case_indices_dev,
             encoding_base=base,
             encoding_shift=shift,
             mode_nmlz_combined=mode_nmlz_combined,
             exterior_mode_nmlz_combined=exterior_mode_nmlz_combined,
             neighbor_source_boxes_starts=neighbor_source_boxes_starts,
-            root_extent=self.tree.root_extent,
+            root_extent=tree.root_extent,
             neighbor_source_boxes_lists=neighbor_source_boxes_lists,
             mode_coefs=mode_coefs,
             source_mode_ids=particle_local_ids,
@@ -6098,13 +6159,12 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             **reconstruction_kwargs,
         )
 
-        if isinstance(out_pot, cl.array.Array):
+        if output_is_device:
             assert res is out_pot
             # FIXME: lazy evaluation sometimes returns incorrect results
             res.finish()
         else:
-            assert isinstance(out_pot, np.ndarray)
-            out_pot = res
+            out_pot = res.get(self.queue)
 
         # sorted_target_ids=self.tree.user_source_ids,
         # user_source_ids=self.tree.user_source_ids)
@@ -6383,21 +6443,28 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         src_box_lists,
         mpole_exps,
     ):
-        return FMMLibExpansionWrangler.multipole_to_local(
+        result = FMMLibExpansionWrangler.multipole_to_local(
             self,
+            self._fmmlib_actx,
             level_start_target_box_nrs,
             target_boxes,
             src_box_starts,
             src_box_lists,
             mpole_exps,
         )
+        return result, None
 
     def eval_multipoles(
         self, target_boxes_by_source_level, source_boxes_by_level, mpole_exps
     ):
-        return FMMLibExpansionWrangler.eval_multipoles(
-            self, target_boxes_by_source_level, source_boxes_by_level, mpole_exps
+        result = FMMLibExpansionWrangler.eval_multipoles(
+            self,
+            self._fmmlib_actx,
+            target_boxes_by_source_level,
+            source_boxes_by_level,
+            mpole_exps,
         )
+        return result, None
 
     def form_locals(
         self,
@@ -6407,14 +6474,16 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         lists,
         src_weights,
     ):
-        return FMMLibExpansionWrangler.form_locals(
+        result = FMMLibExpansionWrangler.form_locals(
             self,
+            self._fmmlib_actx,
             level_start_target_or_target_parent_box_nrs,
             target_or_target_parent_boxes,
             starts,
             lists,
             src_weights,
         )
+        return result, None
 
     def refine_locals(
         self,
@@ -6422,17 +6491,24 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         target_or_target_parent_boxes,
         local_exps,
     ):
-        return FMMLibExpansionWrangler.refine_locals(
+        result = FMMLibExpansionWrangler.refine_locals(
             self,
+            self._fmmlib_actx,
             level_start_target_or_target_parent_box_nrs,
             target_or_target_parent_boxes,
             local_exps,
         )
+        return result, None
 
     def eval_locals(self, level_start_target_box_nrs, target_boxes, local_exps):
-        return FMMLibExpansionWrangler.eval_locals(
-            self, level_start_target_box_nrs, target_boxes, local_exps
+        result = FMMLibExpansionWrangler.eval_locals(
+            self,
+            self._fmmlib_actx,
+            level_start_target_box_nrs,
+            target_boxes,
+            local_exps,
         )
+        return result, None
 
     # }}} End downward pass of fmm
 
@@ -6441,9 +6517,15 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
     def eval_direct_p2p(
         self, target_boxes, source_box_starts, source_box_lists, src_weights
     ):
-        return FMMLibExpansionWrangler.eval_direct(
-            self, target_boxes, source_box_starts, source_box_lists, src_weights
+        result = FMMLibExpansionWrangler.eval_direct(
+            self,
+            self._fmmlib_actx,
+            target_boxes,
+            source_box_starts,
+            source_box_lists,
+            src_weights,
         )
+        return result, None
 
     # }}} End direct evaluation of p2p interactions
 

--- a/volumential/gaussian.py
+++ b/volumential/gaussian.py
@@ -132,6 +132,65 @@ def evaluate_gaussian_mixture(mixture: GaussianMixture, points: np.ndarray) -> n
     return result
 
 
+def _laplacian_power_polynomial_coefficients(
+    *, alpha: float, dim: int, order: int
+) -> tuple[float, ...]:
+    """Return coefficients for ``Delta**order exp(-alpha*r**2)``."""
+
+    if order == 0:
+        return (1.0,)
+    if order == 1:
+        return (-2.0 * alpha * dim, 4.0 * alpha**2)
+    if order == 2:
+        return (
+            4.0 * alpha**2 * dim * (dim + 2.0),
+            -16.0 * alpha**3 * (dim + 2.0),
+            16.0 * alpha**4,
+        )
+    if order == 3:
+        return (
+            -8.0 * alpha**3 * dim * (dim + 2.0) * (dim + 4.0),
+            48.0 * alpha**4 * (dim + 2.0) * (dim + 4.0),
+            -96.0 * alpha**5 * (dim + 4.0),
+            64.0 * alpha**6,
+        )
+    raise ValueError("order must be 0, 1, 2, or 3")
+
+
+def evaluate_gaussian_laplacian_power(
+    mixture: GaussianMixture,
+    points: np.ndarray,
+    *,
+    order: int,
+) -> np.ndarray:
+    """Evaluate ``Delta**order`` of an isotropic Gaussian mixture.
+
+    Orders through three are provided because the fourth-order DMK residual
+    effective-density correction needs ``Delta rho``, ``Delta**2 rho``, and
+    ``Delta**3 rho`` for a Gaussian source.
+    """
+
+    if not isinstance(order, int):
+        raise TypeError("order must be an integer")
+    if order < 0:
+        raise ValueError("order must be non-negative")
+
+    points = _as_points(points, mixture.dim)
+    result = np.zeros(points.shape[0], dtype=np.float64)
+    for component in mixture.components:
+        center = np.asarray(component.center, dtype=np.float64)
+        radius_sq = np.sum((points - center) ** 2, axis=1)
+        gaussian = component.amplitude * np.exp(-component.alpha * radius_sq)
+        coefficients = _laplacian_power_polynomial_coefficients(
+            alpha=component.alpha, dim=component.dim, order=order
+        )
+        polynomial = np.zeros_like(radius_sq)
+        for coefficient in reversed(coefficients):
+            polynomial = polynomial * radius_sq + coefficient
+        result += gaussian * polynomial
+    return result
+
+
 def dmk_gaussian_split_sigma(box_side_length: float, epsilon: float) -> float:
     """Return the DMK-style Gaussian split scale for one box level.
 

--- a/volumential/gaussian.py
+++ b/volumential/gaussian.py
@@ -184,8 +184,9 @@ def evaluate_gaussian_laplacian_power(
         coefficients = _laplacian_power_polynomial_coefficients(
             alpha=component.alpha, dim=component.dim, order=order
         )
-        polynomial = np.zeros_like(radius_sq)
-        for coefficient in reversed(coefficients):
+        coefficient_iterator = reversed(coefficients)
+        polynomial = next(coefficient_iterator)
+        for coefficient in coefficient_iterator:
             polynomial = polynomial * radius_sq + coefficient
         result += gaussian * polynomial
     return result

--- a/volumential/volume_fmm.py
+++ b/volumential/volume_fmm.py
@@ -739,7 +739,9 @@ def drive_volume_fmm(
         field_name="src_func",
     )
 
-    assert (ns := len(src_weights)) == len(src_func)
+    ns = len(src_weights)
+    if ns != len(src_func):
+        raise ValueError("src_weights and src_func must have the same field count")
 
     list1_only = bool(kwargs.get("list1_only", False))
     auto_interpolate_targets = bool(kwargs.pop("auto_interpolate_targets", True))
@@ -781,7 +783,14 @@ def drive_volume_fmm(
         if queue is None:
             raise TypeError("unable to infer command queue for FMMLib wrangler")
 
-        traversal = traversal.get(queue)
+        if hasattr(traversal, "get"):
+            traversal = traversal.get(queue)
+        else:
+            from boxtree.array_context import (
+                PyOpenCLArrayContext as BoxtreePyOpenCLArrayContext,
+            )
+
+            traversal = BoxtreePyOpenCLArrayContext(queue).to_numpy(traversal)
 
         if isinstance(src_weights[0], cl.array.Array):
             src_weights = obj_array_1d([sw.get(queue) for sw in src_weights])


### PR DESCRIPTION
## Summary

- Add corrected DMK far-plus-residual effective-density modeling, finite-box accuracy references, adaptive timing diagnostics, and complete split-strategy cost accounting.
- Add reusable Gaussian helpers and regression coverage used by the benchmark suite.
- Port the FMMLib wrangler to the current Boxtree array-context API and expose `pyfmmlib` through an optional `fmmlib` extra.
- Add a reproducible two-dimensional fixed-background Helmholtz branched-flow solver with compact random media, phase-aware FMMLib orders, GMRES diagnostics, and optional local preconditioner experiments.
- Generalize remote benchmark documentation so public artifacts do not expose infrastructure identities.

## Validation

- `uv run --extra test --extra fmmlib pytest -q test/test_branched_flow_example.py test/test_benchmark_helpers.py test/test_gaussian.py` (`39 passed`)
- Four focused volume-FMM mock regressions with third-party pytest plugin autoload and hardware conftest disabled (`4 passed`)
- `uv lock --check`
- `python -m compileall` on the changed benchmark, example, test, and solver modules
- `ruff check --select E9,F63,F7,F82` on changed Python files
- `git diff --check origin/main...HEAD`

The full local OpenCL-dependent suite and smoke solve could not run on the current machine because it has no OpenCL platform. GitHub CI provides a PoCL environment for those paths.