### PR TITLE
Skip batched-P2M agreement tests when pyfmmlib lacks formmp_imany

### DIFF
--- a/test/test_fmmlib_batched_stages.py
+++ b/test/test_fmmlib_batched_stages.py
@@ -162,8 +162,14 @@ def test_batched_form_multipoles_agrees_with_boxtree(dim, kernel_type, graded):
         q_order=4, nlevels=3, fmm_order=8, graded=graded,
     )
 
-    # the batched path must actually be available for this configuration
-    assert wrangler._get_batched_formmp_routine() is not None
+    # The batched path needs a pyfmmlib with the formmp_imany wrappers
+    # (inducer/pyfmmlib#93 + #94); on stock pyfmmlib the wrangler falls
+    # back to the inherited implementation, so there is nothing to compare.
+    if wrangler._get_batched_formmp_routine() is None:
+        pytest.skip(
+            "pyfmmlib lacks the formmp_imany routines "
+            "(needs inducer/pyfmmlib#93 + #94)"
+        )
 
     trav = wrangler.traversal
     args = (trav.level_start_source_box_nrs, trav.source_boxes, [weights])


### PR DESCRIPTION
Fixes the CI failures on main (runs 30415560105 / 30415775965): CI installs stock pyfmmlib, where `FPNDFMMLibExpansionWrangler` intentionally falls back to the inherited per-box P2M — but the eight P2M agreement tests hard-asserted the batched routine's presence and failed. They now skip with a pointer to inducer/pyfmmlib#93 + #94.

Verified locally: 18 passed with the patched pyfmmlib build (no skips); 8 skipped / 0 failed under a simulated stock pyfmmlib. The GEMM L2P tests are unaffected (they need only stock `taeval`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYp74e5ZTE6ZHDNR3ETgM6