### PR TITLE
Batch FMMLib far-field P2M and L2P in FPNDFMMLibExpansionWrangler

### DIFF
--- a/test/test_fmmlib_batched_stages.py
+++ b/test/test_fmmlib_batched_stages.py
@@ -64,7 +64,7 @@ def _make_pocl_context():
     pytest.skip("pocl (Portable Computing Language) platform not available")
 
 
-def _build_wrangler(ctx, queue, *, kernel_type, q_order, nlevels,
+def _build_wrangler(ctx, queue, *, dim, kernel_type, q_order, nlevels,
                     fmm_order, graded=False, helmholtz_k=2.0):
     from sumpy.kernel import HelmholtzKernel, LaplaceKernel
 
@@ -73,8 +73,8 @@ def _build_wrangler(ctx, queue, *, kernel_type, q_order, nlevels,
         FPNDFMMLibTreeIndependentDataForWrangler,
     )
 
-    dim = 3
-    mesh = mg.MeshGen3D(q_order, nlevels, -0.5, 0.5, queue=queue)
+    mesh_cls = {2: mg.MeshGen2D, 3: mg.MeshGen3D}[dim]
+    mesh = mesh_cls(q_order, nlevels, -0.5, 0.5, queue=queue)
 
     if graded:
         # Refine the cells nearest to a corner to obtain a graded
@@ -129,7 +129,7 @@ def _build_wrangler(ctx, queue, *, kernel_type, q_order, nlevels,
     # smooth source density on the quadrature nodes (in tree order)
     coords = np.array([coords_i.get(queue) for coords_i in q_points])
     density = np.exp(-16 * np.sum(coords**2, axis=0)) * (
-        1 + coords[0] - 2 * coords[1] * coords[2]
+        1 + coords[0] - 2 * coords[-2] * coords[-1]
     )
     weights = density * q_weights.get(queue)
     weights = wrangler.reorder_sources(weights)
@@ -150,14 +150,15 @@ def _synthesize_local_expansions(wrangler, seed=17):
 # }}}
 
 
+@pytest.mark.parametrize("dim", [2, 3])
 @pytest.mark.parametrize("kernel_type", ["laplace", "helmholtz"])
 @pytest.mark.parametrize("graded", [False, True])
-def test_batched_form_multipoles_agrees_with_boxtree(kernel_type, graded):
+def test_batched_form_multipoles_agrees_with_boxtree(dim, kernel_type, graded):
     ctx = _make_pocl_context()
     queue = cl.CommandQueue(ctx)
 
     wrangler, weights = _build_wrangler(
-        ctx, queue, kernel_type=kernel_type,
+        ctx, queue, dim=dim, kernel_type=kernel_type,
         q_order=4, nlevels=3, fmm_order=8, graded=graded,
     )
 
@@ -176,8 +177,8 @@ def test_batched_form_multipoles_agrees_with_boxtree(kernel_type, graded):
     assert ref_scale > 0
     rel_err = np.abs(mpoles_new - mpoles_ref).max() / ref_scale
     logger.info(
-        "form_multipoles (%s, graded=%s): max rel diff %.3e",
-        kernel_type, graded, rel_err,
+        "form_multipoles (%dd, %s, graded=%s): max rel diff %.3e",
+        dim, kernel_type, graded, rel_err,
     )
     assert rel_err <= 1e-14
 
@@ -188,7 +189,7 @@ def test_form_multipoles_fallback_path(monkeypatch):
     queue = cl.CommandQueue(ctx)
 
     wrangler, weights = _build_wrangler(
-        ctx, queue, kernel_type="laplace",
+        ctx, queue, dim=3, kernel_type="laplace",
         q_order=3, nlevels=2, fmm_order=6,
     )
 
@@ -207,14 +208,15 @@ def test_form_multipoles_fallback_path(monkeypatch):
     assert np.abs(mpoles_batched - mpoles_fallback).max() / ref_scale <= 1e-14
 
 
+@pytest.mark.parametrize("dim", [2, 3])
 @pytest.mark.parametrize("kernel_type", ["laplace", "helmholtz"])
 @pytest.mark.parametrize("graded", [False, True])
-def test_gemm_eval_locals_agrees_with_boxtree(kernel_type, graded):
+def test_gemm_eval_locals_agrees_with_boxtree(dim, kernel_type, graded):
     ctx = _make_pocl_context()
     queue = cl.CommandQueue(ctx)
 
     wrangler, _weights = _build_wrangler(
-        ctx, queue, kernel_type=kernel_type,
+        ctx, queue, dim=dim, kernel_type=kernel_type,
         q_order=4, nlevels=3, fmm_order=8, graded=graded,
     )
 
@@ -234,8 +236,8 @@ def test_gemm_eval_locals_agrees_with_boxtree(kernel_type, graded):
     assert ref_norm > 0
     rel_err = np.linalg.norm(pot_new - pot_ref) / ref_norm
     logger.info(
-        "eval_locals (%s, graded=%s): rel l2 diff %.3e",
-        kernel_type, graded, rel_err,
+        "eval_locals (%dd, %s, graded=%s): rel l2 diff %.3e",
+        dim, kernel_type, graded, rel_err,
     )
     assert rel_err <= 1e-12
 
@@ -247,7 +249,7 @@ def test_eval_locals_fallback_path(monkeypatch):
     queue = cl.CommandQueue(ctx)
 
     wrangler, _weights = _build_wrangler(
-        ctx, queue, kernel_type="laplace",
+        ctx, queue, dim=3, kernel_type="laplace",
         q_order=3, nlevels=2, fmm_order=6,
     )
 

--- a/test/test_fmmlib_batched_stages.py
+++ b/test/test_fmmlib_batched_stages.py
@@ -1,0 +1,276 @@
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+"""Exact-agreement tests for the batched far-field stages of
+FPNDFMMLibExpansionWrangler (batched P2M via ``*formmp_imany`` and
+GEMM-based L2P) against the inherited per-box implementations from
+:mod:`boxtree.pyfmmlib_integration`.
+
+These stages do not touch near-field tables, so the wrangler is built with a
+minimal stand-in table object (an established pattern in this test suite).
+"""
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import pyopencl as cl
+import pyopencl.array  # noqa: F401
+
+from boxtree.pyfmmlib_integration import FMMLibExpansionWrangler
+
+import volumential.meshgen as mg
+
+
+logger = logging.getLogger(__name__)
+
+
+# {{{ setup helpers
+
+def _make_pocl_context():
+    """Build a context on the pocl CPU platform (never the Intel GPU)."""
+    try:
+        platforms = cl.get_platforms()
+    except cl.LogicError as exc:
+        pytest.skip(f"OpenCL platforms unavailable: {exc}")
+
+    for platform in platforms:
+        if "Portable Computing Language" in platform.name:
+            devices = platform.get_devices()
+            if devices:
+                return cl.Context(devices=[devices[0]])
+
+    pytest.skip("pocl (Portable Computing Language) platform not available")
+
+
+def _build_wrangler(ctx, queue, *, kernel_type, q_order, nlevels,
+                    fmm_order, graded=False, helmholtz_k=2.0):
+    from sumpy.kernel import HelmholtzKernel, LaplaceKernel
+
+    from volumential.expansion_wrangler_fpnd import (
+        FPNDFMMLibExpansionWrangler,
+        FPNDFMMLibTreeIndependentDataForWrangler,
+    )
+
+    dim = 3
+    mesh = mg.MeshGen3D(q_order, nlevels, -0.5, 0.5, queue=queue)
+
+    if graded:
+        # Refine the cells nearest to a corner to obtain a graded
+        # (adaptive) tree.
+        centers = mesh.get_cell_centers()
+        criteria = -np.linalg.norm(centers - np.array([-0.5] * dim), axis=1)
+        mesh.update_mesh(criteria, 0.2, 0.0)
+
+    q_points, q_weights, tree, traversal = mg.build_geometry_info(
+        ctx,
+        queue,
+        dim,
+        q_order,
+        mesh,
+        bbox=np.array([[-0.5, 0.5]] * dim, dtype=np.float64),
+    )
+
+    if kernel_type == "laplace":
+        knl = LaplaceKernel(dim)
+        kernel_extra_kwargs = {}
+    elif kernel_type == "helmholtz":
+        knl = HelmholtzKernel(dim)
+        kernel_extra_kwargs = {knl.helmholtz_k_name: helmholtz_k}
+    else:
+        raise ValueError(kernel_type)
+
+    tree_indep = FPNDFMMLibTreeIndependentDataForWrangler(
+        ctx, None, None, [knl], exclude_self=True
+    )
+
+    # The far-field stages under test do not use near-field tables; a
+    # minimal stand-in suffices for wrangler construction.
+    host_tree_root_extent = 1.0
+    fake_table = SimpleNamespace(
+        source_box_extent=host_tree_root_extent,
+        quad_order=q_order,
+        is_built=True,
+    )
+
+    wrangler = FPNDFMMLibExpansionWrangler(
+        tree_indep,
+        queue,
+        tree,
+        [fake_table],
+        np.complex128,
+        lambda kernel, kernel_args, tree_, lev: fmm_order,
+        q_order,
+        kernel_extra_kwargs=kernel_extra_kwargs,
+        traversal=traversal,
+    )
+
+    # smooth source density on the quadrature nodes (in tree order)
+    coords = np.array([coords_i.get(queue) for coords_i in q_points])
+    density = np.exp(-16 * np.sum(coords**2, axis=0)) * (
+        1 + coords[0] - 2 * coords[1] * coords[2]
+    )
+    weights = density * q_weights.get(queue)
+    weights = wrangler.reorder_sources(weights)
+
+    return wrangler, weights
+
+
+def _synthesize_local_expansions(wrangler, seed=17):
+    """Random local expansions with the correct per-level shapes."""
+    rng = np.random.default_rng(seed)
+    local_exps = wrangler.local_expansion_zeros()
+    local_exps[:] = (
+        rng.standard_normal(local_exps.shape)
+        + 1j * rng.standard_normal(local_exps.shape)
+    )
+    return local_exps
+
+# }}}
+
+
+@pytest.mark.parametrize("kernel_type", ["laplace", "helmholtz"])
+@pytest.mark.parametrize("graded", [False, True])
+def test_batched_form_multipoles_agrees_with_boxtree(kernel_type, graded):
+    ctx = _make_pocl_context()
+    queue = cl.CommandQueue(ctx)
+
+    wrangler, weights = _build_wrangler(
+        ctx, queue, kernel_type=kernel_type,
+        q_order=4, nlevels=3, fmm_order=8, graded=graded,
+    )
+
+    # the batched path must actually be available for this configuration
+    assert wrangler._get_batched_formmp_routine() is not None
+
+    trav = wrangler.traversal
+    args = (trav.level_start_source_box_nrs, trav.source_boxes, [weights])
+
+    mpoles_new, _ = wrangler.form_multipoles(*args)
+    mpoles_ref = FMMLibExpansionWrangler.form_multipoles(
+        wrangler, wrangler._fmmlib_actx, *args
+    )
+
+    ref_scale = np.abs(mpoles_ref).max()
+    assert ref_scale > 0
+    rel_err = np.abs(mpoles_new - mpoles_ref).max() / ref_scale
+    logger.info(
+        "form_multipoles (%s, graded=%s): max rel diff %.3e",
+        kernel_type, graded, rel_err,
+    )
+    assert rel_err <= 1e-14
+
+
+def test_form_multipoles_fallback_path(monkeypatch):
+    """The fallback to the inherited implementation must stay exercised."""
+    ctx = _make_pocl_context()
+    queue = cl.CommandQueue(ctx)
+
+    wrangler, weights = _build_wrangler(
+        ctx, queue, kernel_type="laplace",
+        q_order=3, nlevels=2, fmm_order=6,
+    )
+
+    trav = wrangler.traversal
+    args = (trav.level_start_source_box_nrs, trav.source_boxes, [weights])
+
+    mpoles_batched, _ = wrangler.form_multipoles(*args)
+
+    monkeypatch.setattr(
+        type(wrangler), "_get_batched_formmp_routine", lambda self: None
+    )
+    mpoles_fallback, _ = wrangler.form_multipoles(*args)
+
+    ref_scale = np.abs(mpoles_fallback).max()
+    assert ref_scale > 0
+    assert np.abs(mpoles_batched - mpoles_fallback).max() / ref_scale <= 1e-14
+
+
+@pytest.mark.parametrize("kernel_type", ["laplace", "helmholtz"])
+@pytest.mark.parametrize("graded", [False, True])
+def test_gemm_eval_locals_agrees_with_boxtree(kernel_type, graded):
+    ctx = _make_pocl_context()
+    queue = cl.CommandQueue(ctx)
+
+    wrangler, _weights = _build_wrangler(
+        ctx, queue, kernel_type=kernel_type,
+        q_order=4, nlevels=3, fmm_order=8, graded=graded,
+    )
+
+    assert wrangler._gemm_l2p_supported()
+
+    local_exps = _synthesize_local_expansions(wrangler)
+
+    trav = wrangler.traversal
+    args = (trav.level_start_target_box_nrs, trav.target_boxes, local_exps)
+
+    pot_new, _ = wrangler.eval_locals(*args)
+    pot_ref = FMMLibExpansionWrangler.eval_locals(
+        wrangler, wrangler._fmmlib_actx, *args
+    )
+
+    ref_norm = np.linalg.norm(pot_ref)
+    assert ref_norm > 0
+    rel_err = np.linalg.norm(pot_new - pot_ref) / ref_norm
+    logger.info(
+        "eval_locals (%s, graded=%s): rel l2 diff %.3e",
+        kernel_type, graded, rel_err,
+    )
+    assert rel_err <= 1e-12
+
+
+def test_eval_locals_fallback_path(monkeypatch):
+    """When the GEMM path declares itself unsupported, the inherited
+    implementation is used and produces the same potentials."""
+    ctx = _make_pocl_context()
+    queue = cl.CommandQueue(ctx)
+
+    wrangler, _weights = _build_wrangler(
+        ctx, queue, kernel_type="laplace",
+        q_order=3, nlevels=2, fmm_order=6,
+    )
+
+    local_exps = _synthesize_local_expansions(wrangler)
+    trav = wrangler.traversal
+    args = (trav.level_start_target_box_nrs, trav.target_boxes, local_exps)
+
+    pot_gemm, _ = wrangler.eval_locals(*args)
+
+    monkeypatch.setattr(
+        type(wrangler), "_gemm_l2p_supported", lambda self: False
+    )
+    pot_fallback, _ = wrangler.eval_locals(*args)
+
+    ref_norm = np.linalg.norm(pot_fallback)
+    assert ref_norm > 0
+    assert np.linalg.norm(pot_gemm - pot_fallback) / ref_norm <= 1e-12
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        pytest.main([__file__, "-v"])

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -5996,7 +5996,10 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             )
 
             if (np.asarray(ier) != 0).any():
-                raise RuntimeError("formmp_imany failed with nonzero ier")
+                raise RuntimeError(
+                    f"formmp_imany failed with nonzero ier "
+                    f"on level {lev} ({nboxes} boxes)"
+                )
 
             # expn has shape (*reversed(expansion_shape), nvcount); boxtree
             # stores mpole.T per box, so expn.T has exactly the layout of
@@ -6670,21 +6673,30 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         return True
 
     @memoize_method
-    def _l2p_matrix(self, lev):
-        """Build the dense L2P evaluation matrix for level *lev*.
+    def _l2p_matrix(self, lev, ref_ibox):
+        """Build the dense L2P evaluation matrix for level *lev*, using
+        the target offsets of box *ref_ibox* as the reference layout.
+
+        *ref_ibox* must be the same box whose offsets
+        :meth:`_l2p_level_layout_ok` verified (i.e. the first nonempty box
+        among the traversal's target boxes of the level), so the matrix is
+        never built from an unverified reference. Memoized on
+        ``(lev, ref_ibox)``; for a fixed traversal the reference box is
+        stable, so the memoization stays effective across calls.
 
         Returns an array of shape ``(ntargets_per_box, ncoefs)`` whose
         column *j* is the potential of the *j*-th unit coefficient vector,
         evaluated (via the same scalar ``taeval`` routine boxtree uses) at
-        the reference target offsets of the level's first nonempty target
-        box. Rows are matched to the C-order raveling of boxtree's
-        per-box expansion view, so at runtime
+        the reference target offsets. Rows are matched to the C-order
+        raveling of boxtree's per-box expansion view, so at runtime
 
             pot = exps_view[boxes].reshape(nboxes, ncoefs) @ M.T
         """
-        start, stop = self.tree.level_start_box_nrs[lev:lev + 2]
-        _, ref_offsets = self._l2p_reference_offsets(lev, range(start, stop))
-        assert ref_offsets is not None
+        pslice = self._get_target_slice(ref_ibox)
+        ref_offsets = (
+            self._get_targets(pslice)
+            - self.tree.box_centers[:, ref_ibox].reshape(-1, 1)
+        )
 
         taeval = self.tree_indep.get_expn_eval_routine("ta")
         rscale = self.level_to_rscale(lev)
@@ -6714,6 +6726,14 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
     ):
         """Per-box scalar L2P for one level; identical math to the loop in
         :meth:`boxtree.pyfmmlib_integration.FMMLibExpansionWrangler.eval_locals`.
+
+        .. note::
+
+            This mirrors boxtree's ``eval_locals`` per-box loop combined
+            with the non-grad branch of its ``add_potgrad_onto_output``
+            (i.e. ``output[tgt_pslice] += pot``). If boxtree's
+            implementation changes, this method must be updated to match,
+            or the agreement tests will surface the drift.
         """
         taeval = self.tree_indep.get_expn_eval_routine("ta")
         rscale = self.level_to_rscale(lev)
@@ -6760,7 +6780,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             if len(boxes_ne) == 0:
                 continue
 
-            _, ref_offsets = self._l2p_reference_offsets(lev, boxes_ne)
+            ref_ibox, ref_offsets = self._l2p_reference_offsets(lev, boxes_ne)
 
             if not self._l2p_level_layout_ok(
                 lev, boxes_ne, counts_ne, ref_offsets
@@ -6775,7 +6795,7 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
                 )
                 continue
 
-            mat = self._l2p_matrix(lev)
+            mat = self._l2p_matrix(lev, ref_ibox)
 
             nboxes = len(boxes_ne)
             exps = local_exps_view[boxes_ne - level_start_ibox].reshape(
@@ -6783,10 +6803,17 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
             )
             pots = exps @ mat.T
 
+            # The layout check guarantees every box on this level has
+            # exactly nref targets, and the target slices of distinct
+            # boxes are disjoint, so a single fancy-indexed accumulate
+            # (no duplicate indices) replaces the per-box loop safely.
+            nref = ref_offsets.shape[1]
             box_target_starts = self.box_target_starts()
-            for i in range(nboxes):
-                pstart = box_target_starts[boxes_ne[i]]
-                output[pstart:pstart + counts_ne[i]] += pots[i]
+            flat_idx = (
+                box_target_starts[boxes_ne][:, None]
+                + np.arange(nref)[None, :]
+            ).ravel()
+            output[flat_idx] += pots.ravel()
 
         return output
 

--- a/volumential/expansion_wrangler_fpnd.py
+++ b/volumential/expansion_wrangler_fpnd.py
@@ -5903,14 +5903,125 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
 
     # {{{ formation & coarsening of multipoles
 
+    def _get_batched_formmp_routine(self):
+        """Return the per-level batched P2M routine
+        ``{l,h}{2,3}dformmp_imany`` from :mod:`pyfmmlib`, or *None* if the
+        batched code path is unavailable for this wrangler configuration.
+        """
+        if self.use_dipoles:
+            return None
+        if self.dim not in (2, 3):
+            return None
+
+        eqn_letter = self.tree_indep.eqn_letter
+        if eqn_letter not in ("l", "h"):
+            return None
+
+        import pyfmmlib
+
+        name = f"{eqn_letter}{self.dim}dformmp_imany"
+        return getattr(pyfmmlib, name, None)
+
+    def _form_multipoles_batched(
+        self, formmp_imany, level_start_source_box_nrs, source_boxes, src_weights
+    ):
+        """Batched (one Fortran call per level) version of
+        :meth:`boxtree.pyfmmlib_integration.FMMLibExpansionWrangler.form_multipoles`.
+
+        Mirrors the inherited semantics exactly: same per-box source slices,
+        the same per-level ``rscale`` and ``nterms``, and the same output
+        layout (including the transpose that boxtree applies when storing
+        expansions).
+
+        .. note::
+
+            All offset/start *values* passed to the ``_imany`` routines are
+            0-based (the Fortran arrays are declared ``(0:*)``).
+        """
+        (src_weights,) = src_weights
+        tree = self.tree
+
+        mpoles = self.multipole_expansion_zeros()
+        charge = np.ascontiguousarray(src_weights, dtype=np.complex128)
+        all_sources = self._get_single_sources_array()
+        all_centers = self._get_single_box_centers_array()
+
+        for lev in range(tree.nlevels):
+            start, stop = level_start_source_box_nrs[lev:lev + 2]
+            if start == stop:
+                continue
+
+            boxes = np.asarray(source_boxes[start:stop])
+            counts = tree.box_source_counts_nonchild[boxes]
+
+            # Empty boxes are excluded from the batched call; their
+            # expansion entries stay zero, matching the inherited behavior.
+            nonempty = counts > 0
+            boxes = boxes[nonempty]
+            counts = counts[nonempty]
+            nboxes = len(boxes)
+            if nboxes == 0:
+                continue
+
+            level_start_ibox, mpoles_view = self.multipole_expansions_view(
+                mpoles, lev
+            )
+
+            rscale = self.level_to_rscale(lev)
+            nterms = self.level_orders[lev]
+
+            # One segment per box (0-based offset values)
+            seg_starts = np.arange(nboxes + 1, dtype=np.int32)
+            box_offsets = np.asarray(
+                tree.box_source_starts[boxes], dtype=np.int32
+            )
+            count_offsets = np.arange(nboxes, dtype=np.int32)
+            center_offsets = np.asarray(boxes, dtype=np.int32)
+
+            ier, expn = formmp_imany(
+                **self.kernel_kwargs,
+                rscale=rscale,
+                sources=all_sources,
+                sources_offsets=box_offsets,
+                sources_starts=seg_starts,
+                charge=charge,
+                charge_offsets=box_offsets,
+                charge_starts=seg_starts,
+                nsources=np.asarray(counts, dtype=np.int32),
+                nsources_offsets=count_offsets,
+                nsources_starts=seg_starts,
+                centers=all_centers,
+                centers_offsets=center_offsets,
+                nterms=nterms,
+            )
+
+            if (np.asarray(ier) != 0).any():
+                raise RuntimeError("formmp_imany failed with nonzero ier")
+
+            # expn has shape (*reversed(expansion_shape), nvcount); boxtree
+            # stores mpole.T per box, so expn.T has exactly the layout of
+            # mpoles_view[boxes], i.e. (nvcount, *expansion_shape).
+            mpoles_view[boxes - level_start_ibox] = expn.T
+
+        return mpoles
+
     def form_multipoles(self, level_start_source_box_nrs, source_boxes, src_weights):
-        result = FMMLibExpansionWrangler.form_multipoles(
-            self,
-            self._fmmlib_actx,
-            level_start_source_box_nrs,
-            source_boxes,
-            src_weights,
-        )
+        formmp_imany = self._get_batched_formmp_routine()
+        if formmp_imany is not None:
+            result = self._form_multipoles_batched(
+                formmp_imany,
+                level_start_source_box_nrs,
+                source_boxes,
+                src_weights,
+            )
+        else:
+            result = FMMLibExpansionWrangler.form_multipoles(
+                self,
+                self._fmmlib_actx,
+                level_start_source_box_nrs,
+                source_boxes,
+                src_weights,
+            )
         return result, None
 
     def coarsen_multipoles(
@@ -6500,14 +6611,200 @@ class FPNDFMMLibExpansionWrangler(ExpansionWranglerInterface, FMMLibExpansionWra
         )
         return result, None
 
-    def eval_locals(self, level_start_target_box_nrs, target_boxes, local_exps):
-        result = FMMLibExpansionWrangler.eval_locals(
-            self,
-            self._fmmlib_actx,
-            level_start_target_box_nrs,
-            target_boxes,
-            local_exps,
+    # {{{ GEMM-based L2P
+
+    _L2P_OFFSET_RTOL = 1e-12
+
+    def _gemm_l2p_supported(self):
+        """Whether the GEMM-based L2P code path applies to this wrangler."""
+        return (
+            not self.tree_indep.ifgrad
+            and self.dim in (2, 3)
+            and self.tree_indep.eqn_letter in ("l", "h")
         )
+
+    def _l2p_reference_offsets(self, lev, target_boxes_of_level):
+        """Return ``(ref_ibox, ref_offsets)`` for level *lev*, where
+        *ref_offsets* is the ``(dim, ntargets_per_box)`` array of target
+        coordinates relative to the box center of the first nonempty target
+        box on that level. Returns ``(None, None)`` if the level has no
+        nonempty target box.
+        """
+        for tgt_ibox in target_boxes_of_level:
+            pslice = self._get_target_slice(tgt_ibox)
+            if pslice.stop - pslice.start == 0:
+                continue
+            offsets = (
+                self._get_targets(pslice)
+                - self.tree.box_centers[:, tgt_ibox].reshape(-1, 1)
+            )
+            return tgt_ibox, offsets
+        return None, None
+
+    def _l2p_level_layout_ok(self, lev, boxes, counts, ref_offsets):
+        """Verify (on a sample of boxes) that every target box on level
+        *lev* shares the same target-node layout relative to its center.
+        This holds for volumential's tensor-product node placement; if it is
+        violated, the caller falls back to the per-box reference loop.
+        """
+        nref = ref_offsets.shape[1]
+        if not (counts == nref).all():
+            return False
+
+        box_size = self.tree.root_extent * 2.0 ** (-lev)
+        tol = self._L2P_OFFSET_RTOL * box_size
+
+        nboxes = len(boxes)
+        sample = np.unique(
+            np.asarray([0, nboxes // 3, (2 * nboxes) // 3, nboxes - 1])
+        )
+        for i in sample:
+            tgt_ibox = boxes[i]
+            pslice = self._get_target_slice(tgt_ibox)
+            offsets = (
+                self._get_targets(pslice)
+                - self.tree.box_centers[:, tgt_ibox].reshape(-1, 1)
+            )
+            if np.abs(offsets - ref_offsets).max() >= tol:
+                return False
+        return True
+
+    @memoize_method
+    def _l2p_matrix(self, lev):
+        """Build the dense L2P evaluation matrix for level *lev*.
+
+        Returns an array of shape ``(ntargets_per_box, ncoefs)`` whose
+        column *j* is the potential of the *j*-th unit coefficient vector,
+        evaluated (via the same scalar ``taeval`` routine boxtree uses) at
+        the reference target offsets of the level's first nonempty target
+        box. Rows are matched to the C-order raveling of boxtree's
+        per-box expansion view, so at runtime
+
+            pot = exps_view[boxes].reshape(nboxes, ncoefs) @ M.T
+        """
+        start, stop = self.tree.level_start_box_nrs[lev:lev + 2]
+        _, ref_offsets = self._l2p_reference_offsets(lev, range(start, stop))
+        assert ref_offsets is not None
+
+        taeval = self.tree_indep.get_expn_eval_routine("ta")
+        rscale = self.level_to_rscale(lev)
+        expn_shape = self.expansion_shape(self.level_orders[lev])
+        ncoefs = int(np.prod(expn_shape))
+        ntargets = ref_offsets.shape[1]
+        center = np.zeros(self.dim)
+
+        mat = np.zeros((ntargets, ncoefs), dtype=np.complex128)
+        unit = np.zeros(expn_shape, dtype=np.complex128)
+        for j in range(ncoefs):
+            unit.flat[j] = 1
+            pot, _grad = taeval(
+                rscale=rscale,
+                center=center,
+                expn=unit.T,
+                ztarg=ref_offsets,
+                **self.kernel_kwargs,
+            )
+            mat[:, j] = pot
+            unit.flat[j] = 0
+
+        return mat
+
+    def _eval_locals_level_reference(
+        self, lev, boxes, local_exps_view, level_start_ibox, output
+    ):
+        """Per-box scalar L2P for one level; identical math to the loop in
+        :meth:`boxtree.pyfmmlib_integration.FMMLibExpansionWrangler.eval_locals`.
+        """
+        taeval = self.tree_indep.get_expn_eval_routine("ta")
+        rscale = self.level_to_rscale(lev)
+
+        for tgt_ibox in boxes:
+            tgt_pslice = self._get_target_slice(tgt_ibox)
+            if tgt_pslice.stop - tgt_pslice.start == 0:
+                continue
+
+            tmp_pot, _tmp_grad = taeval(
+                rscale=rscale,
+                center=self.tree.box_centers[:, tgt_ibox],
+                expn=local_exps_view[tgt_ibox - level_start_ibox].T,
+                ztarg=self._get_targets(tgt_pslice),
+                **self.kernel_kwargs,
+            )
+            output[tgt_pslice] += tmp_pot
+
+    def _eval_locals_gemm(
+        self, level_start_target_box_nrs, target_boxes, local_exps
+    ):
+        """GEMM-based version of ``eval_locals``: per level, gather the
+        local expansion coefficients of all target boxes into a matrix and
+        apply a single precomputed evaluation matrix, instead of one scalar
+        ``taeval`` call per box.
+        """
+        output = FMMLibExpansionWrangler.output_zeros(self)
+
+        for lev in range(self.tree.nlevels):
+            start, stop = level_start_target_box_nrs[lev:lev + 2]
+            if start == stop:
+                continue
+
+            level_start_ibox, local_exps_view = self.local_expansions_view(
+                local_exps, lev
+            )
+
+            boxes = np.asarray(target_boxes[start:stop])
+            counts = self.box_target_counts_nonchild()[boxes]
+
+            nonempty = counts > 0
+            boxes_ne = boxes[nonempty]
+            counts_ne = counts[nonempty]
+            if len(boxes_ne) == 0:
+                continue
+
+            _, ref_offsets = self._l2p_reference_offsets(lev, boxes_ne)
+
+            if not self._l2p_level_layout_ok(
+                lev, boxes_ne, counts_ne, ref_offsets
+            ):
+                logger.warning(
+                    "eval_locals: target-node layout is not uniform on "
+                    "level %d; falling back to per-box L2P for this level",
+                    lev,
+                )
+                self._eval_locals_level_reference(
+                    lev, boxes_ne, local_exps_view, level_start_ibox, output
+                )
+                continue
+
+            mat = self._l2p_matrix(lev)
+
+            nboxes = len(boxes_ne)
+            exps = local_exps_view[boxes_ne - level_start_ibox].reshape(
+                nboxes, -1
+            )
+            pots = exps @ mat.T
+
+            box_target_starts = self.box_target_starts()
+            for i in range(nboxes):
+                pstart = box_target_starts[boxes_ne[i]]
+                output[pstart:pstart + counts_ne[i]] += pots[i]
+
+        return output
+
+    # }}} End GEMM-based L2P
+
+    def eval_locals(self, level_start_target_box_nrs, target_boxes, local_exps):
+        if self._gemm_l2p_supported():
+            result = self._eval_locals_gemm(
+                level_start_target_box_nrs, target_boxes, local_exps
+            )
+        else:
+            result = FMMLibExpansionWrangler.eval_locals(
+                self,
+                self._fmmlib_actx,
+                level_start_target_box_nrs,
+                target_boxes,
+                local_exps,
+            )
         return result, None
 
     # }}} End downward pass of fmm


### PR DESCRIPTION
## What

Two far-field optimizations in `FPNDFMMLibExpansionWrangler` (volumential/expansion_wrangler_fpnd.py):

- **Batched P2M**: `form_multipoles` now calls `{l,h}{2,3}dformmp_imany` once per level (rscale is a per-level scalar in fmmlib) instead of one scalar `formmp` call per box. Semantics mirror `boxtree.pyfmmlib_integration.FMMLibExpansionWrangler.form_multipoles` exactly (same source slices, per-level rscale/nterms, same transposed expansion storage). Empty boxes are excluded and stay zero; nonzero `ier` raises. Falls back to the inherited per-box path for dipole sources or when the `_imany` routine is missing from pyfmmlib.
- **GEMM L2P**: `eval_locals` builds, lazily and memoized per level, a dense evaluation matrix (column j = scalar `taeval` of the j-th unit coefficient vector at the reference target offsets of the level's first nonempty target box) and evaluates all target boxes of a level with one GEMM. This relies on volumential's tensor-product node placement (identical target layout relative to each box center on a level); this is *verified at runtime* on sampled boxes against `1e-12 * box_size`, with a per-box reference-loop fallback for any violating level. Gradient outputs (`ifgrad`) fall back to the inherited path entirely.

## Why

The inherited boxtree implementations make one Fortran call per box, which is dominated by Python/f2py call overhead and cannot use pyfmmlib's OpenMP parallelism (P2M) or BLAS (L2P).

## Agreement with inherited implementations

New test `test/test_fmmlib_batched_stages.py` (3D uniform + graded trees, Laplace + Helmholtz zk=2, pocl CPU platform), comparing against `FMMLibExpansionWrangler.form_multipoles` / `.eval_locals` on identical inputs:

| stage | case | measured difference | tolerance |
|---|---|---|---|
| P2M (`formmp_imany`) | all 4 cases | max rel diff **0.0** (bit-identical) | 1e-14 |
| L2P (GEMM) | laplace uniform | rel l2 **5.0e-16** | 1e-12 |
| L2P (GEMM) | helmholtz uniform | rel l2 **4.7e-16** | 1e-12 |
| L2P (GEMM) | laplace graded | rel l2 **6.6e-16** | 1e-12 |
| L2P (GEMM) | helmholtz graded | rel l2 **5.1e-16** | 1e-12 |

Fallback paths are exercised by dedicated tests (batched routine forced unavailable / GEMM support forced off) and agree with the batched results to the same tolerances.

`pytest test/test_volume_fmm.py -k fmmlib` passes before and after (1 passed, 117 deselected).

## Threading profile

3D Laplace volume FMM, uniform tree, 110,592 source/target nodes, FMM order 16, best of 3 (M2L/M2P: 1 rep), machine: 4C/8T i7-8650U, pocl CPU:

| stage | variant | 1 thread | 4 threads | 8 threads |
|---|---|---|---|---|
| form_multipoles | inherited | 0.210 s | 0.178 s | 0.194 s |
| form_multipoles | **overridden** | **0.197 s** | **0.064 s** | **0.058 s** |
| multipole_to_local | (unchanged) | 3.480 s | 0.693 s | 0.585 s |
| eval_multipoles | (unchanged) | 0.001 s | 0.001 s | 0.001 s |
| eval_locals | inherited | 0.223 s | 0.101 s | 0.303 s |
| eval_locals | **overridden** | **0.014 s** | **0.009 s** | **0.013 s** |

Notes: the batched P2M scales with OpenMP threads (the scalar loop does not); GEMM L2P is 11-23x faster than the per-box loop (steady state, matrix cache warm). `eval_multipoles` is ~empty on this uniform sources-are-targets tree (no list 3). The inherited `eval_locals` 8-thread outlier is SMT oversubscription noise.

## Requirements / base

- **Stacked PR**: based on `feat/batched-yukawa2d-and-rke-assembly`, not master.
- Requires the pyfmmlib **local-combined build with the `_imany` interfaces** (inducer/pyfmmlib#93 + inducer/pyfmmlib#94); without it, `form_multipoles` transparently falls back to the inherited per-box path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYp74e5ZTE6ZHDNR3ETgM6