### PR TITLE
Add intersphinx mapping; fixes docs build under -W

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,11 +48,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
-    "numpy": ("https://numpy.org/doc/stable", None),
     "sumpy": ("https://documen.tician.de/sumpy", None),
-    "boxtree": ("https://documen.tician.de/boxtree", None),
-    "pyopencl": ("https://documen.tician.de/pyopencl", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -47,6 +47,14 @@ extensions = [
     "sphinx.ext.githubpages",
 ]
 
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "sumpy": ("https://documen.tician.de/sumpy", None),
+    "boxtree": ("https://documen.tician.de/boxtree", None),
+    "pyopencl": ("https://documen.tician.de/pyopencl", None),
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
CI Full's Documentation job fails because Sphinx runs with `-W` and the `:mod:` references to `sumpy.kernel` in `derivative_support.rst` cannot resolve: intersphinx was enabled but never given a mapping. This adds only the required Sumpy inventory, avoiding unrelated remote-inventory dependencies. A local `sphinx-build -W --keep-going -n -b html doc/source doc/build` succeeds.

CI Full's other failing job, Testing (macOS), is a pre-existing native `SIGABRT` in the OpenCL stack (the same `Abort trap: 6` seen before #127, then inside `test_rke_table_assembly.py`) and is unrelated to this fix.