### PR TITLE
Windowed RKE table assembly

### DIFF
--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -168,6 +168,11 @@ def _require_finite_positive(value: float, name: str) -> None:
         raise ValueError(f"{name} must be finite and positive")
 
 
+def _require_unique(values, name: str) -> None:
+    if len(set(values)) != len(values):
+        raise ValueError(f"{name} must be unique")
+
+
 def _require_integer(value, name: str, *, minimum=None) -> int:
     if isinstance(value, (bool, np.bool_)):
         raise ValueError(f"{name} must be an integer")
@@ -263,8 +268,7 @@ def _parse_order_pairs(raw: str) -> list[tuple[int, int]]:
         )
     if not pairs:
         raise ValueError("expected at least one 'regular,radial' pair")
-    if len(set(pairs)) != len(pairs):
-        raise ValueError("channel-order policies must be unique")
+    _require_unique(pairs, "channel-order policies")
     return pairs
 
 
@@ -661,6 +665,7 @@ def run_sweep(
         raise ValueError("at least one dimension is required")
     if any(dim not in (2, 3) for dim in dims):
         raise ValueError("dim entries must be 2 or 3")
+    _require_unique(dims, "dimension entries")
     kernels = list(kernels)
     if not kernels:
         raise ValueError("at least one kernel is required")
@@ -669,6 +674,7 @@ def run_sweep(
     ]
     if unknown_kernels:
         raise ValueError(f"unknown kernel: {unknown_kernels[0]}")
+    _require_unique(kernels, "kernel entries")
     if q_order_override is not None:
         q_order_override = _require_integer(
             q_order_override, "q_order_override", minimum=1
@@ -682,18 +688,21 @@ def run_sweep(
     ]
     if not p_stars:
         raise ValueError("at least one p_star is required")
+    _require_unique(p_stars, "p_star entries")
     smooth_orders = [
         _require_integer(order, "smooth_order", minimum=1)
         for order in smooth_orders
     ]
     if not smooth_orders:
         raise ValueError("at least one smooth_order is required")
+    _require_unique(smooth_orders, "smooth_order entries")
     if mus is not None:
         mus = list(mus)
         if not mus:
             raise ValueError("at least one mu is required when mus is provided")
         for mu in mus:
             _require_finite_positive(mu, "mu")
+        _require_unique(mus, "mu entries")
     direct_policies = [
         _require_usable_order_pair(policy, "direct policy")
         for policy in direct_policies
@@ -726,8 +735,7 @@ def run_sweep(
                 "at least one channel policy is required when chan_orders "
                 "is provided"
             )
-        if len(set(chan_orders)) != len(chan_orders):
-            raise ValueError("channel-order policies must be unique")
+        _require_unique(chan_orders, "channel-order policies")
 
     from volumential.rke_table_assembly import (
         _require_o1_box_extent,

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -263,6 +263,8 @@ def _parse_order_pairs(raw: str) -> list[tuple[int, int]]:
         )
     if not pairs:
         raise ValueError("expected at least one 'regular,radial' pair")
+    if len(set(pairs)) != len(pairs):
+        raise ValueError("channel-order policies must be unique")
     return pairs
 
 
@@ -724,6 +726,8 @@ def run_sweep(
                 "at least one channel policy is required when chan_orders "
                 "is provided"
             )
+        if len(set(chan_orders)) != len(chan_orders):
+            raise ValueError("channel-order policies must be unique")
 
     from volumential.rke_table_assembly import (
         _require_o1_box_extent,
@@ -746,6 +750,11 @@ def run_sweep(
         box_extent = float(root_extent) * 0.5**source_level
         _require_finite_positive(box_extent, "box_extent")
         _require_o1_box_extent(box_extent)
+        with np.errstate(over="ignore", under="ignore", divide="ignore"):
+            window_scale = float(
+                np.square(np.float64(box_extent) / np.float64(window_theta))
+            )
+        _require_finite_positive(window_scale, "window_scale")
         dim_mus = sorted(
             mus
             if mus is not None

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -10,7 +10,11 @@ cross-deviations:
 (b) classical series RKE assembly (:func:`assemble_parameterized_table`) at a
     matching certified tolerance, recording the refusal kind when the
     classical certificate cannot be issued (uncertifiable truncation or
-    ill-conditioned recombination);
+    ill-conditioned recombination).  Its canonical channels are materialized
+    by an untimed warm-up call, so ``classical_assemble_seconds`` is the
+    marginal recombination cost and is directly comparable to
+    ``windowed_assemble_seconds``; the one-off construction is reported
+    separately as ``classical_channel_build_seconds``;
 (c) direct fixed-parameter builds through the table manager at two Duffy
     quadrature policies, whose mutual disagreement estimates the reference
     floor below which assembled-vs-direct deviations are quadrature noise.
@@ -76,6 +80,8 @@ FIELDS = (
     "classical_n_series_terms",
     "classical_channel_count",
     "classical_condition_number",
+    "classical_build_was_cold",
+    "classical_channel_build_seconds",
     "classical_assemble_seconds",
     "classical_payload_bytes",
     "classical_channel_regular_order",
@@ -101,6 +107,34 @@ PARAMETER_NAMES = {"Helmholtz": "k", "Yukawa": "lambda"}
 DEFAULT_Q_ORDER = {2: 3, 3: 2}
 DEFAULT_SOURCE_LEVEL = {2: 3, 3: 2}
 CLASSICAL_TOLERANCE = 1.0e-11
+
+# What the windowed assembler covers is the dimensionless local parameter
+# theta = mu * b, not mu itself, and the default source-box extent b differs
+# per dimension (2D: 0.25, 3D: 0.5).  Declaring the default ladders as
+# fractions of the declared window Theta and converting with mu = theta / b
+# therefore keeps every default row inside the coverage disk in both
+# dimensions -- a fixed mu ladder reaching theta = Theta in 2D overshoots to
+# theta = 2 Theta in 3D and is refused outright.  At the default geometry
+# (Theta = 16, root extent 2) these reproduce the historical fixed ladders
+# exactly: smoke '4,64' and full '1,2,4,8,16,24,32,48,64' in 2D.
+DEFAULT_SMOKE_THETA_FRACTIONS = (1.0 / 16.0, 1.0)
+DEFAULT_FULL_THETA_FRACTIONS = (
+    1.0 / 64.0, 1.0 / 32.0, 1.0 / 16.0, 1.0 / 8.0, 1.0 / 4.0,
+    3.0 / 8.0, 1.0 / 2.0, 3.0 / 4.0, 1.0,
+)
+
+
+def _default_mus(mode: str, window_theta: float, box_extent: float):
+    """Default parameter ladder for one dimension's box extent."""
+    fractions = (
+        DEFAULT_SMOKE_THETA_FRACTIONS
+        if mode == "smoke"
+        else DEFAULT_FULL_THETA_FRACTIONS
+    )
+    return [
+        fraction * float(window_theta) / float(box_extent)
+        for fraction in fractions
+    ]
 
 
 def _parse_csv_ints(raw: str) -> list[int]:
@@ -312,8 +346,21 @@ def _run_windowed(
 
 
 def _classify_classical_refusal(exc: BaseException) -> str:
-    message = str(exc)
-    if "cannot certify" in message:
+    """Refusal kind of a classical assembly failure.
+
+    The assembler names its two certified refusal modes structurally, via the
+    ``refusal_kind`` attribute of :class:`~volumential.rke_table_assembly.\
+RKETruncationError` / :class:`~volumential.rke_table_assembly.\
+RKEConditioningError`, so a message rewording can no longer silently
+    reclassify a row.  Message matching survives only as a fallback for
+    exceptions raised without that marker, and keys on the stable part of
+    each message ("certify", "ill-conditioned") rather than the full text.
+    """
+    kind = getattr(exc, "refusal_kind", None)
+    if isinstance(kind, str) and kind:
+        return kind
+    message = str(exc).lower()
+    if "certify" in message:
         return "uncertifiable"
     if "ill-conditioned" in message:
         return "ill-conditioned"
@@ -333,7 +380,21 @@ def _run_classical(
     channel_orders: tuple[int, int],
     entry_ids,
     n_reduced_entries: int,
+    warm_channel_counts: dict[Any, int],
 ) -> dict[str, Any]:
+    """Classical assembly with the one-time channel build kept out of the
+    timed region.
+
+    ``assemble_parameterized_table`` builds whatever canonical channels the
+    requested truncation order needs on first use, so a single timed call
+    conflates that one-off construction with the marginal per-parameter
+    recombination and is not comparable to ``windowed_assemble_seconds``
+    (whose channel family is prepared separately).  An untimed warm-up call
+    materializes the channels first; the timed call that follows is then
+    marginal, exactly like the windowed one.  The warm-up cost is reported as
+    ``classical_channel_build_seconds`` and ``classical_build_was_cold``
+    records whether it actually had to extend the channel family.
+    """
     from volumential.nearfield_potential_table import DuffyBuildConfig
     from volumential.rke_table_assembly import assemble_parameterized_table
 
@@ -342,9 +403,9 @@ def _run_classical(
         regular_quad_order=channel_orders[0],
         radial_quad_order=channel_orders[1],
     )
-    start = time.perf_counter()
-    try:
-        table, certificate = assemble_parameterized_table(
+
+    def assemble():
+        return assemble_parameterized_table(
             queue,
             cache_path,
             dim,
@@ -356,7 +417,26 @@ def _run_classical(
             tolerance=CLASSICAL_TOLERANCE,
             build_config=build_config,
         )
+
+    # The channel family depends on the geometry and the Duffy orders only,
+    # never on the kernel or the parameter; the parameter enters solely
+    # through how many of those channels the truncation order asks for.
+    warm_key = (
+        str(cache_path),
+        int(dim),
+        int(q_order),
+        int(source_box_level),
+        float(root_extent),
+        tuple(channel_orders),
+    )
+    already_built = warm_channel_counts.get(warm_key, 0)
+
+    start = time.perf_counter()
+    try:
+        _, warm_certificate = assemble()
     except (ValueError, RuntimeError, NotImplementedError) as exc:
+        # A refusal is a property of the parameter, not of the timing split:
+        # classify and report it exactly as a single timed call would have.
         return {
             "classical_status": "refused",
             "classical_refusal": _classify_classical_refusal(exc),
@@ -364,6 +444,13 @@ def _run_classical(
             "classical_assemble_seconds": time.perf_counter() - start,
             "values": None,
         }
+    build_seconds = time.perf_counter() - start
+    warm_channel_count = int(warm_certificate["channel_count"])
+    was_cold = warm_channel_count > already_built
+    warm_channel_counts[warm_key] = max(already_built, warm_channel_count)
+
+    start = time.perf_counter()
+    table, certificate = assemble()
     assemble_seconds = time.perf_counter() - start
     values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
     channel_count = int(certificate["channel_count"])
@@ -374,6 +461,8 @@ def _run_classical(
         "classical_n_series_terms": certificate["n_series_terms"],
         "classical_channel_count": channel_count,
         "classical_condition_number": certificate["condition_number"],
+        "classical_build_was_cold": was_cold,
+        "classical_channel_build_seconds": build_seconds,
         "classical_assemble_seconds": assemble_seconds,
         # channel_count real float64 channel tables over the reduced entries
         "classical_payload_bytes": int(
@@ -464,7 +553,7 @@ def run_sweep(
     window_theta: float,
     p_stars: list[int],
     smooth_orders: list[int],
-    mus: list[float],
+    mus: list[float] | None,
     direct_policies: list[tuple[int, int]],
     classical_channel_orders: tuple[int, int],
     chan_orders: list[tuple[int, int]] | None,
@@ -479,6 +568,10 @@ def run_sweep(
 
     rows: list[dict[str, Any]] = []
     channel_prep_records: dict[str, Any] = {}
+    mus_by_dim: dict[int, list[float]] = {}
+    # Highest classical channel count already materialized per channel-cache
+    # key, so ``_run_classical`` can report whether its warm-up was cold.
+    warm_channel_counts: dict[Any, int] = {}
 
     for dim in sorted(dims):
         q_order = (
@@ -492,6 +585,14 @@ def run_sweep(
             else DEFAULT_SOURCE_LEVEL[dim]
         )
         box_extent = float(root_extent) * 0.5**int(source_level)
+        # theta = mu * b is what the declared window covers, so the default
+        # ladder is resolved against this dimension's own box extent.
+        dim_mus = sorted(
+            mus
+            if mus is not None
+            else _default_mus(mode, window_theta, box_extent)
+        )
+        mus_by_dim[dim] = dim_mus
         if chan_orders is None:
             dim_chan_orders = [_resolve_channel_orders(dim, None, None)]
         else:
@@ -510,7 +611,9 @@ def run_sweep(
             "chan_orders="
             + ";".join(
                 f"{regular}/{radial}" for regular, radial in dim_chan_orders
-            ),
+            )
+            + " mus="
+            + ",".join(f"{mu:g}" for mu in dim_mus),
             flush=True,
         )
 
@@ -571,7 +674,7 @@ def run_sweep(
                 )
 
         for kernel in kernels:
-            for mu in mus:
+            for mu in dim_mus:
                 theta = float(mu) * box_extent
                 mu_tag = f"{mu:g}".replace("-", "m").replace(".", "p")
 
@@ -641,6 +744,7 @@ def run_sweep(
                     channel_orders=classical_channel_orders,
                     entry_ids=entry_ids,
                     n_reduced_entries=n_entries,
+                    warm_channel_counts=warm_channel_counts,
                 )
                 if (
                     classical["values"] is not None
@@ -802,10 +906,6 @@ def run_sweep(
                             for key, value in windowed.items():
                                 if key != "values" and key in FIELDS:
                                     row[key] = value
-                            if "smooth_quad_order_used" in windowed:
-                                row["smooth_quad_order_used"] = windowed[
-                                    "smooth_quad_order_used"
-                                ]
                             for key, value in classical.items():
                                 if key != "values" and key in FIELDS:
                                     row[key] = value
@@ -816,6 +916,7 @@ def run_sweep(
         row["benchmark_total_seconds"] = total_seconds
     return rows, {
         "channel_prep": channel_prep_records,
+        "mus_by_dim": {str(dim): values for dim, values in mus_by_dim.items()},
         "total_seconds": total_seconds,
     }
 
@@ -866,8 +967,12 @@ def main() -> int:
     )
     parser.add_argument(
         "--mus",
-        help="comma-separated parameter values; defaults: smoke '4,64', "
-        "full '1,2,4,8,16,24,32,48,64'",
+        help="comma-separated parameter values, applied to every dimension; "
+        "the default ladder is resolved per dimension from the window "
+        "declaration as mu = fraction * window_theta / box_extent, which at "
+        "the default geometry gives smoke '4,64' and full "
+        "'1,2,4,8,16,24,32,48,64' in 2D (and half of each in 3D, whose box "
+        "extent is twice as large)",
     )
     parser.add_argument(
         "--direct-policies",
@@ -927,10 +1032,10 @@ def main() -> int:
     smooth_orders = _parse_csv_ints(
         args.smooth_orders or ("16" if smoke else "8,16,24,32")
     )
-    mus = sorted(
-        _parse_csv_floats(args.mus or ("4,64" if smoke else "1,2,4,8,16,24,32,48,64"))
-    )
-    if any(mu <= 0 for mu in mus):
+    # ``None`` defers the ladder to run_sweep, which resolves it against each
+    # dimension's own box extent.
+    mus = sorted(_parse_csv_floats(args.mus)) if args.mus else None
+    if mus is not None and any(mu <= 0 for mu in mus):
         parser.error("--mus entries must be positive")
     direct_policies = _parse_direct_policies(args.direct_policies)
     classical_channel_orders = _parse_order_pair(args.classical_channel_orders)
@@ -993,11 +1098,31 @@ def main() -> int:
         json.dump(config, outfile, indent=2, sort_keys=True)
         outfile.write("\n")
 
+    # A sweep whose windowed assemblies were all refused, or whose direct
+    # reference builds all failed, produces a CSV with no usable comparison
+    # in it; that must not be indistinguishable from success (this driver is
+    # also a CI smoke check).
+    refused = sum(1 for row in rows if row["windowed_status"] != "ok")
+    no_reference = sum(1 for row in rows if not row["direct_reference_policy"])
+    usable = sum(
+        1
+        for row in rows
+        if row["windowed_status"] == "ok" and row["direct_reference_policy"]
+    )
     print(
-        f"[done] rows={len(rows)} csv={csv_path} json={json_path} "
+        f"[done] rows={len(rows)} usable={usable} "
+        f"windowed_refused={refused} no_direct_reference={no_reference} "
+        f"csv={csv_path} json={json_path} "
         f"total_s={run_info['total_seconds']:.1f}",
         flush=True,
     )
+    if not usable:
+        print(
+            "[error] no row produced both a windowed 'ok' assembly and a "
+            "usable direct reference",
+            flush=True,
+        )
+        return 1
     return 0
 
 

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -723,16 +723,8 @@ def run_sweep(
                 "is provided"
             )
 
-    from volumential.rke_table_assembly import _resolve_channel_orders
-
-    sweep_start = time.perf_counter()
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    queue = _make_queue()
-
-    rows: list[dict[str, Any]] = []
-    channel_prep_records: dict[str, Any] = {}
+    dimension_configs: dict[int, tuple[int, int, float, list[float]]] = {}
     mus_by_dim: dict[int, list[float]] = {}
-
     for dim in sorted(dims):
         q_order = (
             q_order_override
@@ -744,15 +736,31 @@ def run_sweep(
             if source_level_override is not None
             else DEFAULT_SOURCE_LEVEL[dim]
         )
-        box_extent = float(root_extent) * 0.5**int(source_level)
-        # theta = mu * b is what the declared window covers, so the default
-        # ladder is resolved against this dimension's own box extent.
+        box_extent = float(root_extent) * 0.5**source_level
+        _require_finite_positive(box_extent, "box_extent")
         dim_mus = sorted(
             mus
             if mus is not None
             else _default_mus(mode, window_theta, box_extent)
         )
+        for mu in dim_mus:
+            _require_finite_positive(mu, "mu")
+        dimension_configs[dim] = (
+            q_order, source_level, box_extent, dim_mus
+        )
         mus_by_dim[dim] = dim_mus
+
+    from volumential.rke_table_assembly import _resolve_channel_orders
+
+    sweep_start = time.perf_counter()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    queue = _make_queue()
+
+    rows: list[dict[str, Any]] = []
+    channel_prep_records: dict[str, Any] = {}
+
+    for dim in sorted(dims):
+        q_order, source_level, box_extent, dim_mus = dimension_configs[dim]
         if chan_orders is None:
             dim_chan_orders = [_resolve_channel_orders(dim, None, None)]
         else:

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -651,6 +651,8 @@ def run_sweep(
     _require_finite_positive(root_extent, "root_extent")
     _require_finite_positive(window_theta, "window_theta")
     dims = [_require_integer(dim, "dim") for dim in dims]
+    if not dims:
+        raise ValueError("at least one dimension is required")
     if any(dim not in (2, 3) for dim in dims):
         raise ValueError("dim entries must be 2 or 3")
     if q_order_override is not None:

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -675,6 +675,21 @@ def run_sweep(
         _require_usable_order_pair(policy, "direct policy")
         for policy in direct_policies
     ]
+    if len(direct_policies) != 2:
+        raise ValueError(
+            "exactly two direct policies (loose;tight) are required"
+        )
+    loose_policy, tight_policy = direct_policies
+    if any(
+        tight_order < loose_order
+        for loose_order, tight_order in zip(
+            loose_policy, tight_policy, strict=True
+        )
+    ) or tight_policy == loose_policy:
+        raise ValueError(
+            "tight direct policy must be componentwise >= the loose policy "
+            "and strictly larger in at least one component"
+        )
     classical_channel_orders = _require_usable_order_pair(
         classical_channel_orders, "classical channel policy"
     )

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -18,8 +18,11 @@ cross-deviations:
 Deviations are reported against the tight direct policy as both relative
 max-entry and relative L2 over the symmetry-reduced entries.  Windowed
 channel families are built (or reused) once per ``(dim, q_order, level,
-window_theta)`` from a shared cache, so the one-off channel build cost and
-the marginal per-parameter assembly cost are recorded separately.
+window_theta, channel quadrature orders)`` from a per-family cache, so the
+one-off channel build cost and the marginal per-parameter assembly cost are
+recorded separately.  The windowed channel quadrature orders are themselves
+sweepable via ``--chan-orders``; the classical and direct reference builds do
+not depend on them and are computed once per ``(dim, kernel, parameter)``.
 
 Smoke mode is intended for CI/local validation.  Full mode is intended for
 metadata-wrapped runs on a controlled remote compute host.
@@ -132,6 +135,24 @@ def _parse_direct_policies(raw: str) -> list[tuple[int, int]]:
             "exactly two direct policies (loose;tight) are required"
         )
     return policies
+
+
+def _parse_order_pairs(raw: str) -> list[tuple[int, int]]:
+    """Parse ``'regular,radial;regular,radial;...'`` into a list of pairs."""
+    pairs: list[tuple[int, int]] = []
+    for chunk in raw.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = [int(part.strip()) for part in chunk.split(",")]
+        if len(parts) != 2:
+            raise ValueError(
+                "each channel-order policy must be a 'regular,radial' pair"
+            )
+        pairs.append((parts[0], parts[1]))
+    if not pairs:
+        raise ValueError("expected at least one 'regular,radial' pair")
+    return pairs
 
 
 def _parse_order_pair(raw: str) -> tuple[int, int]:
@@ -446,6 +467,7 @@ def run_sweep(
     mus: list[float],
     direct_policies: list[tuple[int, int]],
     classical_channel_orders: tuple[int, int],
+    chan_orders: list[tuple[int, int]] | None,
     cache_dir: Path,
     skip_3d_tight: bool,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -470,11 +492,14 @@ def run_sweep(
             else DEFAULT_SOURCE_LEVEL[dim]
         )
         box_extent = float(root_extent) * 0.5**int(source_level)
-        chan_regular_order, chan_radial_order = _resolve_channel_orders(
-            dim, None, None
-        )
+        if chan_orders is None:
+            dim_chan_orders = [_resolve_channel_orders(dim, None, None)]
+        else:
+            dim_chan_orders = [
+                _resolve_channel_orders(dim, regular, radial)
+                for regular, radial in chan_orders
+            ]
 
-        windowed_cache = cache_dir / f"windowed-channels-d{dim}-q{q_order}.db"
         classical_cache = (
             cache_dir / f"classical-channels-d{dim}-q{q_order}.sqlite"
         )
@@ -482,38 +507,68 @@ def run_sweep(
         print(
             f"[config] dim={dim} q_order={q_order} level={source_level} "
             f"box_extent={box_extent:g} window_theta={window_theta:g} "
-            f"chan_orders={chan_regular_order}/{chan_radial_order}",
+            "chan_orders="
+            + ";".join(
+                f"{regular}/{radial}" for regular, radial in dim_chan_orders
+            ),
             flush=True,
         )
-        channels = _prepare_windowed_channels(
-            cache_path=windowed_cache,
-            dim=dim,
-            q_order=q_order,
-            source_box_level=source_level,
-            root_extent=root_extent,
-            window_theta=window_theta,
-            max_p_star=max(p_stars),
-            chan_regular_order=chan_regular_order,
-            chan_radial_order=chan_radial_order,
-        )
-        print(
-            f"[channels] dim={dim} "
-            f"cold={channels['channel_build_was_cold']} "
-            f"build_s={channels['channel_build_seconds']:.2f} "
-            f"n_reduced_entries={channels['n_reduced_entries']}",
-            flush=True,
-        )
-        channel_prep_records[f"dim{dim}"] = {
-            "q_order": q_order,
-            "source_box_level": source_level,
-            "chan_regular_order": chan_regular_order,
-            "chan_radial_order": chan_radial_order,
-            "channel_build_seconds": channels["channel_build_seconds"],
-            "channel_build_was_cold": channels["channel_build_was_cold"],
-            "n_reduced_entries": channels["n_reduced_entries"],
-        }
-        entry_ids = channels["entry_ids"]
-        n_entries = channels["n_reduced_entries"]
+
+        # The windowed channel families depend only on (dim, q_order, level,
+        # root_extent, window_theta, chan orders) -- not on the kernel or the
+        # parameter -- so build each requested channel-order family once here.
+        channel_families: list[dict[str, Any]] = []
+        for chan_regular_order, chan_radial_order in dim_chan_orders:
+            windowed_cache = cache_dir / (
+                f"windowed-channels-d{dim}-q{q_order}"
+                f"-c{chan_regular_order}x{chan_radial_order}.db"
+            )
+            channels = _prepare_windowed_channels(
+                cache_path=windowed_cache,
+                dim=dim,
+                q_order=q_order,
+                source_box_level=source_level,
+                root_extent=root_extent,
+                window_theta=window_theta,
+                max_p_star=max(p_stars),
+                chan_regular_order=chan_regular_order,
+                chan_radial_order=chan_radial_order,
+            )
+            print(
+                f"[channels] dim={dim} "
+                f"chan_orders={chan_regular_order}/{chan_radial_order} "
+                f"cold={channels['channel_build_was_cold']} "
+                f"build_s={channels['channel_build_seconds']:.2f} "
+                f"n_reduced_entries={channels['n_reduced_entries']}",
+                flush=True,
+            )
+            channel_prep_records[
+                f"dim{dim}_c{chan_regular_order}x{chan_radial_order}"
+            ] = {
+                "q_order": q_order,
+                "source_box_level": source_level,
+                "chan_regular_order": chan_regular_order,
+                "chan_radial_order": chan_radial_order,
+                "channel_build_seconds": channels["channel_build_seconds"],
+                "channel_build_was_cold": channels["channel_build_was_cold"],
+                "n_reduced_entries": channels["n_reduced_entries"],
+            }
+            channels["cache_path"] = windowed_cache
+            channels["chan_regular_order"] = chan_regular_order
+            channels["chan_radial_order"] = chan_radial_order
+            channel_families.append(channels)
+
+        # The reduced-entry index set is a property of (dim, q_order, level)
+        # alone, so all families must agree; the direct and classical
+        # references are then sampled once on that shared index set.
+        entry_ids = channel_families[0]["entry_ids"]
+        n_entries = channel_families[0]["n_reduced_entries"]
+        for family in channel_families[1:]:
+            if not np.array_equal(family["entry_ids"], entry_ids):
+                raise RuntimeError(
+                    "windowed channel families disagree on the reduced entry "
+                    "index set across channel-order pairs"
+                )
 
         for kernel in kernels:
             for mu in mus:
@@ -613,133 +668,148 @@ def run_sweep(
                     flush=True,
                 )
 
-                for p_star in sorted(p_stars):
-                    for smooth_order in sorted(smooth_orders):
-                        windowed = _run_windowed(
-                            cache_path=windowed_cache,
-                            dim=dim,
-                            kernel=kernel,
-                            q_order=q_order,
-                            parameter=mu,
-                            source_box_level=source_level,
-                            root_extent=root_extent,
-                            window_theta=window_theta,
-                            p_star=p_star,
-                            smooth_quad_order=smooth_order,
-                            chan_regular_order=chan_regular_order,
-                            chan_radial_order=chan_radial_order,
-                            entry_ids=entry_ids,
-                            n_reduced_entries=n_entries,
-                        )
-                        if (
-                            windowed["values"] is not None
-                            and reference_values is not None
-                        ):
-                            windowed_rel_max, windowed_rel_l2 = (
-                                _relative_deviations(
-                                    windowed["values"], reference_values
-                                )
+                for family in channel_families:
+                    windowed_cache = family["cache_path"]
+                    chan_regular_order = family["chan_regular_order"]
+                    chan_radial_order = family["chan_radial_order"]
+                    chan_tag = f"c{chan_regular_order}x{chan_radial_order}"
+
+                    for p_star in sorted(p_stars):
+                        for smooth_order in sorted(smooth_orders):
+                            windowed = _run_windowed(
+                                cache_path=windowed_cache,
+                                dim=dim,
+                                kernel=kernel,
+                                q_order=q_order,
+                                parameter=mu,
+                                source_box_level=source_level,
+                                root_extent=root_extent,
+                                window_theta=window_theta,
+                                p_star=p_star,
+                                smooth_quad_order=smooth_order,
+                                chan_regular_order=chan_regular_order,
+                                chan_radial_order=chan_radial_order,
+                                entry_ids=entry_ids,
+                                n_reduced_entries=n_entries,
                             )
-                        else:
-                            windowed_rel_max, windowed_rel_l2 = "", ""
+                            if (
+                                windowed["values"] is not None
+                                and reference_values is not None
+                            ):
+                                windowed_rel_max, windowed_rel_l2 = (
+                                    _relative_deviations(
+                                        windowed["values"], reference_values
+                                    )
+                                )
+                            else:
+                                windowed_rel_max, windowed_rel_l2 = "", ""
 
-                        print(
-                            f"  [row] p_star={p_star} "
-                            f"smooth={smooth_order} "
-                            f"windowed={windowed['windowed_status']} "
-                            f"assemble_s="
-                            f"{windowed['windowed_assemble_seconds']:.2f}"
-                            + (
-                                f" rel_max={windowed_rel_max:.3e}"
-                                if windowed_rel_max != ""
-                                else ""
-                            ),
-                            flush=True,
-                        )
+                            print(
+                                f"  [row] chan={chan_regular_order}/"
+                                f"{chan_radial_order} "
+                                f"p_star={p_star} "
+                                f"smooth={smooth_order} "
+                                f"windowed={windowed['windowed_status']} "
+                                f"assemble_s="
+                                f"{windowed['windowed_assemble_seconds']:.2f}"
+                                + (
+                                    f" rel_max={windowed_rel_max:.3e}"
+                                    if windowed_rel_max != ""
+                                    else ""
+                                ),
+                                flush=True,
+                            )
 
-                        row = {key: "" for key in FIELDS}
-                        row.update(
-                            {
-                                "case_id": (
-                                    f"{kernel.lower()}{dim}d-mu{mu:g}"
-                                    f"-p{p_star}-s{smooth_order}"
-                                ),
-                                "mode": mode,
-                                "dim": dim,
-                                "kernel": kernel,
-                                "parameter_name": PARAMETER_NAMES[kernel],
-                                "parameter_value": mu,
-                                "theta": theta,
-                                "window_theta": window_theta,
-                                "q_order": q_order,
-                                "source_box_level": source_level,
-                                "root_extent": root_extent,
-                                "box_extent": box_extent,
-                                "n_reduced_entries": n_entries,
-                                "p_star": p_star,
-                                "smooth_quad_order_requested": smooth_order,
-                                "chan_regular_order": chan_regular_order,
-                                "chan_radial_order": chan_radial_order,
-                                "channel_build_was_cold": channels[
-                                    "channel_build_was_cold"
-                                ],
-                                "channel_build_seconds": channels[
-                                    "channel_build_seconds"
-                                ],
-                                "classical_tolerance": CLASSICAL_TOLERANCE,
-                                "classical_channel_regular_order": (
-                                    classical_channel_orders[0]
-                                ),
-                                "classical_channel_radial_order": (
-                                    classical_channel_orders[1]
-                                ),
-                                "direct_loose_regular_order": (
-                                    direct_policies[0][0]
-                                ),
-                                "direct_loose_radial_order": (
-                                    direct_policies[0][1]
-                                ),
-                                "direct_loose_status": loose["status"],
-                                "direct_loose_build_seconds": loose[
-                                    "build_seconds"
-                                ],
-                                "direct_tight_regular_order": (
-                                    direct_policies[1][0]
-                                ),
-                                "direct_tight_radial_order": (
-                                    direct_policies[1][1]
-                                ),
-                                "direct_tight_status": tight["status"],
-                                "direct_tight_build_seconds": tight[
-                                    "build_seconds"
-                                ],
-                                "direct_policy_rel_max_entry_floor": (
-                                    floor_rel_max
-                                ),
-                                "direct_reference_policy": reference_policy,
-                                "windowed_vs_direct_rel_max_entry": (
-                                    windowed_rel_max
-                                ),
-                                "windowed_vs_direct_rel_l2": windowed_rel_l2,
-                                "classical_vs_direct_rel_max_entry": (
-                                    classical_rel_max
-                                ),
-                                "classical_vs_direct_rel_l2": (
-                                    classical_rel_l2
-                                ),
-                            }
-                        )
-                        for key, value in windowed.items():
-                            if key != "values" and key in FIELDS:
-                                row[key] = value
-                        if "smooth_quad_order_used" in windowed:
-                            row["smooth_quad_order_used"] = windowed[
-                                "smooth_quad_order_used"
-                            ]
-                        for key, value in classical.items():
-                            if key != "values" and key in FIELDS:
-                                row[key] = value
-                        rows.append(row)
+                            row = {key: "" for key in FIELDS}
+                            row.update(
+                                {
+                                    "case_id": (
+                                        f"{kernel.lower()}{dim}d-mu{mu:g}"
+                                        f"-{chan_tag}"
+                                        f"-p{p_star}-s{smooth_order}"
+                                    ),
+                                    "mode": mode,
+                                    "dim": dim,
+                                    "kernel": kernel,
+                                    "parameter_name": PARAMETER_NAMES[kernel],
+                                    "parameter_value": mu,
+                                    "theta": theta,
+                                    "window_theta": window_theta,
+                                    "q_order": q_order,
+                                    "source_box_level": source_level,
+                                    "root_extent": root_extent,
+                                    "box_extent": box_extent,
+                                    "n_reduced_entries": n_entries,
+                                    "p_star": p_star,
+                                    "smooth_quad_order_requested": (
+                                        smooth_order
+                                    ),
+                                    "chan_regular_order": chan_regular_order,
+                                    "chan_radial_order": chan_radial_order,
+                                    "channel_build_was_cold": family[
+                                        "channel_build_was_cold"
+                                    ],
+                                    "channel_build_seconds": family[
+                                        "channel_build_seconds"
+                                    ],
+                                    "classical_tolerance": CLASSICAL_TOLERANCE,
+                                    "classical_channel_regular_order": (
+                                        classical_channel_orders[0]
+                                    ),
+                                    "classical_channel_radial_order": (
+                                        classical_channel_orders[1]
+                                    ),
+                                    "direct_loose_regular_order": (
+                                        direct_policies[0][0]
+                                    ),
+                                    "direct_loose_radial_order": (
+                                        direct_policies[0][1]
+                                    ),
+                                    "direct_loose_status": loose["status"],
+                                    "direct_loose_build_seconds": loose[
+                                        "build_seconds"
+                                    ],
+                                    "direct_tight_regular_order": (
+                                        direct_policies[1][0]
+                                    ),
+                                    "direct_tight_radial_order": (
+                                        direct_policies[1][1]
+                                    ),
+                                    "direct_tight_status": tight["status"],
+                                    "direct_tight_build_seconds": tight[
+                                        "build_seconds"
+                                    ],
+                                    "direct_policy_rel_max_entry_floor": (
+                                        floor_rel_max
+                                    ),
+                                    "direct_reference_policy": (
+                                        reference_policy
+                                    ),
+                                    "windowed_vs_direct_rel_max_entry": (
+                                        windowed_rel_max
+                                    ),
+                                    "windowed_vs_direct_rel_l2": (
+                                        windowed_rel_l2
+                                    ),
+                                    "classical_vs_direct_rel_max_entry": (
+                                        classical_rel_max
+                                    ),
+                                    "classical_vs_direct_rel_l2": (
+                                        classical_rel_l2
+                                    ),
+                                }
+                            )
+                            for key, value in windowed.items():
+                                if key != "values" and key in FIELDS:
+                                    row[key] = value
+                            if "smooth_quad_order_used" in windowed:
+                                row["smooth_quad_order_used"] = windowed[
+                                    "smooth_quad_order_used"
+                                ]
+                            for key, value in classical.items():
+                                if key != "values" and key in FIELDS:
+                                    row[key] = value
+                            rows.append(row)
 
     total_seconds = time.perf_counter() - sweep_start
     for row in rows:
@@ -811,6 +881,13 @@ def main() -> int:
         help="'regular,radial' Duffy orders for classical channel builds",
     )
     parser.add_argument(
+        "--chan-orders",
+        help="semicolon-separated 'regular,radial' Duffy orders for the "
+        "windowed channel builds, e.g. '48,61;64,121'; each pair is swept "
+        "as its own family with its own channel cache.  Default: the single "
+        "per-dimension tested pair (2D: 48,61; 3D: 20,61)",
+    )
+    parser.add_argument(
         "--cache-dir",
         type=Path,
         default=Path("build/benchmarks/windowed-rke-cache"),
@@ -857,6 +934,11 @@ def main() -> int:
         parser.error("--mus entries must be positive")
     direct_policies = _parse_direct_policies(args.direct_policies)
     classical_channel_orders = _parse_order_pair(args.classical_channel_orders)
+    # Both smoke and full default to the single tested per-dimension pair;
+    # a channel-order sweep is always requested explicitly.
+    chan_orders = (
+        _parse_order_pairs(args.chan_orders) if args.chan_orders else None
+    )
 
     rows, run_info = run_sweep(
         mode=args.mode,
@@ -871,6 +953,7 @@ def main() -> int:
         mus=mus,
         direct_policies=direct_policies,
         classical_channel_orders=classical_channel_orders,
+        chan_orders=chan_orders,
         cache_dir=args.cache_dir,
         skip_3d_tight=args.skip_3d_tight,
     )
@@ -893,6 +976,11 @@ def main() -> int:
         "mus": mus,
         "direct_policies": [list(policy) for policy in direct_policies],
         "classical_channel_orders": list(classical_channel_orders),
+        "chan_orders": (
+            [list(pair) for pair in chan_orders]
+            if chan_orders is not None
+            else None
+        ),
         "classical_tolerance": CLASSICAL_TOLERANCE,
         "cache_dir": str(args.cache_dir),
         "skip_3d_tight": args.skip_3d_tight,

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -648,6 +648,8 @@ def run_sweep(
     cache_dir: Path,
     skip_3d_tight: bool,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if mode not in ("smoke", "full"):
+        raise ValueError("mode must be 'smoke' or 'full'")
     _require_finite_positive(root_extent, "root_extent")
     _require_finite_positive(window_theta, "window_theta")
     dims = [_require_integer(dim, "dim") for dim in dims]
@@ -655,6 +657,14 @@ def run_sweep(
         raise ValueError("at least one dimension is required")
     if any(dim not in (2, 3) for dim in dims):
         raise ValueError("dim entries must be 2 or 3")
+    kernels = list(kernels)
+    if not kernels:
+        raise ValueError("at least one kernel is required")
+    unknown_kernels = [
+        kernel for kernel in kernels if kernel not in PARAMETER_NAMES
+    ]
+    if unknown_kernels:
+        raise ValueError(f"unknown kernel: {unknown_kernels[0]}")
     if q_order_override is not None:
         q_order_override = _require_integer(
             q_order_override, "q_order_override", minimum=1
@@ -666,11 +676,18 @@ def run_sweep(
     p_stars = [
         _require_integer(p_star, "p_star", minimum=1) for p_star in p_stars
     ]
+    if not p_stars:
+        raise ValueError("at least one p_star is required")
     smooth_orders = [
         _require_integer(order, "smooth_order", minimum=1)
         for order in smooth_orders
     ]
+    if not smooth_orders:
+        raise ValueError("at least one smooth_order is required")
     if mus is not None:
+        mus = list(mus)
+        if not mus:
+            raise ValueError("at least one mu is required when mus is provided")
         for mu in mus:
             _require_finite_positive(mu, "mu")
     direct_policies = [
@@ -700,6 +717,11 @@ def run_sweep(
             _require_usable_order_pair(policy, "channel policy")
             for policy in chan_orders
         ]
+        if not chan_orders:
+            raise ValueError(
+                "at least one channel policy is required when chan_orders "
+                "is provided"
+            )
 
     from volumential.rke_table_assembly import _resolve_channel_orders
 

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -619,6 +619,9 @@ def _build_direct_table(
                 build_config=build_config,
                 **get_kwargs,
             )
+        values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
+        if not np.all(np.isfinite(values)):
+            raise RuntimeError("direct reference table contains non-finite values")
     except Exception as exc:
         return {
             "status": f"failed: {type(exc).__name__}: {exc}",
@@ -626,7 +629,6 @@ def _build_direct_table(
             "values": None,
         }
     build_seconds = time.perf_counter() - start
-    values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
     return {"status": "ok", "build_seconds": build_seconds, "values": values}
 
 
@@ -723,6 +725,11 @@ def run_sweep(
                 "is provided"
             )
 
+    from volumential.rke_table_assembly import (
+        _require_o1_box_extent,
+        _resolve_channel_orders,
+    )
+
     dimension_configs: dict[int, tuple[int, int, float, list[float]]] = {}
     mus_by_dim: dict[int, list[float]] = {}
     for dim in sorted(dims):
@@ -738,6 +745,7 @@ def run_sweep(
         )
         box_extent = float(root_extent) * 0.5**source_level
         _require_finite_positive(box_extent, "box_extent")
+        _require_o1_box_extent(box_extent)
         dim_mus = sorted(
             mus
             if mus is not None
@@ -749,8 +757,6 @@ def run_sweep(
             q_order, source_level, box_extent, dim_mus
         )
         mus_by_dim[dim] = dim_mus
-
-    from volumential.rke_table_assembly import _resolve_channel_orders
 
     sweep_start = time.perf_counter()
     cache_dir.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -10,11 +10,11 @@ cross-deviations:
 (b) classical series RKE assembly (:func:`assemble_parameterized_table`) at a
     matching certified tolerance, recording the refusal kind when the
     classical certificate cannot be issued (uncertifiable truncation or
-    ill-conditioned recombination).  Its canonical channels are materialized
-    by an untimed warm-up call, so ``classical_assemble_seconds`` is the
-    marginal recombination cost and is directly comparable to
-    ``windowed_assemble_seconds``; the one-off construction is reported
-    separately as ``classical_channel_build_seconds``;
+    ill-conditioned recombination).  A separately timed warm-up call prepares
+    any missing canonical channels.  ``classical_warmup_seconds`` records that
+    complete first attempt, including cache loading, possible channel builds,
+    and recombination; ``classical_assemble_seconds`` records a second
+    warm-cache end-to-end assembly, including channel loading;
 (c) direct fixed-parameter builds through the table manager at two Duffy
     quadrature policies, whose mutual disagreement estimates the reference
     floor below which assembled-vs-direct deviations are quadrature noise.
@@ -22,7 +22,8 @@ cross-deviations:
 Deviations are reported against the tight direct policy as both relative
 max-entry and relative L2 over the symmetry-reduced entries.  Windowed
 channel families are built (or reused) once per ``(dim, q_order, level,
-window_theta, channel quadrature orders)`` from a per-family cache, so the
+root_extent, window_theta, channel quadrature orders)`` from a per-family
+cache, so the
 one-off channel build cost and the marginal per-parameter assembly cost are
 recorded separately.  The windowed channel quadrature orders are themselves
 sweepable via ``--chan-orders``; the classical and direct reference builds do
@@ -37,12 +38,12 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import operator
 import time
 from pathlib import Path
 from typing import Any
 
 import numpy as np
-
 
 FIELDS = (
     "case_id",
@@ -80,8 +81,7 @@ FIELDS = (
     "classical_n_series_terms",
     "classical_channel_count",
     "classical_condition_number",
-    "classical_build_was_cold",
-    "classical_channel_build_seconds",
+    "classical_warmup_seconds",
     "classical_assemble_seconds",
     "classical_payload_bytes",
     "classical_channel_regular_order",
@@ -137,6 +137,62 @@ def _default_mus(mode: str, window_theta: float, box_extent: float):
     ]
 
 
+def _exact_float_token(value: float) -> str:
+    """Filename-safe token preserving the exact binary64 value."""
+    return float(value).hex()
+
+
+def _parameter_identity_token(value: float) -> str:
+    """Readable parameter prefix plus an exact collision-free identity."""
+    return f"{float(value):g}-{_exact_float_token(value)}"
+
+
+def _classical_cache_path(
+    cache_dir: Path,
+    dim: int,
+    q_order: int,
+    root_extent: float,
+    channel_orders: tuple[int, int],
+) -> Path:
+    """Classical cache identity including file-wide geometry and policy."""
+    root_token = _exact_float_token(root_extent)
+    regular_order, radial_order = channel_orders
+    return cache_dir / (
+        f"classical-channels-d{int(dim)}-q{int(q_order)}"
+        f"-r{root_token}-c{int(regular_order)}x{int(radial_order)}.sqlite"
+    )
+
+
+def _require_finite_positive(value: float, name: str) -> None:
+    if not np.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be finite and positive")
+
+
+def _require_integer(value, name: str, *, minimum=None) -> int:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        result = operator.index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    result = int(result)
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return result
+
+
+def _require_usable_order_pair(
+    pair: tuple[int, int], name: str
+) -> tuple[int, int]:
+    regular_order = _require_integer(pair[0], f"{name} regular order")
+    radial_order = _require_integer(pair[1], f"{name} radial order")
+    if regular_order < 2:
+        raise ValueError(f"{name} regular order must be >= 2")
+    if radial_order < 7:
+        raise ValueError(f"{name} radial order must be >= 7")
+    return regular_order, radial_order
+
+
 def _parse_csv_ints(raw: str) -> list[int]:
     values = [int(part.strip()) for part in raw.split(",") if part.strip()]
     if not values:
@@ -168,6 +224,23 @@ def _parse_direct_policies(raw: str) -> list[tuple[int, int]]:
         raise ValueError(
             "exactly two direct policies (loose;tight) are required"
         )
+    policies = [
+        _require_usable_order_pair(policy, "direct policy")
+        for policy in policies
+    ]
+    loose, tight = policies
+    if any(
+        tight_order < loose_order
+        for loose_order, tight_order in zip(loose, tight, strict=True)
+    ):
+        raise ValueError(
+            "tight direct policy must be componentwise >= the loose policy"
+        )
+    if tight == loose:
+        raise ValueError(
+            "tight direct policy must be strictly larger in at least one "
+            "component"
+        )
     return policies
 
 
@@ -183,7 +256,11 @@ def _parse_order_pairs(raw: str) -> list[tuple[int, int]]:
             raise ValueError(
                 "each channel-order policy must be a 'regular,radial' pair"
             )
-        pairs.append((parts[0], parts[1]))
+        pairs.append(
+            _require_usable_order_pair(
+                (parts[0], parts[1]), "channel policy"
+            )
+        )
     if not pairs:
         raise ValueError("expected at least one 'regular,radial' pair")
     return pairs
@@ -193,7 +270,9 @@ def _parse_order_pair(raw: str) -> tuple[int, int]:
     parts = [int(part.strip()) for part in raw.split(",")]
     if len(parts) != 2:
         raise ValueError("expected a 'regular,radial' integer pair")
-    return parts[0], parts[1]
+    return _require_usable_order_pair(
+        (parts[0], parts[1]), "classical channel policy"
+    )
 
 
 def _clear_sqlite_cache(path: Path) -> None:
@@ -234,27 +313,9 @@ def _prepare_windowed_channels(
     chan_radial_order: int,
 ) -> dict[str, Any]:
     """Build (or reload) the windowed channel family once and time it."""
-    from volumential.rke_table_assembly import (
-        _windowed_channel_cache_file,
-        get_windowed_channel_table,
-    )
+    from volumential.rke_table_assembly import get_windowed_channel_table
 
     was_cold = False
-    for m in range(max_p_star):
-        cache_file, _ = _windowed_channel_cache_file(
-            cache_path,
-            dim,
-            q_order,
-            source_box_level,
-            root_extent,
-            window_theta,
-            m,
-            chan_regular_order,
-            chan_radial_order,
-        )
-        if not cache_file.is_file():
-            was_cold = True
-
     start = time.perf_counter()
     base_channel = None
     for m in range(max_p_star):
@@ -269,6 +330,17 @@ def _prepare_windowed_channels(
             chan_regular_order=chan_regular_order,
             chan_radial_order=chan_radial_order,
         )
+        disposition = getattr(
+            channel,
+            "_windowed_cache_disposition",
+            getattr(channel, "_cache_disposition", None),
+        )
+        if disposition not in ("hit", "rebuilt"):
+            raise RuntimeError(
+                "windowed channel table did not report a valid private "
+                "cache disposition"
+            )
+        was_cold = was_cold or disposition == "rebuilt"
         if m == 0:
             base_channel = channel
     build_seconds = time.perf_counter() - start
@@ -300,6 +372,8 @@ def _run_windowed(
     n_reduced_entries: int,
 ) -> dict[str, Any]:
     from volumential.rke_table_assembly import (
+        RKEWindowConditioningError,
+        RKEWindowCoverageError,
         assemble_windowed_parameterized_table,
     )
 
@@ -319,9 +393,16 @@ def _run_windowed(
             chan_regular_order=chan_regular_order,
             chan_radial_order=chan_radial_order,
         )
-    except (ValueError, RuntimeError) as exc:
+    except (RKEWindowCoverageError, RKEWindowConditioningError) as exc:
         return {
             "windowed_status": "refused",
+            "windowed_refusal": f"{type(exc).__name__}: {exc}",
+            "windowed_assemble_seconds": time.perf_counter() - start,
+            "values": None,
+        }
+    except (ValueError, RuntimeError, NotImplementedError) as exc:
+        return {
+            "windowed_status": "failed",
             "windowed_refusal": f"{type(exc).__name__}: {exc}",
             "windowed_assemble_seconds": time.perf_counter() - start,
             "values": None,
@@ -380,23 +461,20 @@ def _run_classical(
     channel_orders: tuple[int, int],
     entry_ids,
     n_reduced_entries: int,
-    warm_channel_counts: dict[Any, int],
 ) -> dict[str, Any]:
-    """Classical assembly with the one-time channel build kept out of the
-    timed region.
+    """Classical assembly with a separate warm-up and warm-cache timing.
 
-    ``assemble_parameterized_table`` builds whatever canonical channels the
-    requested truncation order needs on first use, so a single timed call
-    conflates that one-off construction with the marginal per-parameter
-    recombination and is not comparable to ``windowed_assemble_seconds``
-    (whose channel family is prepared separately).  An untimed warm-up call
-    materializes the channels first; the timed call that follows is then
-    marginal, exactly like the windowed one.  The warm-up cost is reported as
-    ``classical_channel_build_seconds`` and ``classical_build_was_cold``
-    records whether it actually had to extend the channel family.
+    The first call may load or build canonical channels and performs a full
+    recombination, so its elapsed time is reported only as
+    ``classical_warmup_seconds``.  The second call measures the repeatable
+    warm-cache path, including channel deserialization and recombination.
     """
     from volumential.nearfield_potential_table import DuffyBuildConfig
-    from volumential.rke_table_assembly import assemble_parameterized_table
+    from volumential.rke_table_assembly import (
+        RKEConditioningError,
+        RKETruncationError,
+        assemble_parameterized_table,
+    )
 
     build_config = DuffyBuildConfig(
         radial_rule="tanh-sinh-fast",
@@ -418,39 +496,50 @@ def _run_classical(
             build_config=build_config,
         )
 
-    # The channel family depends on the geometry and the Duffy orders only,
-    # never on the kernel or the parameter; the parameter enters solely
-    # through how many of those channels the truncation order asks for.
-    warm_key = (
-        str(cache_path),
-        int(dim),
-        int(q_order),
-        int(source_box_level),
-        float(root_extent),
-        tuple(channel_orders),
-    )
-    already_built = warm_channel_counts.get(warm_key, 0)
+    start = time.perf_counter()
+    try:
+        assemble()
+    except (RKETruncationError, RKEConditioningError) as exc:
+        return {
+            "classical_status": "refused",
+            "classical_refusal": exc.refusal_kind,
+            "classical_refusal_detail": f"{type(exc).__name__}: {exc}",
+            "classical_warmup_seconds": time.perf_counter() - start,
+            "classical_assemble_seconds": "",
+            "values": None,
+        }
+    except (ValueError, RuntimeError, NotImplementedError) as exc:
+        return {
+            "classical_status": "failed",
+            "classical_refusal": "",
+            "classical_refusal_detail": f"{type(exc).__name__}: {exc}",
+            "classical_warmup_seconds": time.perf_counter() - start,
+            "classical_assemble_seconds": "",
+            "values": None,
+        }
+    warmup_seconds = time.perf_counter() - start
 
     start = time.perf_counter()
     try:
-        _, warm_certificate = assemble()
-    except (ValueError, RuntimeError, NotImplementedError) as exc:
-        # A refusal is a property of the parameter, not of the timing split:
-        # classify and report it exactly as a single timed call would have.
+        table, certificate = assemble()
+    except (RKETruncationError, RKEConditioningError) as exc:
         return {
             "classical_status": "refused",
-            "classical_refusal": _classify_classical_refusal(exc),
+            "classical_refusal": exc.refusal_kind,
             "classical_refusal_detail": f"{type(exc).__name__}: {exc}",
-            "classical_assemble_seconds": time.perf_counter() - start,
+            "classical_warmup_seconds": warmup_seconds,
+            "classical_assemble_seconds": "",
             "values": None,
         }
-    build_seconds = time.perf_counter() - start
-    warm_channel_count = int(warm_certificate["channel_count"])
-    was_cold = warm_channel_count > already_built
-    warm_channel_counts[warm_key] = max(already_built, warm_channel_count)
-
-    start = time.perf_counter()
-    table, certificate = assemble()
+    except (ValueError, RuntimeError, NotImplementedError) as exc:
+        return {
+            "classical_status": "failed",
+            "classical_refusal": "",
+            "classical_refusal_detail": f"{type(exc).__name__}: {exc}",
+            "classical_warmup_seconds": warmup_seconds,
+            "classical_assemble_seconds": "",
+            "values": None,
+        }
     assemble_seconds = time.perf_counter() - start
     values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
     channel_count = int(certificate["channel_count"])
@@ -461,8 +550,7 @@ def _run_classical(
         "classical_n_series_terms": certificate["n_series_terms"],
         "classical_channel_count": channel_count,
         "classical_condition_number": certificate["condition_number"],
-        "classical_build_was_cold": was_cold,
-        "classical_channel_build_seconds": build_seconds,
+        "classical_warmup_seconds": warmup_seconds,
         "classical_assemble_seconds": assemble_seconds,
         # channel_count real float64 channel tables over the reduced entries
         "classical_payload_bytes": int(
@@ -560,6 +648,42 @@ def run_sweep(
     cache_dir: Path,
     skip_3d_tight: bool,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    _require_finite_positive(root_extent, "root_extent")
+    _require_finite_positive(window_theta, "window_theta")
+    dims = [_require_integer(dim, "dim") for dim in dims]
+    if any(dim not in (2, 3) for dim in dims):
+        raise ValueError("dim entries must be 2 or 3")
+    if q_order_override is not None:
+        q_order_override = _require_integer(
+            q_order_override, "q_order_override", minimum=1
+        )
+    if source_level_override is not None:
+        source_level_override = _require_integer(
+            source_level_override, "source_level_override", minimum=0
+        )
+    p_stars = [
+        _require_integer(p_star, "p_star", minimum=1) for p_star in p_stars
+    ]
+    smooth_orders = [
+        _require_integer(order, "smooth_order", minimum=1)
+        for order in smooth_orders
+    ]
+    if mus is not None:
+        for mu in mus:
+            _require_finite_positive(mu, "mu")
+    direct_policies = [
+        _require_usable_order_pair(policy, "direct policy")
+        for policy in direct_policies
+    ]
+    classical_channel_orders = _require_usable_order_pair(
+        classical_channel_orders, "classical channel policy"
+    )
+    if chan_orders is not None:
+        chan_orders = [
+            _require_usable_order_pair(policy, "channel policy")
+            for policy in chan_orders
+        ]
+
     from volumential.rke_table_assembly import _resolve_channel_orders
 
     sweep_start = time.perf_counter()
@@ -569,9 +693,6 @@ def run_sweep(
     rows: list[dict[str, Any]] = []
     channel_prep_records: dict[str, Any] = {}
     mus_by_dim: dict[int, list[float]] = {}
-    # Highest classical channel count already materialized per channel-cache
-    # key, so ``_run_classical`` can report whether its warm-up was cold.
-    warm_channel_counts: dict[Any, int] = {}
 
     for dim in sorted(dims):
         q_order = (
@@ -601,8 +722,12 @@ def run_sweep(
                 for regular, radial in chan_orders
             ]
 
-        classical_cache = (
-            cache_dir / f"classical-channels-d{dim}-q{q_order}.sqlite"
+        classical_cache = _classical_cache_path(
+            cache_dir,
+            dim,
+            q_order,
+            root_extent,
+            classical_channel_orders,
         )
 
         print(
@@ -676,7 +801,7 @@ def run_sweep(
         for kernel in kernels:
             for mu in dim_mus:
                 theta = float(mu) * box_extent
-                mu_tag = f"{mu:g}".replace("-", "m").replace(".", "p")
+                mu_tag = _parameter_identity_token(mu)
 
                 policy_results = []
                 for policy_index, (regular, radial) in enumerate(
@@ -744,7 +869,6 @@ def run_sweep(
                     channel_orders=classical_channel_orders,
                     entry_ids=entry_ids,
                     n_reduced_entries=n_entries,
-                    warm_channel_counts=warm_channel_counts,
                 )
                 if (
                     classical["values"] is not None
@@ -828,7 +952,7 @@ def run_sweep(
                             row.update(
                                 {
                                     "case_id": (
-                                        f"{kernel.lower()}{dim}d-mu{mu:g}"
+                                        f"{kernel.lower()}{dim}d-mu{mu_tag}"
                                         f"-{chan_tag}"
                                         f"-p{p_star}-s{smooth_order}"
                                     ),
@@ -1010,6 +1134,12 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    try:
+        _require_finite_positive(args.root_extent, "--root-extent")
+        _require_finite_positive(args.window_theta, "--window-theta")
+    except ValueError as exc:
+        parser.error(str(exc))
+
     smoke = args.mode == "smoke"
     dims = _parse_csv_ints(args.dim or ("2" if smoke else "2,3"))
     if any(dim not in (2, 3) for dim in dims):
@@ -1032,18 +1162,33 @@ def main() -> int:
     smooth_orders = _parse_csv_ints(
         args.smooth_orders or ("16" if smoke else "8,16,24,32")
     )
+    if any(order < 1 for order in smooth_orders):
+        parser.error("--smooth-orders entries must be >= 1")
+    if args.q_order is not None and args.q_order < 1:
+        parser.error("--q-order must be >= 1")
+    if args.source_level is not None and args.source_level < 0:
+        parser.error("--source-level must be >= 0")
     # ``None`` defers the ladder to run_sweep, which resolves it against each
     # dimension's own box extent.
-    mus = sorted(_parse_csv_floats(args.mus)) if args.mus else None
-    if mus is not None and any(mu <= 0 for mu in mus):
-        parser.error("--mus entries must be positive")
-    direct_policies = _parse_direct_policies(args.direct_policies)
-    classical_channel_orders = _parse_order_pair(args.classical_channel_orders)
+    try:
+        mus = sorted(_parse_csv_floats(args.mus)) if args.mus else None
+        if mus is not None:
+            for mu in mus:
+                _require_finite_positive(mu, "--mus entries")
+        direct_policies = _parse_direct_policies(args.direct_policies)
+        classical_channel_orders = _parse_order_pair(
+            args.classical_channel_orders
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     # Both smoke and full default to the single tested per-dimension pair;
     # a channel-order sweep is always requested explicitly.
-    chan_orders = (
-        _parse_order_pairs(args.chan_orders) if args.chan_orders else None
-    )
+    try:
+        chan_orders = (
+            _parse_order_pairs(args.chan_orders) if args.chan_orders else None
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
 
     rows, run_info = run_sweep(
         mode=args.mode,
@@ -1102,7 +1247,13 @@ def main() -> int:
     # reference builds all failed, produces a CSV with no usable comparison
     # in it; that must not be indistinguishable from success (this driver is
     # also a CI smoke check).
-    refused = sum(1 for row in rows if row["windowed_status"] != "ok")
+    refused = sum(1 for row in rows if row["windowed_status"] == "refused")
+    windowed_failed = sum(
+        1 for row in rows if row["windowed_status"] == "failed"
+    )
+    classical_failed = sum(
+        1 for row in rows if row["classical_status"] == "failed"
+    )
     no_reference = sum(1 for row in rows if not row["direct_reference_policy"])
     usable = sum(
         1
@@ -1111,15 +1262,17 @@ def main() -> int:
     )
     print(
         f"[done] rows={len(rows)} usable={usable} "
-        f"windowed_refused={refused} no_direct_reference={no_reference} "
+        f"windowed_refused={refused} windowed_failed={windowed_failed} "
+        f"classical_failed={classical_failed} "
+        f"no_direct_reference={no_reference} "
         f"csv={csv_path} json={json_path} "
         f"total_s={run_info['total_seconds']:.1f}",
         flush=True,
     )
-    if not usable:
+    if windowed_failed or classical_failed or not usable:
         print(
-            "[error] no row produced both a windowed 'ok' assembly and a "
-            "usable direct reference",
+            "[error] sweep has unexpected assembly failures or no row with "
+            "both a windowed 'ok' assembly and a usable direct reference",
             flush=True,
         )
         return 1

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -1156,7 +1156,10 @@ def main() -> int:
         parser.error(str(exc))
 
     smoke = args.mode == "smoke"
-    dims = _parse_csv_ints(args.dim or ("2" if smoke else "2,3"))
+    try:
+        dims = _parse_csv_ints(args.dim or ("2" if smoke else "2,3"))
+    except ValueError as exc:
+        parser.error(str(exc))
     if any(dim not in (2, 3) for dim in dims):
         parser.error("--dim entries must be 2 or 3")
     kernel_map = {"helmholtz": "Helmholtz", "yukawa": "Yukawa"}
@@ -1171,12 +1174,15 @@ def main() -> int:
     if not kernels:
         parser.error("at least one kernel is required")
 
-    p_stars = _parse_csv_ints(args.p_star)
+    try:
+        p_stars = _parse_csv_ints(args.p_star)
+        smooth_orders = _parse_csv_ints(
+            args.smooth_orders or ("16" if smoke else "8,16,24,32")
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     if any(p < 1 for p in p_stars):
         parser.error("--p-star entries must be >= 1")
-    smooth_orders = _parse_csv_ints(
-        args.smooth_orders or ("16" if smoke else "8,16,24,32")
-    )
     if any(order < 1 for order in smooth_orders):
         parser.error("--smooth-orders entries must be >= 1")
     if args.q_order is not None and args.q_order < 1:
@@ -1270,6 +1276,12 @@ def main() -> int:
         1 for row in rows if row["classical_status"] == "failed"
     )
     no_reference = sum(1 for row in rows if not row["direct_reference_policy"])
+    direct_failed = sum(
+        1
+        for row in rows
+        if row["direct_loose_status"].startswith("failed:")
+        or row["direct_tight_status"].startswith("failed:")
+    )
     usable = sum(
         1
         for row in rows
@@ -1279,12 +1291,12 @@ def main() -> int:
         f"[done] rows={len(rows)} usable={usable} "
         f"windowed_refused={refused} windowed_failed={windowed_failed} "
         f"classical_failed={classical_failed} "
-        f"no_direct_reference={no_reference} "
+        f"direct_failed={direct_failed} no_direct_reference={no_reference} "
         f"csv={csv_path} json={json_path} "
         f"total_s={run_info['total_seconds']:.1f}",
         flush=True,
     )
-    if windowed_failed or classical_failed or not usable:
+    if windowed_failed or classical_failed or direct_failed or not usable:
         print(
             "[error] sweep has unexpected assembly failures or no row with "
             "both a windowed 'ok' assembly and a usable direct reference",

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -697,7 +697,7 @@ def run_sweep(
         raise ValueError("at least one smooth_order is required")
     _require_unique(smooth_orders, "smooth_order entries")
     if mus is not None:
-        mus = list(mus)
+        mus = [float(mu) for mu in mus]
         if not mus:
             raise ValueError("at least one mu is required when mus is provided")
         for mu in mus:
@@ -1263,6 +1263,16 @@ def main() -> int:
         chan_orders = (
             _parse_order_pairs(args.chan_orders) if args.chan_orders else None
         )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    try:
+        _require_unique(dims, "--dim entries")
+        _require_unique(kernels, "--kernels entries")
+        _require_unique(p_stars, "--p-star entries")
+        _require_unique(smooth_orders, "--smooth-orders entries")
+        if mus is not None:
+            _require_unique(mus, "--mus entries")
     except ValueError as exc:
         parser.error(str(exc))
 

--- a/benchmarks/windowed_rke_sweep.py
+++ b/benchmarks/windowed_rke_sweep.py
@@ -1,0 +1,917 @@
+#!/usr/bin/env python3
+"""Table-level certificate sweep for windowed RKE near-field assembly.
+
+For each swept fixed parameter the driver produces the same near-field table
+three ways and records certificates, wall times, payload accounting, and
+cross-deviations:
+
+(a) windowed RKE assembly (:func:`assemble_windowed_parameterized_table`),
+    swept over ``p_star`` and the smooth-remainder quadrature order;
+(b) classical series RKE assembly (:func:`assemble_parameterized_table`) at a
+    matching certified tolerance, recording the refusal kind when the
+    classical certificate cannot be issued (uncertifiable truncation or
+    ill-conditioned recombination);
+(c) direct fixed-parameter builds through the table manager at two Duffy
+    quadrature policies, whose mutual disagreement estimates the reference
+    floor below which assembled-vs-direct deviations are quadrature noise.
+
+Deviations are reported against the tight direct policy as both relative
+max-entry and relative L2 over the symmetry-reduced entries.  Windowed
+channel families are built (or reused) once per ``(dim, q_order, level,
+window_theta)`` from a shared cache, so the one-off channel build cost and
+the marginal per-parameter assembly cost are recorded separately.
+
+Smoke mode is intended for CI/local validation.  Full mode is intended for
+metadata-wrapped runs on a controlled remote compute host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+FIELDS = (
+    "case_id",
+    "mode",
+    "dim",
+    "kernel",
+    "parameter_name",
+    "parameter_value",
+    "theta",
+    "window_theta",
+    "q_order",
+    "source_box_level",
+    "root_extent",
+    "box_extent",
+    "n_reduced_entries",
+    "p_star",
+    "smooth_quad_order_requested",
+    "smooth_quad_order_used",
+    "chan_regular_order",
+    "chan_radial_order",
+    "channel_build_was_cold",
+    "channel_build_seconds",
+    "windowed_status",
+    "windowed_refusal",
+    "windowed_assemble_seconds",
+    "windowed_condition_number",
+    "windowed_coefficient_bound",
+    "windowed_remainder_peak",
+    "windowed_truncation_tail_bound",
+    "windowed_payload_bytes",
+    "classical_status",
+    "classical_refusal",
+    "classical_refusal_detail",
+    "classical_tolerance",
+    "classical_n_series_terms",
+    "classical_channel_count",
+    "classical_condition_number",
+    "classical_assemble_seconds",
+    "classical_payload_bytes",
+    "classical_channel_regular_order",
+    "classical_channel_radial_order",
+    "direct_loose_regular_order",
+    "direct_loose_radial_order",
+    "direct_loose_status",
+    "direct_loose_build_seconds",
+    "direct_tight_regular_order",
+    "direct_tight_radial_order",
+    "direct_tight_status",
+    "direct_tight_build_seconds",
+    "direct_policy_rel_max_entry_floor",
+    "direct_reference_policy",
+    "windowed_vs_direct_rel_max_entry",
+    "windowed_vs_direct_rel_l2",
+    "classical_vs_direct_rel_max_entry",
+    "classical_vs_direct_rel_l2",
+    "benchmark_total_seconds",
+)
+
+PARAMETER_NAMES = {"Helmholtz": "k", "Yukawa": "lambda"}
+DEFAULT_Q_ORDER = {2: 3, 3: 2}
+DEFAULT_SOURCE_LEVEL = {2: 3, 3: 2}
+CLASSICAL_TOLERANCE = 1.0e-11
+
+
+def _parse_csv_ints(raw: str) -> list[int]:
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("expected at least one integer value")
+    return values
+
+
+def _parse_csv_floats(raw: str) -> list[float]:
+    values = [float(part.strip()) for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("expected at least one float value")
+    return values
+
+
+def _parse_direct_policies(raw: str) -> list[tuple[int, int]]:
+    """Parse ``'regular,radial;regular,radial'`` into [(loose), (tight)]."""
+    policies = []
+    for chunk in raw.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = [int(part.strip()) for part in chunk.split(",")]
+        if len(parts) != 2:
+            raise ValueError(
+                "each direct policy must be a 'regular,radial' pair"
+            )
+        policies.append((parts[0], parts[1]))
+    if len(policies) != 2:
+        raise ValueError(
+            "exactly two direct policies (loose;tight) are required"
+        )
+    return policies
+
+
+def _parse_order_pair(raw: str) -> tuple[int, int]:
+    parts = [int(part.strip()) for part in raw.split(",")]
+    if len(parts) != 2:
+        raise ValueError("expected a 'regular,radial' integer pair")
+    return parts[0], parts[1]
+
+
+def _clear_sqlite_cache(path: Path) -> None:
+    for suffix in ("", "-shm", "-wal"):
+        Path(f"{path}{suffix}").unlink(missing_ok=True)
+
+
+def _make_queue():
+    import pyopencl as cl
+
+    ctx = cl.create_some_context(interactive=False)
+    return cl.CommandQueue(ctx)
+
+
+def _relative_deviations(values, reference):
+    """(rel max-entry, rel L2) of ``values`` against ``reference``."""
+    values = np.asarray(values)
+    reference = np.asarray(reference)
+    diff = values.astype(np.complex128) - reference.astype(np.complex128)
+    ref_max = max(float(np.max(np.abs(reference))), 1.0e-300)
+    ref_l2 = max(float(np.linalg.norm(reference)), 1.0e-300)
+    return (
+        float(np.max(np.abs(diff)) / ref_max),
+        float(np.linalg.norm(diff) / ref_l2),
+    )
+
+
+def _prepare_windowed_channels(
+    *,
+    cache_path: Path,
+    dim: int,
+    q_order: int,
+    source_box_level: int,
+    root_extent: float,
+    window_theta: float,
+    max_p_star: int,
+    chan_regular_order: int,
+    chan_radial_order: int,
+) -> dict[str, Any]:
+    """Build (or reload) the windowed channel family once and time it."""
+    from volumential.rke_table_assembly import (
+        _windowed_channel_cache_file,
+        get_windowed_channel_table,
+    )
+
+    was_cold = False
+    for m in range(max_p_star):
+        cache_file, _ = _windowed_channel_cache_file(
+            cache_path,
+            dim,
+            q_order,
+            source_box_level,
+            root_extent,
+            window_theta,
+            m,
+            chan_regular_order,
+            chan_radial_order,
+        )
+        if not cache_file.is_file():
+            was_cold = True
+
+    start = time.perf_counter()
+    base_channel = None
+    for m in range(max_p_star):
+        channel = get_windowed_channel_table(
+            cache_path,
+            dim,
+            q_order,
+            m,
+            source_box_level=source_box_level,
+            root_extent=root_extent,
+            window_theta=window_theta,
+            chan_regular_order=chan_regular_order,
+            chan_radial_order=chan_radial_order,
+        )
+        if m == 0:
+            base_channel = channel
+    build_seconds = time.perf_counter() - start
+
+    entry_ids = np.asarray(base_channel.get_reduced_entry_ids(), dtype=np.int64)
+    return {
+        "entry_ids": entry_ids,
+        "n_reduced_entries": int(entry_ids.size),
+        "channel_build_seconds": build_seconds,
+        "channel_build_was_cold": was_cold,
+    }
+
+
+def _run_windowed(
+    *,
+    cache_path: Path,
+    dim: int,
+    kernel: str,
+    q_order: int,
+    parameter: float,
+    source_box_level: int,
+    root_extent: float,
+    window_theta: float,
+    p_star: int,
+    smooth_quad_order: int,
+    chan_regular_order: int,
+    chan_radial_order: int,
+    entry_ids,
+    n_reduced_entries: int,
+) -> dict[str, Any]:
+    from volumential.rke_table_assembly import (
+        assemble_windowed_parameterized_table,
+    )
+
+    start = time.perf_counter()
+    try:
+        table, certificate = assemble_windowed_parameterized_table(
+            cache_path,
+            dim,
+            kernel,
+            q_order,
+            parameter,
+            source_box_level=source_box_level,
+            root_extent=root_extent,
+            window_theta=window_theta,
+            p_star=p_star,
+            smooth_quad_order=smooth_quad_order,
+            chan_regular_order=chan_regular_order,
+            chan_radial_order=chan_radial_order,
+        )
+    except (ValueError, RuntimeError) as exc:
+        return {
+            "windowed_status": "refused",
+            "windowed_refusal": f"{type(exc).__name__}: {exc}",
+            "windowed_assemble_seconds": time.perf_counter() - start,
+            "values": None,
+        }
+    assemble_seconds = time.perf_counter() - start
+    values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
+    return {
+        "windowed_status": "ok",
+        "windowed_refusal": "",
+        "windowed_assemble_seconds": assemble_seconds,
+        "windowed_condition_number": certificate["condition_number"],
+        "windowed_coefficient_bound": certificate["coefficient_bound"],
+        "windowed_remainder_peak": certificate["remainder_peak"],
+        "windowed_truncation_tail_bound": (
+            certificate["truncation_tail_bound"]
+        ),
+        "smooth_quad_order_used": certificate["smooth_quad_order"],
+        # p_star real float64 channel tables over the reduced entries
+        "windowed_payload_bytes": int(n_reduced_entries * 8 * p_star),
+        "values": values,
+    }
+
+
+def _classify_classical_refusal(exc: BaseException) -> str:
+    message = str(exc)
+    if "cannot certify" in message:
+        return "uncertifiable"
+    if "ill-conditioned" in message:
+        return "ill-conditioned"
+    return type(exc).__name__
+
+
+def _run_classical(
+    *,
+    queue,
+    cache_path: Path,
+    dim: int,
+    kernel: str,
+    q_order: int,
+    parameter: float,
+    source_box_level: int,
+    root_extent: float,
+    channel_orders: tuple[int, int],
+    entry_ids,
+    n_reduced_entries: int,
+) -> dict[str, Any]:
+    from volumential.nearfield_potential_table import DuffyBuildConfig
+    from volumential.rke_table_assembly import assemble_parameterized_table
+
+    build_config = DuffyBuildConfig(
+        radial_rule="tanh-sinh-fast",
+        regular_quad_order=channel_orders[0],
+        radial_quad_order=channel_orders[1],
+    )
+    start = time.perf_counter()
+    try:
+        table, certificate = assemble_parameterized_table(
+            queue,
+            cache_path,
+            dim,
+            kernel,
+            q_order,
+            parameter,
+            source_box_level=source_box_level,
+            root_extent=root_extent,
+            tolerance=CLASSICAL_TOLERANCE,
+            build_config=build_config,
+        )
+    except (ValueError, RuntimeError, NotImplementedError) as exc:
+        return {
+            "classical_status": "refused",
+            "classical_refusal": _classify_classical_refusal(exc),
+            "classical_refusal_detail": f"{type(exc).__name__}: {exc}",
+            "classical_assemble_seconds": time.perf_counter() - start,
+            "values": None,
+        }
+    assemble_seconds = time.perf_counter() - start
+    values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
+    channel_count = int(certificate["channel_count"])
+    return {
+        "classical_status": "ok",
+        "classical_refusal": "",
+        "classical_refusal_detail": "",
+        "classical_n_series_terms": certificate["n_series_terms"],
+        "classical_channel_count": channel_count,
+        "classical_condition_number": certificate["condition_number"],
+        "classical_assemble_seconds": assemble_seconds,
+        # channel_count real float64 channel tables over the reduced entries
+        "classical_payload_bytes": int(
+            n_reduced_entries * 8 * channel_count
+        ),
+        "values": values,
+    }
+
+
+def _build_direct_table(
+    *,
+    queue,
+    cache_path: Path,
+    dim: int,
+    kernel: str,
+    q_order: int,
+    parameter: float,
+    source_box_level: int,
+    root_extent: float,
+    regular_order: int,
+    radial_order: int,
+    entry_ids,
+) -> dict[str, Any]:
+    from volumential.nearfield_potential_table import DuffyBuildConfig
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    build_config = DuffyBuildConfig(
+        radial_rule="tanh-sinh-fast",
+        regular_quad_order=regular_order,
+        radial_quad_order=radial_order,
+    )
+    manager_kwargs: dict[str, Any] = {}
+    get_kwargs: dict[str, Any] = {}
+    if kernel == "Helmholtz":
+        from sumpy.kernel import HelmholtzKernel
+
+        knl = HelmholtzKernel(dim)
+        manager_kwargs["dtype"] = np.complex128
+        get_kwargs["sumpy_knl"] = knl
+        get_kwargs[knl.helmholtz_k_name] = float(parameter)
+        kernel_request = "Helmholtz-Reference"
+    elif kernel == "Yukawa":
+        get_kwargs["lam"] = float(parameter)
+        kernel_request = "Yukawa"
+    else:
+        raise ValueError(f"unknown kernel: {kernel}")
+
+    # A cold build per call keeps the recorded seconds an honest build cost
+    # and prevents force_recompute from resurrecting a cached build config.
+    _clear_sqlite_cache(cache_path)
+    start = time.perf_counter()
+    try:
+        with NearFieldInteractionTableManager(
+            str(cache_path),
+            root_extent=float(root_extent),
+            queue=queue,
+            **manager_kwargs,
+        ) as table_manager:
+            table, _ = table_manager.get_table(
+                dim,
+                kernel_request,
+                q_order,
+                source_box_level=int(source_box_level),
+                force_recompute=True,
+                queue=queue,
+                build_config=build_config,
+                **get_kwargs,
+            )
+    except Exception as exc:
+        return {
+            "status": f"failed: {type(exc).__name__}: {exc}",
+            "build_seconds": time.perf_counter() - start,
+            "values": None,
+        }
+    build_seconds = time.perf_counter() - start
+    values = np.asarray(table.get_entry_data_for_full_indices(entry_ids))
+    return {"status": "ok", "build_seconds": build_seconds, "values": values}
+
+
+def run_sweep(
+    *,
+    mode: str,
+    dims: list[int],
+    kernels: list[str],
+    q_order_override: int | None,
+    source_level_override: int | None,
+    root_extent: float,
+    window_theta: float,
+    p_stars: list[int],
+    smooth_orders: list[int],
+    mus: list[float],
+    direct_policies: list[tuple[int, int]],
+    classical_channel_orders: tuple[int, int],
+    cache_dir: Path,
+    skip_3d_tight: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    from volumential.rke_table_assembly import _resolve_channel_orders
+
+    sweep_start = time.perf_counter()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    queue = _make_queue()
+
+    rows: list[dict[str, Any]] = []
+    channel_prep_records: dict[str, Any] = {}
+
+    for dim in sorted(dims):
+        q_order = (
+            q_order_override
+            if q_order_override is not None
+            else DEFAULT_Q_ORDER[dim]
+        )
+        source_level = (
+            source_level_override
+            if source_level_override is not None
+            else DEFAULT_SOURCE_LEVEL[dim]
+        )
+        box_extent = float(root_extent) * 0.5**int(source_level)
+        chan_regular_order, chan_radial_order = _resolve_channel_orders(
+            dim, None, None
+        )
+
+        windowed_cache = cache_dir / f"windowed-channels-d{dim}-q{q_order}.db"
+        classical_cache = (
+            cache_dir / f"classical-channels-d{dim}-q{q_order}.sqlite"
+        )
+
+        print(
+            f"[config] dim={dim} q_order={q_order} level={source_level} "
+            f"box_extent={box_extent:g} window_theta={window_theta:g} "
+            f"chan_orders={chan_regular_order}/{chan_radial_order}",
+            flush=True,
+        )
+        channels = _prepare_windowed_channels(
+            cache_path=windowed_cache,
+            dim=dim,
+            q_order=q_order,
+            source_box_level=source_level,
+            root_extent=root_extent,
+            window_theta=window_theta,
+            max_p_star=max(p_stars),
+            chan_regular_order=chan_regular_order,
+            chan_radial_order=chan_radial_order,
+        )
+        print(
+            f"[channels] dim={dim} "
+            f"cold={channels['channel_build_was_cold']} "
+            f"build_s={channels['channel_build_seconds']:.2f} "
+            f"n_reduced_entries={channels['n_reduced_entries']}",
+            flush=True,
+        )
+        channel_prep_records[f"dim{dim}"] = {
+            "q_order": q_order,
+            "source_box_level": source_level,
+            "chan_regular_order": chan_regular_order,
+            "chan_radial_order": chan_radial_order,
+            "channel_build_seconds": channels["channel_build_seconds"],
+            "channel_build_was_cold": channels["channel_build_was_cold"],
+            "n_reduced_entries": channels["n_reduced_entries"],
+        }
+        entry_ids = channels["entry_ids"]
+        n_entries = channels["n_reduced_entries"]
+
+        for kernel in kernels:
+            for mu in mus:
+                theta = float(mu) * box_extent
+                mu_tag = f"{mu:g}".replace("-", "m").replace(".", "p")
+
+                policy_results = []
+                for policy_index, (regular, radial) in enumerate(
+                    direct_policies
+                ):
+                    policy_name = "loose" if policy_index == 0 else "tight"
+                    if policy_name == "tight" and dim == 3 and skip_3d_tight:
+                        policy_results.append(
+                            {
+                                "status": "skipped: --skip-3d-tight",
+                                "build_seconds": "",
+                                "values": None,
+                            }
+                        )
+                        continue
+                    direct_cache = cache_dir / (
+                        f"direct-d{dim}-{kernel.lower()}-mu{mu_tag}"
+                        f"-{policy_name}.sqlite"
+                    )
+                    policy_results.append(
+                        _build_direct_table(
+                            queue=queue,
+                            cache_path=direct_cache,
+                            dim=dim,
+                            kernel=kernel,
+                            q_order=q_order,
+                            parameter=mu,
+                            source_box_level=source_level,
+                            root_extent=root_extent,
+                            regular_order=regular,
+                            radial_order=radial,
+                            entry_ids=entry_ids,
+                        )
+                    )
+                loose, tight = policy_results
+
+                if (
+                    loose["values"] is not None
+                    and tight["values"] is not None
+                ):
+                    floor_rel_max, _ = _relative_deviations(
+                        loose["values"], tight["values"]
+                    )
+                else:
+                    floor_rel_max = ""
+                if tight["values"] is not None:
+                    reference_policy = "tight"
+                    reference_values = tight["values"]
+                elif loose["values"] is not None:
+                    reference_policy = "loose"
+                    reference_values = loose["values"]
+                else:
+                    reference_policy = ""
+                    reference_values = None
+
+                classical = _run_classical(
+                    queue=queue,
+                    cache_path=classical_cache,
+                    dim=dim,
+                    kernel=kernel,
+                    q_order=q_order,
+                    parameter=mu,
+                    source_box_level=source_level,
+                    root_extent=root_extent,
+                    channel_orders=classical_channel_orders,
+                    entry_ids=entry_ids,
+                    n_reduced_entries=n_entries,
+                )
+                if (
+                    classical["values"] is not None
+                    and reference_values is not None
+                ):
+                    classical_rel_max, classical_rel_l2 = (
+                        _relative_deviations(
+                            classical["values"], reference_values
+                        )
+                    )
+                else:
+                    classical_rel_max, classical_rel_l2 = "", ""
+
+                print(
+                    f"[case] dim={dim} kernel={kernel} mu={mu:g} "
+                    f"theta={theta:g} "
+                    f"direct_loose={loose['status']} "
+                    f"direct_tight={tight['status']} "
+                    f"classical={classical['classical_status']}"
+                    + (
+                        f" ({classical['classical_refusal']})"
+                        if classical["classical_status"] == "refused"
+                        else ""
+                    ),
+                    flush=True,
+                )
+
+                for p_star in sorted(p_stars):
+                    for smooth_order in sorted(smooth_orders):
+                        windowed = _run_windowed(
+                            cache_path=windowed_cache,
+                            dim=dim,
+                            kernel=kernel,
+                            q_order=q_order,
+                            parameter=mu,
+                            source_box_level=source_level,
+                            root_extent=root_extent,
+                            window_theta=window_theta,
+                            p_star=p_star,
+                            smooth_quad_order=smooth_order,
+                            chan_regular_order=chan_regular_order,
+                            chan_radial_order=chan_radial_order,
+                            entry_ids=entry_ids,
+                            n_reduced_entries=n_entries,
+                        )
+                        if (
+                            windowed["values"] is not None
+                            and reference_values is not None
+                        ):
+                            windowed_rel_max, windowed_rel_l2 = (
+                                _relative_deviations(
+                                    windowed["values"], reference_values
+                                )
+                            )
+                        else:
+                            windowed_rel_max, windowed_rel_l2 = "", ""
+
+                        print(
+                            f"  [row] p_star={p_star} "
+                            f"smooth={smooth_order} "
+                            f"windowed={windowed['windowed_status']} "
+                            f"assemble_s="
+                            f"{windowed['windowed_assemble_seconds']:.2f}"
+                            + (
+                                f" rel_max={windowed_rel_max:.3e}"
+                                if windowed_rel_max != ""
+                                else ""
+                            ),
+                            flush=True,
+                        )
+
+                        row = {key: "" for key in FIELDS}
+                        row.update(
+                            {
+                                "case_id": (
+                                    f"{kernel.lower()}{dim}d-mu{mu:g}"
+                                    f"-p{p_star}-s{smooth_order}"
+                                ),
+                                "mode": mode,
+                                "dim": dim,
+                                "kernel": kernel,
+                                "parameter_name": PARAMETER_NAMES[kernel],
+                                "parameter_value": mu,
+                                "theta": theta,
+                                "window_theta": window_theta,
+                                "q_order": q_order,
+                                "source_box_level": source_level,
+                                "root_extent": root_extent,
+                                "box_extent": box_extent,
+                                "n_reduced_entries": n_entries,
+                                "p_star": p_star,
+                                "smooth_quad_order_requested": smooth_order,
+                                "chan_regular_order": chan_regular_order,
+                                "chan_radial_order": chan_radial_order,
+                                "channel_build_was_cold": channels[
+                                    "channel_build_was_cold"
+                                ],
+                                "channel_build_seconds": channels[
+                                    "channel_build_seconds"
+                                ],
+                                "classical_tolerance": CLASSICAL_TOLERANCE,
+                                "classical_channel_regular_order": (
+                                    classical_channel_orders[0]
+                                ),
+                                "classical_channel_radial_order": (
+                                    classical_channel_orders[1]
+                                ),
+                                "direct_loose_regular_order": (
+                                    direct_policies[0][0]
+                                ),
+                                "direct_loose_radial_order": (
+                                    direct_policies[0][1]
+                                ),
+                                "direct_loose_status": loose["status"],
+                                "direct_loose_build_seconds": loose[
+                                    "build_seconds"
+                                ],
+                                "direct_tight_regular_order": (
+                                    direct_policies[1][0]
+                                ),
+                                "direct_tight_radial_order": (
+                                    direct_policies[1][1]
+                                ),
+                                "direct_tight_status": tight["status"],
+                                "direct_tight_build_seconds": tight[
+                                    "build_seconds"
+                                ],
+                                "direct_policy_rel_max_entry_floor": (
+                                    floor_rel_max
+                                ),
+                                "direct_reference_policy": reference_policy,
+                                "windowed_vs_direct_rel_max_entry": (
+                                    windowed_rel_max
+                                ),
+                                "windowed_vs_direct_rel_l2": windowed_rel_l2,
+                                "classical_vs_direct_rel_max_entry": (
+                                    classical_rel_max
+                                ),
+                                "classical_vs_direct_rel_l2": (
+                                    classical_rel_l2
+                                ),
+                            }
+                        )
+                        for key, value in windowed.items():
+                            if key != "values" and key in FIELDS:
+                                row[key] = value
+                        if "smooth_quad_order_used" in windowed:
+                            row["smooth_quad_order_used"] = windowed[
+                                "smooth_quad_order_used"
+                            ]
+                        for key, value in classical.items():
+                            if key != "values" and key in FIELDS:
+                                row[key] = value
+                        rows.append(row)
+
+    total_seconds = time.perf_counter() - sweep_start
+    for row in rows:
+        row["benchmark_total_seconds"] = total_seconds
+    return rows, {
+        "channel_prep": channel_prep_records,
+        "total_seconds": total_seconds,
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("smoke", "full"), default="smoke")
+    parser.add_argument(
+        "--dim",
+        help="comma-separated dimensions (2 and/or 3); "
+        "defaults: smoke '2', full '2,3'",
+    )
+    parser.add_argument(
+        "--kernels",
+        default="helmholtz,yukawa",
+        help="comma-separated kernels from {helmholtz, yukawa}",
+    )
+    parser.add_argument(
+        "--q-order",
+        type=int,
+        help="override the per-dimension default q_order (2D: 3, 3D: 2)",
+    )
+    parser.add_argument(
+        "--source-level",
+        type=int,
+        help="override the per-dimension default source-box level "
+        "(2D: 3, 3D: 2)",
+    )
+    parser.add_argument("--root-extent", type=float, default=2.0)
+    parser.add_argument("--window-theta", type=float, default=16.0)
+    parser.add_argument(
+        "--p-star",
+        default="4,6",
+        help="comma-separated windowed channel counts",
+    )
+    parser.add_argument(
+        "--smooth-orders",
+        help="comma-separated smooth-remainder Gauss orders; "
+        "defaults: smoke '16', full '8,16,24,32'",
+    )
+    parser.add_argument(
+        "--mus",
+        help="comma-separated parameter values; defaults: smoke '4,64', "
+        "full '1,2,4,8,16,24,32,48,64'",
+    )
+    parser.add_argument(
+        "--direct-policies",
+        default="24,61;48,160",
+        help="two 'regular,radial' Duffy policies separated by ';' "
+        "(loose;tight)",
+    )
+    parser.add_argument(
+        "--classical-channel-orders",
+        default="24,61",
+        help="'regular,radial' Duffy orders for classical channel builds",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("build/benchmarks/windowed-rke-cache"),
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("build/benchmarks/windowed-rke-sweep"),
+    )
+    parser.add_argument(
+        "--skip-3d-tight",
+        action="store_true",
+        help="skip the tight direct policy in 3D to guard runtime "
+        "(the loose policy then serves as the deviation reference)",
+    )
+    args = parser.parse_args()
+
+    smoke = args.mode == "smoke"
+    dims = _parse_csv_ints(args.dim or ("2" if smoke else "2,3"))
+    if any(dim not in (2, 3) for dim in dims):
+        parser.error("--dim entries must be 2 or 3")
+    kernel_map = {"helmholtz": "Helmholtz", "yukawa": "Yukawa"}
+    kernels = []
+    for name in args.kernels.split(","):
+        name = name.strip().lower()
+        if not name:
+            continue
+        if name not in kernel_map:
+            parser.error(f"unknown kernel: {name}")
+        kernels.append(kernel_map[name])
+    if not kernels:
+        parser.error("at least one kernel is required")
+
+    p_stars = _parse_csv_ints(args.p_star)
+    if any(p < 1 for p in p_stars):
+        parser.error("--p-star entries must be >= 1")
+    smooth_orders = _parse_csv_ints(
+        args.smooth_orders or ("16" if smoke else "8,16,24,32")
+    )
+    mus = sorted(
+        _parse_csv_floats(args.mus or ("4,64" if smoke else "1,2,4,8,16,24,32,48,64"))
+    )
+    if any(mu <= 0 for mu in mus):
+        parser.error("--mus entries must be positive")
+    direct_policies = _parse_direct_policies(args.direct_policies)
+    classical_channel_orders = _parse_order_pair(args.classical_channel_orders)
+
+    rows, run_info = run_sweep(
+        mode=args.mode,
+        dims=dims,
+        kernels=kernels,
+        q_order_override=args.q_order,
+        source_level_override=args.source_level,
+        root_extent=args.root_extent,
+        window_theta=args.window_theta,
+        p_stars=p_stars,
+        smooth_orders=smooth_orders,
+        mus=mus,
+        direct_policies=direct_policies,
+        classical_channel_orders=classical_channel_orders,
+        cache_dir=args.cache_dir,
+        skip_3d_tight=args.skip_3d_tight,
+    )
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = out_dir / "windowed_rke_sweep.csv"
+    write_csv(csv_path, rows)
+
+    config = {
+        "mode": args.mode,
+        "dims": dims,
+        "kernels": kernels,
+        "q_order_override": args.q_order,
+        "source_level_override": args.source_level,
+        "root_extent": args.root_extent,
+        "window_theta": args.window_theta,
+        "p_stars": sorted(p_stars),
+        "smooth_orders": sorted(smooth_orders),
+        "mus": mus,
+        "direct_policies": [list(policy) for policy in direct_policies],
+        "classical_channel_orders": list(classical_channel_orders),
+        "classical_tolerance": CLASSICAL_TOLERANCE,
+        "cache_dir": str(args.cache_dir),
+        "skip_3d_tight": args.skip_3d_tight,
+        "csv_path": str(csv_path),
+        "row_count": len(rows),
+        **run_info,
+    }
+    json_path = out_dir / "windowed_rke_sweep_config.json"
+    with json_path.open("w") as outfile:
+        json.dump(config, outfile, indent=2, sort_keys=True)
+        outfile.write("\n")
+
+    print(
+        f"[done] rows={len(rows)} csv={csv_path} json={json_path} "
+        f"total_s={run_info['total_seconds']:.1f}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -529,6 +529,28 @@ def test_windowed_sweep_rejects_nonpositive_or_nonfinite_cli_values(
     assert exc_info.value.code == 2
 
 
+@pytest.mark.parametrize(("option", "value"), [
+    ("--dim", "x"),
+    ("--p-star", "x"),
+    ("--smooth-orders", "x"),
+])
+def test_windowed_sweep_reports_malformed_csv_as_cli_error(
+    option, value, monkeypatch, capsys
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    monkeypatch.setattr(sys, "argv", ["windowed_rke_sweep.py", option, value])
+    monkeypatch.setattr(
+        module,
+        "run_sweep",
+        lambda **kwargs: pytest.fail("run_sweep must not be called"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+    assert exc_info.value.code == 2
+    assert "error:" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize("raw", [
     "24,61;24,61",
     "24,61;23,160",
@@ -778,6 +800,8 @@ def test_windowed_sweep_main_fails_if_any_assembly_failed(
     usable = {
         "windowed_status": "ok",
         "classical_status": "ok",
+        "direct_loose_status": "ok",
+        "direct_tight_status": "ok",
         "direct_reference_policy": "tight",
     }
     failed = {**usable, failed_column: "failed"}
@@ -798,6 +822,41 @@ def test_windowed_sweep_main_fails_if_any_assembly_failed(
     ])
 
     assert module.main() == 1
+
+
+@pytest.mark.parametrize(("loose_status", "tight_status", "expected"), [
+    ("failed: RuntimeError: loose", "ok", 1),
+    ("ok", "failed: RuntimeError: tight", 1),
+    ("ok", "skipped: --skip-3d-tight", 0),
+])
+def test_windowed_sweep_main_fails_on_unexpected_direct_build_failure(
+    tmp_path, monkeypatch, loose_status, tight_status, expected
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    row = {
+        "windowed_status": "ok",
+        "classical_status": "ok",
+        "direct_loose_status": loose_status,
+        "direct_tight_status": tight_status,
+        "direct_reference_policy": "tight" if tight_status == "ok" else "loose",
+    }
+    monkeypatch.setattr(
+        module,
+        "run_sweep",
+        lambda **kwargs: (
+            [row],
+            {"total_seconds": 0.0, "channel_prep": {}, "mus_by_dim": {}},
+        ),
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "windowed_rke_sweep.py",
+        "--out-dir",
+        str(tmp_path / "out"),
+        "--cache-dir",
+        str(tmp_path / "cache"),
+    ])
+
+    assert module.main() == expected
 
 
 def _windowed_sweep_classical_kwargs(tmp_path):

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -420,6 +420,83 @@ def test_split_benchmark_full_yukawa_order_convergence(tmp_path):
     assert errors[3] < 1.0e-9
 
 
+def test_windowed_sweep_classifies_genuine_classical_refusals(tmp_path):
+    """Pin both classical refusal kinds end to end.
+
+    ``classical_refusal`` names the two certified refusal modes apart in the
+    sweep CSV, and downstream analysis distinguishes them by name, so a
+    silent reclassification (an exception type or message reworded in the
+    assembler) has to fail here rather than quietly relabel rows.
+    """
+    module = _load_benchmark("windowed_rke_sweep")
+
+    from volumential.rke_table_assembly import assemble_parameterized_table
+
+    # lam * radius ~ 68 at level 0 exhausts the default series window, so the
+    # truncation selector refuses before any channel is built (no queue).
+    with pytest.raises(ValueError) as uncertifiable:
+        assemble_parameterized_table(
+            None,
+            tmp_path / "uncertifiable.sqlite",
+            2,
+            "Yukawa",
+            2,
+            8.0,
+            source_box_level=0,
+            tolerance=1.0e-12,
+        )
+    assert module._classify_classical_refusal(uncertifiable.value) == (
+        "uncertifiable"
+    )
+
+    import pyopencl as cl
+
+    try:
+        ctx = cl.create_some_context(interactive=False)
+    except Exception as exc:
+        pytest.skip(f"no OpenCL context available: {exc}")
+
+    # certifiable but cancellation-heavy: the channels assemble and the
+    # deliberately tight max_condition then trips the conditioning guard
+    with pytest.raises(RuntimeError) as ill_conditioned:
+        assemble_parameterized_table(
+            cl.CommandQueue(ctx),
+            tmp_path / "ill-conditioned.sqlite",
+            2,
+            "Yukawa",
+            2,
+            4.0,
+            source_box_level=3,
+            tolerance=1.0e-8,
+            max_condition=1.0,
+        )
+    assert module._classify_classical_refusal(ill_conditioned.value) == (
+        "ill-conditioned"
+    )
+
+
+def test_windowed_sweep_refusal_classifier_message_fallback():
+    """Unmarked exceptions still classify off the stable message fragments."""
+    module = _load_benchmark("windowed_rke_sweep")
+
+    assert module._classify_classical_refusal(
+        ValueError("cannot certify tolerance 1e-11 within 60 series terms")
+    ) == "uncertifiable"
+    # the conditioning message also says "certified float64 recombination",
+    # so the uncertifiable probe must not match it
+    assert module._classify_classical_refusal(
+        RuntimeError(
+            "RKE table assembly is ill-conditioned for this parameter and "
+            "box size (condition 1.0e+07 > 1.0e+06); the local parameter |k| "
+            "times the separation radius (68.00) is too large for certified "
+            "float64 recombination."
+        )
+    ) == "ill-conditioned"
+    assert module._classify_classical_refusal(
+        NotImplementedError("RKE table assembly supports 2D and 3D")
+    ) == "NotImplementedError"
+
+
 def test_keller_segel_critical_profile_is_mass_normalized():
     module = _load_benchmark("keller_segel_continuation")
     axis = np.linspace(-1.0, 1.0, 33)

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -783,6 +783,33 @@ def test_windowed_sweep_rejects_empty_dimensions_before_side_effects(
     assert not cache_dir.exists()
 
 
+@pytest.mark.parametrize(("update", "match"), [
+    ({"mode": "invalid"}, "mode must"),
+    ({"kernels": []}, "at least one kernel"),
+    ({"kernels": ["Laplace"]}, "unknown kernel"),
+    ({"p_stars": []}, "at least one p_star"),
+    ({"smooth_orders": []}, "at least one smooth_order"),
+    ({"mus": []}, "at least one mu"),
+    ({"chan_orders": []}, "at least one channel policy"),
+])
+def test_windowed_sweep_rejects_empty_or_unknown_axes_before_side_effects(
+    tmp_path, monkeypatch, update, match
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs.update(update)
+
+    with pytest.raises(ValueError, match=match):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
 @pytest.mark.parametrize("direct_policies", [
     [(2, 7)],
     [(2, 7), (3, 8), (4, 9)],

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -551,6 +551,31 @@ def test_windowed_sweep_reports_malformed_csv_as_cli_error(
     assert "error:" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(("option", "value"), [
+    ("--dim", "2,2"),
+    ("--kernels", "yukawa,yukawa"),
+    ("--p-star", "4,4"),
+    ("--smooth-orders", "8,8"),
+    ("--mus", "1,1"),
+    ("--chan-orders", "2,7;2,7"),
+])
+def test_windowed_sweep_reports_duplicate_axes_as_cli_errors(
+    option, value, monkeypatch, capsys
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    monkeypatch.setattr(sys, "argv", ["windowed_rke_sweep.py", option, value])
+    monkeypatch.setattr(
+        module,
+        "run_sweep",
+        lambda **kwargs: pytest.fail("run_sweep must not be called"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+    assert exc_info.value.code == 2
+    assert "error:" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize("raw", [
     "24,61;24,61",
     "24,61;23,160",
@@ -829,6 +854,28 @@ def test_windowed_sweep_rejects_underflowed_window_scale_before_side_effects(
     )
 
     with pytest.raises(ValueError, match="window_scale must be finite and positive"):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
+def test_windowed_sweep_normalizes_mus_before_uniqueness_check(
+    tmp_path, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    lower = np.longdouble(1.0)
+    adjacent = np.nextafter(lower, np.longdouble(2.0))
+    assert lower != adjacent
+    assert float(lower) == float(adjacent)
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs["mus"] = [lower, adjacent]
+
+    with pytest.raises(ValueError, match="mu entries must be unique"):
         module.run_sweep(**kwargs)
     assert not cache_dir.exists()
 

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -888,6 +888,11 @@ def test_windowed_sweep_direct_rejects_nonfinite_reference(
     ({"smooth_orders": []}, "at least one smooth_order"),
     ({"mus": []}, "at least one mu"),
     ({"chan_orders": []}, "at least one channel policy"),
+    ({"dims": [2, 2]}, "must be unique"),
+    ({"kernels": ["Yukawa", "Yukawa"]}, "must be unique"),
+    ({"p_stars": [1, 1]}, "must be unique"),
+    ({"smooth_orders": [2, 2]}, "must be unique"),
+    ({"mus": [1.0, 1.0]}, "must be unique"),
     ({"chan_orders": [(2, 7), (2, 7)]}, "must be unique"),
 ])
 def test_windowed_sweep_rejects_empty_or_unknown_axes_before_side_effects(

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -660,6 +660,10 @@ def test_windowed_sweep_channel_cold_status_uses_cache_disposition(
     assert recovered["channel_build_was_cold"] is True
     assert warm["channel_build_was_cold"] is False
 
+    for bad in (None, "unknown"):
+        with pytest.raises(RuntimeError, match="cache disposition"):
+            prepare([bad, "hit"])
+
 
 @pytest.mark.parametrize(("root_extent", "window_theta"), [
     (0.0, 16.0),
@@ -735,6 +739,30 @@ def test_windowed_sweep_programmatic_integer_validation_precedes_side_effects(
     kwargs.update(update)
 
     with pytest.raises(ValueError, match="must be an integer"):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
+@pytest.mark.parametrize("direct_policies", [
+    [(2, 7)],
+    [(2, 7), (3, 8), (4, 9)],
+    [(2, 7), (2, 7)],
+    [(3, 8), (2, 9)],
+])
+def test_windowed_sweep_programmatic_direct_policy_contract_precedes_side_effects(
+    tmp_path, monkeypatch, direct_policies
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs["direct_policies"] = direct_policies
+
+    with pytest.raises(ValueError, match="direct polic"):
         module.run_sweep(**kwargs)
     assert not cache_dir.exists()
 

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -785,7 +785,7 @@ def test_windowed_sweep_rejects_empty_dimensions_before_side_effects(
 
 @pytest.mark.parametrize(("source_level", "match"), [
     (11, "outside the supported O\\(1\\) range"),
-    (1074, "mu must be finite and positive"),
+    (1074, "outside the supported O\\(1\\) range"),
     (1075, "box_extent must be finite and positive"),
 ])
 def test_windowed_sweep_rejects_unsupported_geometry_before_side_effects(
@@ -802,6 +802,29 @@ def test_windowed_sweep_rejects_unsupported_geometry_before_side_effects(
     kwargs.update(source_level_override=source_level, mus=None)
 
     with pytest.raises(ValueError, match=match):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
+def test_windowed_sweep_rejects_overflowed_default_mu_before_side_effects(
+    tmp_path, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs.update(
+        root_extent=1.0e-3,
+        window_theta=1.0e308,
+        source_level_override=0,
+        mus=None,
+    )
+
+    with pytest.raises(ValueError, match="mu must be finite and positive"):
         module.run_sweep(**kwargs)
     assert not cache_dir.exists()
 

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -765,6 +765,24 @@ def test_windowed_sweep_programmatic_integer_validation_precedes_side_effects(
     assert not cache_dir.exists()
 
 
+def test_windowed_sweep_rejects_empty_dimensions_before_side_effects(
+    tmp_path, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs["dims"] = []
+
+    with pytest.raises(ValueError, match="at least one dimension"):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
 @pytest.mark.parametrize("direct_policies", [
     [(2, 7)],
     [(2, 7), (3, 8), (4, 9)],

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -784,10 +784,11 @@ def test_windowed_sweep_rejects_empty_dimensions_before_side_effects(
 
 
 @pytest.mark.parametrize(("source_level", "match"), [
+    (11, "outside the supported O\\(1\\) range"),
     (1074, "mu must be finite and positive"),
     (1075, "box_extent must be finite and positive"),
 ])
-def test_windowed_sweep_rejects_underflowed_geometry_before_side_effects(
+def test_windowed_sweep_rejects_unsupported_geometry_before_side_effects(
     tmp_path, monkeypatch, source_level, match
 ):
     module = _load_benchmark("windowed_rke_sweep")
@@ -803,6 +804,53 @@ def test_windowed_sweep_rejects_underflowed_geometry_before_side_effects(
     with pytest.raises(ValueError, match=match):
         module.run_sweep(**kwargs)
     assert not cache_dir.exists()
+
+
+def test_windowed_sweep_direct_rejects_nonfinite_reference(
+    tmp_path, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    import volumential.table_manager as table_manager
+
+    class FakeTable:
+        def get_entry_data_for_full_indices(self, entry_ids):
+            assert np.array_equal(entry_ids, np.array([0]))
+            return np.array([np.nan])
+
+    class FakeManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            pass
+
+        def get_table(self, *args, **kwargs):
+            return FakeTable(), {}
+
+    monkeypatch.setattr(
+        table_manager, "NearFieldInteractionTableManager", FakeManager
+    )
+
+    result = module._build_direct_table(
+        queue=None,
+        cache_path=tmp_path / "direct.sqlite",
+        dim=2,
+        kernel="Yukawa",
+        q_order=1,
+        parameter=1.0,
+        source_box_level=0,
+        root_extent=2.0,
+        regular_order=2,
+        radial_order=7,
+        entry_ids=np.array([0]),
+    )
+
+    assert result["status"].startswith("failed: RuntimeError:")
+    assert "non-finite" in result["status"]
+    assert result["values"] is None
 
 
 @pytest.mark.parametrize(("update", "match"), [

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -1,10 +1,9 @@
 import importlib.util
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
-
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -495,6 +494,461 @@ def test_windowed_sweep_refusal_classifier_message_fallback():
     assert module._classify_classical_refusal(
         NotImplementedError("RKE table assembly supports 2D and 3D")
     ) == "NotImplementedError"
+
+
+@pytest.mark.parametrize(("option", "value"), [
+    ("--root-extent", "0"),
+    ("--root-extent", "-1"),
+    ("--root-extent", "nan"),
+    ("--root-extent", "inf"),
+    ("--root-extent", "-inf"),
+    ("--window-theta", "0"),
+    ("--window-theta", "-1"),
+    ("--window-theta", "nan"),
+    ("--window-theta", "inf"),
+    ("--window-theta", "-inf"),
+    ("--mus", "0"),
+    ("--mus", "-1"),
+    ("--mus", "nan"),
+    ("--mus", "inf"),
+    ("--mus", "-inf"),
+])
+def test_windowed_sweep_rejects_nonpositive_or_nonfinite_cli_values(
+    option, value, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    monkeypatch.setattr(sys, "argv", ["windowed_rke_sweep.py", option, value])
+    monkeypatch.setattr(
+        module,
+        "run_sweep",
+        lambda **kwargs: pytest.fail("run_sweep must not be called"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize("raw", [
+    "24,61;24,61",
+    "24,61;23,160",
+    "24,61;48,60",
+])
+def test_windowed_sweep_rejects_invalid_direct_policies(raw):
+    module = _load_benchmark("windowed_rke_sweep")
+
+    with pytest.raises(ValueError):
+        module._parse_direct_policies(raw)
+
+    assert module._parse_direct_policies("24,61;48,61") == [
+        (24, 61),
+        (48, 61),
+    ]
+
+
+@pytest.mark.parametrize("regular_order", [0, 1])
+def test_windowed_sweep_rejects_unusable_regular_orders(regular_order):
+    module = _load_benchmark("windowed_rke_sweep")
+    invalid_inputs = [
+        (module._parse_direct_policies, f"{regular_order},7;2,8"),
+        (module._parse_order_pair, f"{regular_order},7"),
+        (module._parse_order_pairs, f"{regular_order},7;2,8"),
+    ]
+
+    for parser, raw in invalid_inputs:
+        with pytest.raises(ValueError, match="regular order must be >= 2"):
+            parser(raw)
+
+
+@pytest.mark.parametrize("radial_order", range(1, 7))
+def test_windowed_sweep_rejects_unusable_radial_orders(radial_order):
+    module = _load_benchmark("windowed_rke_sweep")
+    invalid_inputs = [
+        (module._parse_direct_policies, f"2,{radial_order};3,7"),
+        (module._parse_order_pair, f"2,{radial_order}"),
+        (module._parse_order_pairs, f"2,{radial_order};3,7"),
+    ]
+
+    for parser, raw in invalid_inputs:
+        with pytest.raises(ValueError, match="radial order must be >= 7"):
+            parser(raw)
+
+
+def test_windowed_sweep_accepts_usable_channel_orders():
+    module = _load_benchmark("windowed_rke_sweep")
+
+    assert module._parse_order_pair("24,61") == (24, 61)
+    assert module._parse_order_pairs("48,61;64,121") == [
+        (48, 61),
+        (64, 121),
+    ]
+
+
+def test_windowed_sweep_float_identity_distinguishes_adjacent_values():
+    module = _load_benchmark("windowed_rke_sweep")
+    value = 1.0
+    adjacent = np.nextafter(value, np.inf)
+
+    assert f"{value:g}" == f"{adjacent:g}"
+    assert value.hex() in module._parameter_identity_token(value)
+    assert module._parameter_identity_token(value) != (
+        module._parameter_identity_token(adjacent)
+    )
+    assert module._parameter_identity_token(value) == (
+        module._parameter_identity_token(value)
+    )
+
+
+def test_windowed_sweep_classical_cache_identity_includes_geometry_and_policy(
+    tmp_path,
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    adjacent_extent = np.nextafter(2.0, np.inf)
+
+    baseline = module._classical_cache_path(tmp_path, 2, 3, 2.0, (24, 61))
+    same = module._classical_cache_path(tmp_path, 2, 3, 2.0, (24, 61))
+    changed_extent = module._classical_cache_path(
+        tmp_path, 2, 3, adjacent_extent, (24, 61)
+    )
+    changed_policy = module._classical_cache_path(
+        tmp_path, 2, 3, 2.0, (25, 61)
+    )
+
+    assert baseline == same
+    assert module._exact_float_token(2.0) in baseline.name
+    assert "c24x61" in baseline.name
+    assert len({baseline, changed_extent, changed_policy}) == 3
+
+
+def test_windowed_sweep_channel_cold_status_uses_cache_disposition(
+    tmp_path, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    import volumential.rke_table_assembly as rke
+
+    class FakeChannel:
+        def __init__(self, disposition):
+            self._windowed_cache_disposition = disposition
+
+        def get_reduced_entry_ids(self):
+            return np.array([0], dtype=np.int64)
+
+    def prepare(dispositions):
+        dispositions = iter(dispositions)
+
+        def get_channel(*args, **kwargs):
+            return FakeChannel(next(dispositions))
+
+        monkeypatch.setattr(rke, "get_windowed_channel_table", get_channel)
+        return module._prepare_windowed_channels(
+            cache_path=tmp_path / "channels.sqlite",
+            dim=2,
+            q_order=1,
+            source_box_level=0,
+            root_extent=2.0,
+            window_theta=16.0,
+            max_p_star=2,
+            chan_regular_order=2,
+            chan_radial_order=7,
+        )
+
+    # The first disposition represents an existing checksum-corrupt cache
+    # that the core loader recovered by rebuilding.
+    recovered = prepare(["rebuilt", "hit"])
+    warm = prepare(["hit", "hit"])
+
+    assert recovered["channel_build_was_cold"] is True
+    assert warm["channel_build_was_cold"] is False
+
+
+@pytest.mark.parametrize(("root_extent", "window_theta"), [
+    (0.0, 16.0),
+    (np.nan, 16.0),
+    (2.0, 0.0),
+    (2.0, np.inf),
+])
+def test_windowed_sweep_programmatic_geometry_validation_precedes_side_effects(
+    tmp_path, monkeypatch, root_extent, window_theta
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs.update(root_extent=root_extent, window_theta=window_theta)
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
+def _windowed_sweep_run_kwargs(cache_dir):
+    return {
+        "mode": "smoke",
+        "dims": [2],
+        "kernels": ["Yukawa"],
+        "q_order_override": 1,
+        "source_level_override": 0,
+        "root_extent": 2.0,
+        "window_theta": 16.0,
+        "p_stars": [1],
+        "smooth_orders": [2],
+        "mus": [1.0],
+        "direct_policies": [(2, 7), (3, 8)],
+        "classical_channel_orders": (2, 7),
+        "chan_orders": [(2, 7)],
+        "cache_dir": cache_dir,
+        "skip_3d_tight": False,
+    }
+
+
+@pytest.mark.parametrize("update", [
+    {"q_order_override": 1.5},
+    {"q_order_override": True},
+    {"source_level_override": 0.5},
+    {"source_level_override": False},
+    {"smooth_orders": [1.5]},
+    {"smooth_orders": [True]},
+    {"p_stars": [1.5]},
+    {"p_stars": [True]},
+    {"direct_policies": [(2.5, 7), (3, 8)]},
+    {"direct_policies": [(True, 7), (3, 8)]},
+    {"classical_channel_orders": (2, 7.5)},
+    {"classical_channel_orders": (2, True)},
+    {"chan_orders": [(2.5, 7)]},
+    {"chan_orders": [(2, False)]},
+])
+def test_windowed_sweep_programmatic_integer_validation_precedes_side_effects(
+    tmp_path, monkeypatch, update
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs.update(update)
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
+@pytest.mark.parametrize("failed_column", [
+    "windowed_status",
+    "classical_status",
+])
+def test_windowed_sweep_main_fails_if_any_assembly_failed(
+    tmp_path, monkeypatch, failed_column
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    usable = {
+        "windowed_status": "ok",
+        "classical_status": "ok",
+        "direct_reference_policy": "tight",
+    }
+    failed = {**usable, failed_column: "failed"}
+    monkeypatch.setattr(
+        module,
+        "run_sweep",
+        lambda **kwargs: (
+            [usable, failed],
+            {"total_seconds": 0.0, "channel_prep": {}, "mus_by_dim": {}},
+        ),
+    )
+    monkeypatch.setattr(sys, "argv", [
+        "windowed_rke_sweep.py",
+        "--out-dir",
+        str(tmp_path / "out"),
+        "--cache-dir",
+        str(tmp_path / "cache"),
+    ])
+
+    assert module.main() == 1
+
+
+def _windowed_sweep_classical_kwargs(tmp_path):
+    return {
+        "queue": None,
+        "cache_path": tmp_path / "classical.sqlite",
+        "dim": 2,
+        "kernel": "Yukawa",
+        "q_order": 2,
+        "parameter": 1.0,
+        "source_box_level": 3,
+        "root_extent": 2.0,
+        "channel_orders": (24, 61),
+        "entry_ids": np.array([0], dtype=np.int64),
+        "n_reduced_entries": 1,
+    }
+
+
+def _set_windowed_sweep_clock(module, monkeypatch, values):
+    values = iter(values)
+
+    class Clock:
+        @staticmethod
+        def perf_counter():
+            return next(values)
+
+    monkeypatch.setattr(module, "time", Clock())
+
+
+def _windowed_sweep_windowed_kwargs(tmp_path):
+    return {
+        "cache_path": tmp_path / "windowed.sqlite",
+        "dim": 2,
+        "kernel": "Yukawa",
+        "q_order": 1,
+        "parameter": 1.0,
+        "source_box_level": 0,
+        "root_extent": 2.0,
+        "window_theta": 16.0,
+        "p_star": 1,
+        "smooth_quad_order": 2,
+        "chan_regular_order": 2,
+        "chan_radial_order": 7,
+        "entry_ids": np.array([0], dtype=np.int64),
+        "n_reduced_entries": 1,
+    }
+
+
+@pytest.mark.parametrize(("error_name", "expected_status"), [
+    ("RKEWindowCoverageError", "refused"),
+    ("RKEWindowConditioningError", "refused"),
+    ("ValueError", "failed"),
+    ("RuntimeError", "failed"),
+    ("NotImplementedError", "failed"),
+])
+def test_windowed_sweep_windowed_errors_use_structured_refusal_taxonomy(
+    tmp_path, monkeypatch, error_name, expected_status
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    import volumential.rke_table_assembly as rke
+
+    error_types = {
+        "RKEWindowCoverageError": rke.RKEWindowCoverageError,
+        "RKEWindowConditioningError": rke.RKEWindowConditioningError,
+        "ValueError": ValueError,
+        "RuntimeError": RuntimeError,
+        "NotImplementedError": NotImplementedError,
+    }
+
+    def assemble(*args, **kwargs):
+        raise error_types[error_name]("probe failure")
+
+    monkeypatch.setattr(rke, "assemble_windowed_parameterized_table", assemble)
+    _set_windowed_sweep_clock(module, monkeypatch, [3.0, 4.5])
+
+    result = module._run_windowed(
+        **_windowed_sweep_windowed_kwargs(tmp_path)
+    )
+
+    assert result["windowed_status"] == expected_status
+    assert error_name in result["windowed_refusal"]
+    assert result["windowed_assemble_seconds"] == pytest.approx(1.5)
+    assert result["values"] is None
+
+
+def test_windowed_sweep_classical_timing_schema_is_truthful(
+    tmp_path, monkeypatch
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    import volumential.rke_table_assembly as rke
+
+    class FakeTable:
+        def get_entry_data_for_full_indices(self, entry_ids):
+            assert np.array_equal(entry_ids, np.array([0]))
+            return np.array([2.0])
+
+    calls = []
+
+    def assemble(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeTable(), {
+            "n_series_terms": 2,
+            "channel_count": 6,
+            "condition_number": 1.5,
+        }
+
+    monkeypatch.setattr(rke, "assemble_parameterized_table", assemble)
+    _set_windowed_sweep_clock(
+        module, monkeypatch, [1.0, 3.5, 10.0, 11.25]
+    )
+
+    result = module._run_classical(
+        **_windowed_sweep_classical_kwargs(tmp_path)
+    )
+
+    assert len(calls) == 2
+    assert result["classical_status"] == "ok"
+    assert result["classical_warmup_seconds"] == pytest.approx(2.5)
+    assert result["classical_assemble_seconds"] == pytest.approx(1.25)
+    assert np.array_equal(result["values"], np.array([2.0]))
+    assert "classical_build_was_cold" not in module.FIELDS
+    assert "classical_channel_build_seconds" not in module.FIELDS
+
+
+@pytest.mark.parametrize(("error_type", "refusal_kind"), [
+    ("RKETruncationError", "uncertifiable"),
+    ("RKEConditioningError", "ill-conditioned"),
+])
+def test_windowed_sweep_classical_structured_refusal_uses_warmup_time(
+    tmp_path, monkeypatch, error_type, refusal_kind
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    import volumential.rke_table_assembly as rke
+
+    def assemble(*args, **kwargs):
+        raise getattr(rke, error_type)("numerical refusal")
+
+    monkeypatch.setattr(rke, "assemble_parameterized_table", assemble)
+    _set_windowed_sweep_clock(module, monkeypatch, [4.0, 6.5])
+
+    result = module._run_classical(
+        **_windowed_sweep_classical_kwargs(tmp_path)
+    )
+
+    assert result["classical_status"] == "refused"
+    assert result["classical_refusal"] == refusal_kind
+    assert error_type in result["classical_refusal_detail"]
+    assert result["classical_warmup_seconds"] == pytest.approx(2.5)
+    assert result["classical_assemble_seconds"] == ""
+    assert result["values"] is None
+
+
+@pytest.mark.parametrize("error", [
+    ValueError("bad configuration"),
+    RuntimeError("cache mismatch"),
+    NotImplementedError("unsupported infrastructure"),
+])
+def test_windowed_sweep_classical_unexpected_errors_are_failures(
+    tmp_path, monkeypatch, error
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    import volumential.rke_table_assembly as rke
+
+    def assemble(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(rke, "assemble_parameterized_table", assemble)
+    _set_windowed_sweep_clock(module, monkeypatch, [8.0, 9.0])
+
+    result = module._run_classical(
+        **_windowed_sweep_classical_kwargs(tmp_path)
+    )
+
+    assert result["classical_status"] == "failed"
+    assert result["classical_refusal"] == ""
+    assert type(error).__name__ in result["classical_refusal_detail"]
+    assert result["classical_warmup_seconds"] == pytest.approx(1.0)
+    assert result["classical_assemble_seconds"] == ""
+    assert result["values"] is None
 
 
 def test_keller_segel_critical_profile_is_mass_normalized():

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -783,6 +783,28 @@ def test_windowed_sweep_rejects_empty_dimensions_before_side_effects(
     assert not cache_dir.exists()
 
 
+@pytest.mark.parametrize(("source_level", "match"), [
+    (1074, "mu must be finite and positive"),
+    (1075, "box_extent must be finite and positive"),
+])
+def test_windowed_sweep_rejects_underflowed_geometry_before_side_effects(
+    tmp_path, monkeypatch, source_level, match
+):
+    module = _load_benchmark("windowed_rke_sweep")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr(
+        module,
+        "_make_queue",
+        lambda: pytest.fail("queue creation must not be attempted"),
+    )
+    kwargs = _windowed_sweep_run_kwargs(cache_dir)
+    kwargs.update(source_level_override=source_level, mus=None)
+
+    with pytest.raises(ValueError, match=match):
+        module.run_sweep(**kwargs)
+    assert not cache_dir.exists()
+
+
 @pytest.mark.parametrize(("update", "match"), [
     ({"mode": "invalid"}, "mode must"),
     ({"kernels": []}, "at least one kernel"),

--- a/test/test_benchmark_helpers.py
+++ b/test/test_benchmark_helpers.py
@@ -604,6 +604,10 @@ def test_windowed_sweep_accepts_usable_channel_orders():
         (48, 61),
         (64, 121),
     ]
+    with pytest.raises(
+        ValueError, match="channel-order policies must be unique"
+    ):
+        module._parse_order_pairs("48,61;48,61")
 
 
 def test_windowed_sweep_float_identity_distinguishes_adjacent_values():
@@ -806,7 +810,7 @@ def test_windowed_sweep_rejects_unsupported_geometry_before_side_effects(
     assert not cache_dir.exists()
 
 
-def test_windowed_sweep_rejects_overflowed_default_mu_before_side_effects(
+def test_windowed_sweep_rejects_underflowed_window_scale_before_side_effects(
     tmp_path, monkeypatch
 ):
     module = _load_benchmark("windowed_rke_sweep")
@@ -818,13 +822,13 @@ def test_windowed_sweep_rejects_overflowed_default_mu_before_side_effects(
     )
     kwargs = _windowed_sweep_run_kwargs(cache_dir)
     kwargs.update(
-        root_extent=1.0e-3,
+        root_extent=2.0,
         window_theta=1.0e308,
         source_level_override=0,
-        mus=None,
+        mus=[1.0],
     )
 
-    with pytest.raises(ValueError, match="mu must be finite and positive"):
+    with pytest.raises(ValueError, match="window_scale must be finite and positive"):
         module.run_sweep(**kwargs)
     assert not cache_dir.exists()
 
@@ -884,6 +888,7 @@ def test_windowed_sweep_direct_rejects_nonfinite_reference(
     ({"smooth_orders": []}, "at least one smooth_order"),
     ({"mus": []}, "at least one mu"),
     ({"chan_orders": []}, "at least one channel policy"),
+    ({"chan_orders": [(2, 7), (2, 7)]}, "must be unique"),
 ])
 def test_windowed_sweep_rejects_empty_or_unknown_axes_before_side_effects(
     tmp_path, monkeypatch, update, match

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -448,6 +448,74 @@ def test_germ_cancellation_implementation_remainder(dim, kernel_type):
         1e-3, float(np.max(moderate))
     )
 
+
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("kernel_type", ["Yukawa", "Helmholtz"])
+def test_windowed_remainder_defines_origin_limit(dim, kernel_type):
+    import mpmath as mp
+
+    source_box_level = 3 if dim == 2 else 2
+    box_extent = _box_extent(source_box_level)
+    window_scale = (box_extent / WINDOW_THETA) ** 2
+    parameter = 4.0
+    zeta = parameter**2 if kernel_type == "Yukawa" else -(parameter**2)
+    remainder = windowed_remainder_profile(
+        dim,
+        zeta,
+        _kernel_radial(dim, kernel_type, parameter),
+        window_scale,
+        6,
+    )
+
+    old_dps = mp.mp.dps
+    mp.mp.dps = 100
+    try:
+        r = mp.sqrt(window_scale) * mp.mpf("1e-40")
+        x = r * r / (4 * window_scale)
+        if kernel_type == "Yukawa":
+            kernel = (
+                mp.besselk(0, parameter * r) / (2 * mp.pi)
+                if dim == 2
+                else mp.exp(-parameter * r) / (4 * mp.pi * r)
+            )
+        else:
+            kernel = (
+                0.25j * mp.hankel1(0, parameter * r)
+                if dim == 2
+                else mp.exp(1j * parameter * r) / (4 * mp.pi * r)
+            )
+
+        if dim == 2:
+            value = mp.e1(x)
+            profiles = [mp.mpf("0.5") * value]
+            for m in range(1, 6):
+                value = (mp.exp(-x) - x * value) / m
+                profiles.append(mp.mpf("0.5") * value)
+            prefactor = 1 / (2 * mp.pi)
+        else:
+            value = mp.sqrt(mp.pi) * mp.erfc(mp.sqrt(x)) / mp.sqrt(x)
+            scale = 1 / (2 * mp.sqrt(mp.pi * window_scale))
+            profiles = [scale * value]
+            for m in range(1, 6):
+                value = (mp.exp(-x) - x * value) / (m - mp.mpf("0.5"))
+                profiles.append(scale * value)
+            prefactor = 1 / (4 * mp.pi)
+
+        coefficient = mp.mpc(1)
+        channel_sum = mp.mpc(0)
+        for m, profile in enumerate(profiles):
+            channel_sum += coefficient * profile
+            coefficient *= -mp.mpc(zeta * window_scale) / (m + 1)
+        expected = complex(kernel - prefactor * channel_sum)
+    finally:
+        mp.mp.dps = old_dps
+
+    at_origin = remainder(0.0)
+    values = remainder(np.array([0.0, 1.0e-7 * box_extent]))
+    assert np.isfinite(at_origin)
+    assert values[0] == pytest.approx(at_origin)
+    assert at_origin == pytest.approx(expected, rel=2.0e-12, abs=2.0e-12)
+
 # }}}
 
 

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -132,13 +132,13 @@ def _scalar_direct_entries(
 ):
     """Independent scalar-DuffyRadial reference entries for a radial kernel
     (real and imaginary parts separately when complex)."""
-    values = np.empty(len(entry_ids), dtype=np.complex128)
     parts = ("real", "imag") if complex_valued else ("real",)
     part_values = {}
+    # only ``kernel_func`` differs between the parts, so one skeleton serves
+    table = _windowed_channel_skeleton(
+        dim, q_order, source_box_level, ROOT_EXTENT, WINDOW_THETA, 0
+    )
     for part in parts:
-        table = _windowed_channel_skeleton(
-            dim, q_order, source_box_level, ROOT_EXTENT, WINDOW_THETA, 0
-        )
 
         def kernel_func(x, y=None, z=None, _part=part):
             coords = [c for c in (x, y, z) if c is not None][:dim]
@@ -241,6 +241,9 @@ def test_vectorized_channel_builder_matches_scalar_duffy():
         table.kernel_func = _windowed_channel_kernel_func(
             dim, m, window_scale
         )
+        # the picks are fixed positions in the reduced list; a shrunk entry
+        # count must fail as an assertion here, not as an opaque IndexError
+        assert len(entry_ids) > max(picks), (dim, q_order, len(entry_ids))
         for pick in picks:
             _, reference = table.compute_table_entry_duffy_radial(
                 int(entry_ids[pick]),
@@ -382,6 +385,17 @@ def test_tensor_gauss_points_match_meshgen(dim, q_order):
         NearFieldInteractionTable,
     )
 
+    # Only environment unavailability may skip: a missing meshgen module or
+    # no OpenCL platform to run it on.  A q-point, API or geometry failure in
+    # the constructor is precisely what this test exists to catch and must
+    # not be swallowed into a green skip.
+    try:
+        import pyopencl as cl
+    except ImportError:
+        unavailable: tuple[type[BaseException], ...] = (ImportError,)
+    else:
+        unavailable = (ImportError, cl.Error)
+
     try:
         real_table = NearFieldInteractionTable(
             quad_order=q_order,
@@ -393,7 +407,7 @@ def test_tensor_gauss_points_match_meshgen(dim, q_order):
             dtype=np.float64,
             progress_bar=False,
         )
-    except Exception as exc:
+    except unavailable as exc:
         pytest.skip(f"no mesh-generator table construction available: {exc}")
     assert (
         np.max(np.abs(np.asarray(real_table.q_points) - points))
@@ -698,7 +712,6 @@ def test_smooth_order_convergence(channel_cache):
     # non-increasing within noise, and converged (plateaued) by order 32
     for coarse, fine in zip(deviations[:-1], deviations[1:]):
         assert fine <= 1.25 * coarse + 1e-9, deviations
-    assert deviations[-1] <= 1.25 * deviations[-2] + 1e-9, deviations
     assert deviations[-1] < 1e-6, deviations
 
 # }}}
@@ -943,8 +956,24 @@ def test_channel_cache_self_heals(tmp_path):
     assert np.array_equal(np.asarray(ids), np.asarray(ids_healed))
     assert np.array_equal(np.asarray(values), np.asarray(values_healed))
 
+    # the heal must have rewritten the same deterministic cache key, or the
+    # next corruption step would poison an orphan file and assert nothing
+    assert sorted(cache_dir.glob("*.npz")) == cache_files
+
     # arbitrary garbage (stale format) likewise self-heals
     cache_files[0].write_bytes(b"not a zip file")
+    healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    assert np.array_equal(
+        np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])
+    )
+
+    # a loadable file whose key and entry IDs check out but whose value array
+    # has the wrong shape must also rebuild: accepting it would raise out of
+    # ``set_reduced_table_data`` and wedge every later call on the bad file
+    with np.load(cache_files[0], allow_pickle=False) as payload:
+        arrays = {name: payload[name] for name in payload.files}
+    arrays["values"] = np.asarray(arrays["values"])[:-1]
+    np.savez(cache_files[0], **arrays)
     healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
     assert np.array_equal(
         np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -1582,6 +1582,26 @@ def test_invalid_window_scales_and_declarations(tmp_path, invalid):
     assert not Path(str(cache) + ".windowed").exists()
 
 
+@pytest.mark.parametrize("invalid", [0.0, -1.0, np.nan, np.inf])
+def test_invalid_window_condition_thresholds(tmp_path, invalid):
+    from pathlib import Path
+
+    cache = tmp_path / "condition-guards.sqlite"
+
+    def zero_kernel(r):
+        return np.zeros_like(np.asarray(r, dtype=np.float64))
+
+    with pytest.raises(ValueError, match="max_condition must be finite and positive"):
+        _assemble_windowed_for_zeta(
+            cache, 2, 1, 1.0, zero_kernel, max_condition=invalid
+        )
+    with pytest.raises(ValueError, match="max_condition must be finite and positive"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 1, 1.0, max_condition=invalid
+        )
+    assert not Path(str(cache) + ".windowed").exists()
+
+
 def test_windowed_declaration_guards(tmp_path):
     cache = tmp_path / "guards.sqlite"
 

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -1708,6 +1708,21 @@ def test_invalid_window_condition_thresholds(tmp_path, invalid):
     assert not Path(str(cache) + ".windowed").exists()
 
 
+def test_zero_zeta_is_rejected_before_channel_side_effects(tmp_path):
+    from pathlib import Path
+
+    cache = tmp_path / "zero-zeta-guard.sqlite"
+
+    def zero_kernel(r):
+        return np.zeros_like(np.asarray(r, dtype=np.float64))
+
+    with pytest.raises(ValueError, match="zeta must be nonzero"):
+        windowed_remainder_profile(2, 0.0, zero_kernel, 1.0, 1)
+    with pytest.raises(ValueError, match="zeta must be nonzero"):
+        _assemble_windowed_for_zeta(cache, 2, 1, 0.0, zero_kernel)
+    assert not Path(str(cache) + ".windowed").exists()
+
+
 def test_windowed_declaration_guards(tmp_path):
     cache = tmp_path / "guards.sqlite"
 

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -1,0 +1,1090 @@
+__copyright__ = "Copyright (C) 2026 Xiaoyu Wei"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import numpy as np
+import pytest
+
+from volumential.rke_table_assembly import (
+    _assemble_windowed_for_zeta,
+    _duffy_channel_entry_values,
+    _tensor_product_gauss_points,
+    _windowed_channel_kernel_func,
+    _windowed_channel_skeleton,
+    assemble_parameterized_table,
+    assemble_windowed_parameterized_table,
+    windowed_channel_profile,
+    windowed_remainder_profile,
+)
+
+
+WINDOW_THETA = 16.0
+ROOT_EXTENT = 2.0
+
+# Channel quadrature orders used consistently per dimension so every test
+# shares one cached channel family per (dim, q, level).  2D q=3 puts
+# interpolation nodes close to the box edge, and the resulting high-aspect
+# Duffy triangles converge slowly in the angular order (the same effect
+# governs direct builds), so the 2D channels use angular order 48 — which
+# is also the module's resolved 2D default (see
+# test_default_channel_orders); the 3D q=2 geometry is mild (measured
+# drift of 14/45 versus 28/61 is below 1e-7 relative) and 14/45 keeps the
+# one-time build under a minute.
+CHAN_ORDERS_2D = {"chan_regular_order": 48, "chan_radial_order": 61}
+CHAN_ORDERS_3D = {"chan_regular_order": 14, "chan_radial_order": 45}
+
+
+def _get_queue_or_skip():
+    import pyopencl as cl
+
+    try:
+        ctx = cl.create_some_context(interactive=False)
+    except Exception as exc:
+        pytest.skip(f"no OpenCL context available: {exc}")
+    return cl.CommandQueue(ctx)
+
+
+def _box_extent(source_box_level):
+    return ROOT_EXTENT * 0.5**source_box_level
+
+
+def _kernel_radial(dim, kernel_type, parameter):
+    import scipy.special as sps
+
+    parameter = complex(parameter)
+    if kernel_type == "Yukawa":
+        if dim == 2:
+            return lambda r: sps.kv(0, parameter * np.asarray(r)) / (
+                2.0 * np.pi
+            )
+        return lambda r: np.exp(-parameter * np.asarray(r)) / (
+            4.0 * np.pi * np.asarray(r)
+        )
+    assert kernel_type == "Helmholtz"
+    if dim == 2:
+        return lambda r: 0.25j * sps.hankel1(
+            0, parameter * np.asarray(r, dtype=np.complex128)
+        )
+    return lambda r: np.exp(1j * parameter * np.asarray(r)) / (
+        4.0 * np.pi * np.asarray(r)
+    )
+
+
+def _windowed_remainder(dim, kernel_type, parameter, source_box_level, p_star):
+    box_extent = _box_extent(source_box_level)
+    window_scale = (box_extent / WINDOW_THETA) ** 2
+    if kernel_type == "Yukawa":
+        zeta = complex(parameter) ** 2
+    else:
+        zeta = -(complex(parameter) ** 2)
+    prefactor = 1.0 / (2.0 * np.pi) if dim == 2 else 1.0 / (4.0 * np.pi)
+    profiles = [
+        windowed_channel_profile(dim, m, window_scale) for m in range(p_star)
+    ]
+    kernel = _kernel_radial(dim, kernel_type, parameter)
+
+    def remainder(r):
+        coefficient = 1.0 + 0.0j
+        channel_sum = np.zeros(np.shape(np.asarray(r)), dtype=np.complex128)
+        for m in range(p_star):
+            channel_sum = channel_sum + coefficient * profiles[m](r)
+            coefficient = coefficient * (-zeta) / (m + 1)
+        return kernel(r) - prefactor * channel_sum
+
+    def channel_sum_only(r):
+        coefficient = 1.0 + 0.0j
+        acc = np.zeros(np.shape(np.asarray(r)), dtype=np.complex128)
+        for m in range(p_star):
+            acc = acc + coefficient * profiles[m](r)
+            coefficient = coefficient * (-zeta) / (m + 1)
+        return prefactor * acc
+
+    return kernel, channel_sum_only, remainder
+
+
+def _scalar_direct_entries(
+    dim,
+    q_order,
+    source_box_level,
+    entry_ids,
+    kernel_radial,
+    deg_theta,
+    radial_quad_order,
+    complex_valued=False,
+):
+    """Independent scalar-DuffyRadial reference entries for a radial kernel
+    (real and imaginary parts separately when complex)."""
+    values = np.empty(len(entry_ids), dtype=np.complex128)
+    parts = ("real", "imag") if complex_valued else ("real",)
+    part_values = {}
+    for part in parts:
+        table = _windowed_channel_skeleton(
+            dim, q_order, source_box_level, ROOT_EXTENT, WINDOW_THETA, 0
+        )
+
+        def kernel_func(x, y=None, z=None, _part=part):
+            coords = [c for c in (x, y, z) if c is not None][:dim]
+            r = np.sqrt(
+                sum(np.asarray(c, dtype=np.float64) ** 2 for c in coords)
+            )
+            value = kernel_radial(r)
+            return getattr(np, _part)(value)
+
+        table.kernel_func = kernel_func
+        part_values[part] = np.array(
+            [
+                table.compute_table_entry_duffy_radial(
+                    int(entry_id),
+                    radial_rule="tanh-sinh-fast",
+                    deg_theta=deg_theta,
+                    radial_quad_order=radial_quad_order,
+                    mp_dps=50,
+                )[1]
+                for entry_id in entry_ids
+            ],
+            dtype=np.float64,
+        )
+    values = part_values["real"].astype(np.complex128)
+    if complex_valued:
+        values = values + 1j * part_values["imag"]
+    return values
+
+
+def _spot_entry_ids(entry_ids, values, n_top=6, n_spread=6):
+    """A deterministic subset: the largest-magnitude entries plus an even
+    spread across the reduced list."""
+    order = np.argsort(-np.abs(np.asarray(values)))
+    chosen = list(order[:n_top])
+    chosen.extend(
+        int(i) for i in np.linspace(0, len(entry_ids) - 1, n_spread)
+    )
+    positions = sorted(set(int(i) for i in chosen))
+    return positions
+
+
+# {{{ T1: channel profiles against mpmath, and vectorized-vs-scalar Duffy
+
+@pytest.mark.parametrize("dim", [2, 3])
+def test_channel_profiles_match_mpmath(dim):
+    import mpmath as mp
+
+    old_dps = mp.mp.dps
+    mp.mp.dps = 40
+    try:
+        box_extent = 0.25 if dim == 2 else 0.5
+        window_scale = (box_extent / WINDOW_THETA) ** 2
+        radii = np.geomspace(
+            1e-6 * box_extent, 3.0 * np.sqrt(dim) * box_extent, 40
+        )
+        for m in range(6):
+            profile = windowed_channel_profile(dim, m, window_scale)
+            values = profile(radii)
+            for radius, value in zip(radii, values):
+                x = mp.mpf(radius) ** 2 / (4 * mp.mpf(window_scale))
+                if dim == 2:
+                    reference = (
+                        mp.mpf("0.5")
+                        * (mp.mpf(radius) ** 2 / 4) ** m
+                        * mp.gammainc(-m, x, mp.inf)
+                    )
+                else:
+                    reference = (
+                        (mp.mpf(radius) ** 2 / 4)
+                        ** (mp.mpf(m) - mp.mpf("0.5"))
+                        * mp.gammainc(mp.mpf("0.5") - m, x, mp.inf)
+                        / (2 * mp.sqrt(mp.pi))
+                    )
+                reference = float(reference)
+                assert abs(value - reference) <= 1e-13 * max(
+                    1.0, abs(reference)
+                ), (dim, m, radius)
+    finally:
+        mp.mp.dps = old_dps
+
+
+def test_vectorized_channel_builder_matches_scalar_duffy():
+    # identical node sets make the agreement order-independent, so low
+    # orders suffice to certify the vectorized evaluator entry-for-entry
+    cases = [
+        (2, 3, 3, 1, 8, 15, (0, 120, 356)),
+        (3, 2, 2, 0, 4, 9, (0, 128)),
+    ]
+    for dim, q_order, level, m, deg, radial, picks in cases:
+        table = _windowed_channel_skeleton(
+            dim, q_order, level, ROOT_EXTENT, WINDOW_THETA, m
+        )
+        window_scale = (_box_extent(level) / WINDOW_THETA) ** 2
+        entry_ids, values = _duffy_channel_entry_values(
+            table,
+            windowed_channel_profile(dim, m, window_scale),
+            deg,
+            radial,
+        )
+        table.kernel_func = _windowed_channel_kernel_func(
+            dim, m, window_scale
+        )
+        for pick in picks:
+            _, reference = table.compute_table_entry_duffy_radial(
+                int(entry_ids[pick]),
+                radial_rule="tanh-sinh-fast",
+                deg_theta=deg,
+                radial_quad_order=radial,
+                mp_dps=50,
+            )
+            assert abs(values[pick] - reference) <= 1e-12 * max(
+                1.0, abs(reference)
+            ), (dim, pick)
+
+# }}}
+
+
+# {{{ T2: germ cancellation at the design edge theta = Theta
+
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("kernel_type", ["Yukawa", "Helmholtz"])
+def test_germ_cancellation_at_design_theta(dim, kernel_type):
+    source_box_level = 3 if dim == 2 else 2
+    box_extent = _box_extent(source_box_level)
+    parameter = WINDOW_THETA / box_extent
+    kernel, channel_sum, remainder = _windowed_remainder(
+        dim, kernel_type, parameter, source_box_level, p_star=6
+    )
+
+    r_tiny = np.array([1e-7 * box_extent, 1e-5 * box_extent])
+    kernel_tiny = np.asarray(kernel(r_tiny), dtype=np.complex128)
+    channels_tiny = np.asarray(channel_sum(r_tiny), dtype=np.complex128)
+    remainder_tiny = np.asarray(remainder(r_tiny), dtype=np.complex128)
+
+    assert np.all(np.isfinite(remainder_tiny))
+
+    # the kernel and the channel sum individually grow as r -> 0 ...
+    kernel_growth = abs(kernel_tiny[0] - kernel_tiny[1])
+    channel_growth = abs(channels_tiny[0] - channels_tiny[1])
+    assert kernel_growth > 0.1
+    assert channel_growth > 0.1
+
+    # ... while their difference does not: the log (2D) / 1-over-r (3D)
+    # germ coefficients of kernel and channel sum agree
+    remainder_growth = abs(remainder_tiny[0] - remainder_tiny[1])
+    assert remainder_growth <= 1e-6 * max(1.0, kernel_growth)
+
+    # R stays at the scale it has on the resolved part of the range
+    moderate = np.abs(
+        np.asarray(
+            remainder(np.linspace(0.1 * box_extent, box_extent, 64)),
+            dtype=np.complex128,
+        )
+    )
+    assert np.max(np.abs(remainder_tiny)) <= 100.0 * max(
+        1e-3, float(np.max(moderate))
+    )
+
+
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("kernel_type", ["Yukawa", "Helmholtz"])
+def test_germ_cancellation_implementation_remainder(dim, kernel_type):
+    """Same germ-cancellation certificate as above, but through the
+    implementation's own remainder path (``windowed_remainder_profile`` is
+    exactly what the assembler integrates), so a sign/prefactor/coefficient
+    bug on the implementation side cannot hide behind the test helper's
+    independent re-derivation."""
+    source_box_level = 3 if dim == 2 else 2
+    box_extent = _box_extent(source_box_level)
+    window_scale = (box_extent / WINDOW_THETA) ** 2
+    parameter = WINDOW_THETA / box_extent
+    if kernel_type == "Yukawa":
+        zeta = complex(parameter) ** 2
+    else:
+        zeta = -(complex(parameter) ** 2)
+
+    kernel = _kernel_radial(dim, kernel_type, parameter)
+    remainder = windowed_remainder_profile(
+        dim, zeta, kernel, window_scale, 6
+    )
+
+    r_tiny = np.array([1e-7 * box_extent, 1e-5 * box_extent])
+    kernel_tiny = np.asarray(kernel(r_tiny), dtype=np.complex128)
+    remainder_tiny = np.asarray(remainder(r_tiny), dtype=np.complex128)
+
+    assert np.all(np.isfinite(remainder_tiny))
+    kernel_growth = abs(kernel_tiny[0] - kernel_tiny[1])
+    assert kernel_growth > 0.1
+    remainder_growth = abs(remainder_tiny[0] - remainder_tiny[1])
+    assert remainder_growth <= 1e-6 * max(1.0, kernel_growth)
+
+    moderate = np.abs(
+        np.asarray(
+            remainder(np.linspace(0.1 * box_extent, box_extent, 64)),
+            dtype=np.complex128,
+        )
+    )
+    assert np.max(np.abs(remainder_tiny)) <= 100.0 * max(
+        1e-3, float(np.max(moderate))
+    )
+
+# }}}
+
+
+# {{{ T2b: table geometry pinned independently of the implementation
+
+@pytest.mark.parametrize(("dim", "q_order"), [(2, 3), (3, 2)])
+def test_tensor_gauss_points_explicit_ordering(dim, q_order):
+    """Pin the queue-free q-point construction against an explicit
+    nested-loop re-derivation of the documented ordering (axis 0 slowest,
+    last axis fastest — independent of np.meshgrid semantics)."""
+    extent = _box_extent(3 if dim == 2 else 2)
+    points = _tensor_product_gauss_points(q_order, dim, extent)
+
+    nodes = np.polynomial.legendre.leggauss(q_order)[0]
+    axis = 0.5 * extent * (nodes + 1.0)
+    expected = []
+    if dim == 2:
+        for i in range(q_order):
+            for j in range(q_order):
+                expected.append((axis[i], axis[j]))
+    else:
+        for i in range(q_order):
+            for j in range(q_order):
+                for k in range(q_order):
+                    expected.append((axis[i], axis[j], axis[k]))
+    expected = np.asarray(expected, dtype=np.float64)
+    assert points.shape == expected.shape
+    assert np.max(np.abs(points - expected)) <= 1e-14 * extent
+
+
+@pytest.mark.parametrize(("dim", "q_order"), [(2, 3), (3, 2)])
+def test_tensor_gauss_points_match_meshgen(dim, q_order):
+    """Pin the queue-free q-point construction against the real
+    mesh-generator-backed table constructor when one is available (the
+    geometry T3/T4 exercise through the table manager)."""
+    extent = _box_extent(3 if dim == 2 else 2)
+    points = _tensor_product_gauss_points(q_order, dim, extent)
+
+    from volumential.nearfield_potential_table import (
+        NearFieldInteractionTable,
+    )
+
+    try:
+        real_table = NearFieldInteractionTable(
+            quad_order=q_order,
+            dim=dim,
+            kernel_func=None,
+            kernel_type=None,
+            sumpy_kernel=None,
+            source_box_extent=extent,
+            dtype=np.float64,
+            progress_bar=False,
+        )
+    except Exception as exc:
+        pytest.skip(f"no mesh-generator table construction available: {exc}")
+    assert (
+        np.max(np.abs(np.asarray(real_table.q_points) - points))
+        <= 1e-13 * extent
+    )
+
+# }}}
+
+
+# {{{ T3: assembled-vs-direct parity at the classical configurations
+
+@pytest.fixture(scope="session")
+def channel_cache(tmp_path_factory):
+    return tmp_path_factory.mktemp("windowed-channels") / "channels.sqlite"
+
+
+def _direct_reference_table(
+    queue, cache_path, dim, kernel_type, q_order, parameter, level,
+    build_config,
+):
+    from volumential.table_manager import NearFieldInteractionTableManager
+
+    manager_kwargs = {}
+    get_kwargs = {}
+    if kernel_type == "Helmholtz":
+        from sumpy.kernel import HelmholtzKernel
+
+        knl = HelmholtzKernel(dim)
+        manager_kwargs["dtype"] = np.complex128
+        get_kwargs["sumpy_knl"] = knl
+        get_kwargs[knl.helmholtz_k_name] = float(parameter)
+        kernel_request = "Helmholtz-Reference"
+    else:
+        get_kwargs["lam"] = float(parameter)
+        kernel_request = "Yukawa"
+
+    with NearFieldInteractionTableManager(
+        str(cache_path),
+        root_extent=ROOT_EXTENT,
+        queue=queue,
+        **manager_kwargs,
+    ) as table_manager:
+        table, _ = table_manager.get_table(
+            dim,
+            kernel_request,
+            q_order,
+            source_box_level=level,
+            force_recompute=True,
+            queue=queue,
+            build_config=build_config,
+            **get_kwargs,
+        )
+    return table
+
+
+@pytest.mark.parametrize(
+    ("dim", "kernel_type", "q_order", "parameter", "level"),
+    [
+        (2, "Yukawa", 3, 4.0, 3),
+        (2, "Helmholtz", 3, 4.0, 3),
+        (3, "Yukawa", 2, 2.0, 2),
+        (3, "Helmholtz", 2, 2.0, 2),
+    ],
+)
+def test_windowed_matches_direct_batched(
+    tmp_path, channel_cache, dim, kernel_type, q_order, parameter, level
+):
+    chan_kwargs = CHAN_ORDERS_3D if dim == 3 else CHAN_ORDERS_2D
+    assembled, certificate = assemble_windowed_parameterized_table(
+        channel_cache,
+        dim,
+        kernel_type,
+        q_order,
+        parameter,
+        source_box_level=level,
+        window_theta=WINDOW_THETA,
+        **chan_kwargs,
+    )
+
+    if dim == 2:
+        # full manager-path reference: real mesh-generator geometry, batched
+        # OpenCL Duffy engine, full entry IDs
+        queue = _get_queue_or_skip()
+        from volumential.nearfield_potential_table import DuffyBuildConfig
+
+        direct_table = _direct_reference_table(
+            queue,
+            tmp_path / "direct.sqlite",
+            dim,
+            kernel_type,
+            q_order,
+            parameter,
+            level,
+            DuffyBuildConfig(
+                radial_rule="tanh-sinh-fast",
+                regular_quad_order=16,
+                radial_quad_order=45,
+            ),
+        )
+        ids_direct, direct_values = direct_table.get_reduced_table_data()
+        ids_direct = np.asarray(ids_direct)
+        direct_values = np.asarray(direct_values)
+    else:
+        # The 3D batched Duffy builder fails on constrained OpenCL runtimes
+        # (observed clEnqueueReadBuffer OUT_OF_RESOURCES under pocl) and its
+        # full-table scalar fallback is prohibitively slow, so reference a
+        # deterministic spot subset of the reduced entries with the
+        # pre-existing scalar Duffy engine instead (queue-free; the q-point
+        # geometry parity with the real mesh generator is pinned by
+        # test_tensor_gauss_points_match_meshgen, and the scalar engine's
+        # per-entry cost caps the affordable subset size).
+        entry_ids = np.asarray(assembled.get_reduced_entry_ids())
+        _, values_all = assembled.get_reduced_table_data()
+        positions = _spot_entry_ids(entry_ids, values_all, 6, 6)
+        ids_direct = entry_ids[positions]
+        direct_values = _scalar_direct_entries(
+            dim,
+            q_order,
+            level,
+            ids_direct,
+            _kernel_radial(dim, kernel_type, parameter),
+            deg_theta=8,
+            radial_quad_order=25,
+            complex_valued=(kernel_type == "Helmholtz"),
+        )
+        if kernel_type == "Yukawa":
+            direct_values = direct_values.real
+    assembled_values = np.asarray(
+        assembled.get_entry_data_for_full_indices(ids_direct)
+    )
+
+    scale = max(float(np.max(np.abs(direct_values))), 1e-300)
+    deviation = float(
+        np.max(np.abs(assembled_values - direct_values)) / scale
+    )
+    assert deviation < 5.0e-6, (deviation, certificate)
+    assert certificate["condition_number"] < 50.0
+    assert certificate["truncation_tail_bound"] == 0.0
+    if kernel_type == "Yukawa":
+        assert assembled.dtype == np.float64
+        assert certificate["assembled_max_abs_imag"] <= 1.0e-10 * scale
+    else:
+        assert assembled.dtype == np.complex128
+    # like the classical assembler, the result must not inherit a
+    # scale-reuse kernel identity
+    assert assembled.kernel_type is None
+
+# }}}
+
+
+# {{{ T4: high-theta parity at the design edge, with classical contrast
+
+@pytest.fixture(scope="module")
+def high_theta_direct_refs(tmp_path_factory):
+    """Direct references at theta = 16 under two quadrature policies; their
+    agreement estimates the direct references' own accuracy floor."""
+    queue = _get_queue_or_skip()
+    from volumential.nearfield_potential_table import DuffyBuildConfig
+
+    cache_dir = tmp_path_factory.mktemp("high-theta-direct")
+    policies = {
+        "mid": DuffyBuildConfig(
+            radial_rule="tanh-sinh-fast",
+            regular_quad_order=24,
+            radial_quad_order=61,
+        ),
+        "tight": DuffyBuildConfig(
+            radial_rule="tanh-sinh-fast",
+            regular_quad_order=48,
+            radial_quad_order=160,
+        ),
+    }
+    refs = {}
+    for kernel_type in ("Yukawa", "Helmholtz"):
+        per_policy = {}
+        for name, build_config in policies.items():
+            table = _direct_reference_table(
+                queue,
+                cache_dir / f"{kernel_type}-{name}.sqlite",
+                2,
+                kernel_type,
+                3,
+                64.0,
+                3,
+                build_config,
+            )
+            ids, values = table.get_reduced_table_data()
+            per_policy[name] = (np.asarray(ids), np.asarray(values))
+        refs[kernel_type] = per_policy
+    return refs
+
+
+@pytest.mark.parametrize("kernel_type", ["Yukawa", "Helmholtz"])
+def test_high_theta_parity(
+    tmp_path, channel_cache, high_theta_direct_refs, kernel_type
+):
+    ids_tight, tight_values = high_theta_direct_refs[kernel_type]["tight"]
+    ids_mid, mid_values = high_theta_direct_refs[kernel_type]["mid"]
+    assert np.array_equal(ids_tight, ids_mid)
+
+    scale = max(float(np.max(np.abs(tight_values))), 1e-300)
+    direct_floor = float(
+        np.max(np.abs(mid_values - tight_values)) / scale
+    )
+
+    assembled, certificate = assemble_windowed_parameterized_table(
+        channel_cache,
+        2,
+        kernel_type,
+        3,
+        64.0,
+        source_box_level=3,
+        window_theta=WINDOW_THETA,
+        **CHAN_ORDERS_2D,
+    )
+    assembled_values = np.asarray(
+        assembled.get_entry_data_for_full_indices(ids_tight)
+    )
+    deviation = float(
+        np.max(np.abs(assembled_values - tight_values)) / scale
+    )
+
+    assert deviation < 1.0e-4, (deviation, direct_floor, certificate)
+    # the assembled table's own accuracy floor is the one-time channel
+    # quadrature (angular order 48 holds the 2D q = 3 channel family to
+    # about 2e-7 relative — see _resolve_channel_orders), so the deviation
+    # must be explained by that floor or by the direct references' floor
+    assert deviation <= max(10.0 * direct_floor, 5.0e-7), (
+        deviation,
+        direct_floor,
+    )
+    assert certificate["condition_number"] < 50.0
+    assert certificate["theta"] == pytest.approx(16.0)
+
+    # the classical series assembly cannot serve this point: it refuses in
+    # choose_truncation_order before any table build (the pinned message
+    # distinguishes the principled refusal from an unrelated crash)
+    queue = _get_queue_or_skip()
+    with pytest.raises(ValueError, match="cannot certify"):
+        assemble_parameterized_table(
+            queue,
+            tmp_path / "classical-contrast.sqlite",
+            2,
+            kernel_type,
+            3,
+            64.0,
+            source_box_level=3,
+            tolerance=1.0e-11,
+        )
+
+# }}}
+
+
+# {{{ T5: smooth-remainder order convergence
+
+def test_smooth_order_convergence(channel_cache):
+    dim, q_order, level, parameter = 2, 3, 3, 32.0  # theta = 8
+    probe_smooth_orders = (8, 16, 24, 32)
+
+    tables = {}
+    for smooth_order in probe_smooth_orders:
+        table, certificate = assemble_windowed_parameterized_table(
+            channel_cache,
+            dim,
+            "Yukawa",
+            q_order,
+            parameter,
+            source_box_level=level,
+            window_theta=WINDOW_THETA,
+            p_star=6,
+            smooth_quad_order=smooth_order,
+            **CHAN_ORDERS_2D,
+        )
+        assert certificate["smooth_quad_order"] == smooth_order
+        tables[smooth_order] = table
+
+    entry_ids = np.asarray(tables[32].get_reduced_entry_ids())
+    _, finest_values = tables[32].get_reduced_table_data()
+    positions = _spot_entry_ids(entry_ids, finest_values, 6, 6)
+    spot_ids = entry_ids[positions]
+
+    reference = _scalar_direct_entries(
+        dim,
+        q_order,
+        level,
+        spot_ids,
+        _kernel_radial(dim, "Yukawa", parameter),
+        deg_theta=48,
+        radial_quad_order=160,
+    ).real
+    scale = max(float(np.max(np.abs(reference))), 1e-300)
+
+    deviations = []
+    for smooth_order in probe_smooth_orders:
+        values = np.asarray(
+            tables[smooth_order].get_entry_data_for_full_indices(spot_ids)
+        )
+        deviations.append(
+            float(np.max(np.abs(values - reference)) / scale)
+        )
+
+    # non-increasing within noise, and converged (plateaued) by order 32
+    for coarse, fine in zip(deviations[:-1], deviations[1:]):
+        assert fine <= 1.25 * coarse + 1e-9, deviations
+    assert deviations[-1] <= 1.25 * deviations[-2] + 1e-9, deviations
+    assert deviations[-1] < 1e-6, deviations
+
+# }}}
+
+
+# {{{ T6: complex squared frequency (damped Helmholtz)
+
+def test_complex_zeta_damped_helmholtz(channel_cache):
+    import scipy.special as sps
+
+    dim, q_order, level = 2, 3, 3
+    k_complex = 8.0 * (1.0 + 0.05j)
+    zeta = -(k_complex * k_complex)
+
+    def kernel_radial(r):
+        return 0.25j * sps.hankel1(
+            0, k_complex * np.asarray(r, dtype=np.complex128)
+        )
+
+    table, certificate = _assemble_windowed_for_zeta(
+        channel_cache,
+        dim,
+        q_order,
+        zeta,
+        kernel_radial,
+        source_box_level=level,
+        window_theta=WINDOW_THETA,
+        **CHAN_ORDERS_2D,
+    )
+    assert certificate["condition_number"] < 50.0
+    assert complex(certificate["zeta_real"], certificate["zeta_imag"]) == (
+        pytest.approx(zeta)
+    )
+
+    entry_ids = np.asarray(table.get_reduced_entry_ids())
+    _, values_all = table.get_reduced_table_data()
+    positions = _spot_entry_ids(entry_ids, values_all, 3, 3)
+    spot_ids = entry_ids[positions]
+    assembled_values = np.asarray(
+        table.get_entry_data_for_full_indices(spot_ids)
+    )
+
+    reference = _scalar_direct_entries(
+        dim,
+        q_order,
+        level,
+        spot_ids,
+        kernel_radial,
+        deg_theta=48,
+        radial_quad_order=160,
+        complex_valued=True,
+    )
+    scale = max(float(np.max(np.abs(reference))), 1e-300)
+    deviation = float(
+        np.max(np.abs(assembled_values - reference)) / scale
+    )
+    assert deviation < 1e-5, deviation
+
+# }}}
+
+
+# {{{ T7: p_star knob at the design edge
+
+def test_p_star_knob_at_design_theta(channel_cache):
+    dim, q_order, level, parameter = 2, 3, 3, 64.0  # theta = 16
+
+    values_by_p_star = {}
+    for p_star in (4, 6):
+        table, certificate = assemble_windowed_parameterized_table(
+            channel_cache,
+            dim,
+            "Yukawa",
+            q_order,
+            parameter,
+            source_box_level=level,
+            window_theta=WINDOW_THETA,
+            p_star=p_star,
+            **CHAN_ORDERS_2D,
+        )
+        assert certificate["condition_number"] < 50.0
+        assert certificate["p_star"] == p_star
+        # pin the window-units contract directly: t_w = (b/Theta)^2, and at
+        # theta = Theta the coefficient bound (theta/Theta)^{2m}/m! peaks
+        # at exactly 1 — a (1/Theta)^2-style units bug would break both
+        assert certificate["window_scale_t_w"] == pytest.approx(
+            (_box_extent(level) / WINDOW_THETA) ** 2, rel=1e-14
+        )
+        assert certificate["coefficient_bound"] == pytest.approx(
+            1.0, rel=1e-12
+        )
+        values_by_p_star[p_star] = table
+
+    entry_ids = np.asarray(values_by_p_star[6].get_reduced_entry_ids())
+    _, finest_values = values_by_p_star[6].get_reduced_table_data()
+    positions = _spot_entry_ids(entry_ids, finest_values, 4, 4)
+    spot_ids = entry_ids[positions]
+
+    reference = _scalar_direct_entries(
+        dim,
+        q_order,
+        level,
+        spot_ids,
+        _kernel_radial(dim, "Yukawa", parameter),
+        deg_theta=48,
+        radial_quad_order=160,
+    ).real
+    scale = max(float(np.max(np.abs(reference))), 1e-300)
+
+    deviations = {}
+    for p_star, table in values_by_p_star.items():
+        values = np.asarray(
+            table.get_entry_data_for_full_indices(spot_ids)
+        )
+        deviations[p_star] = float(
+            np.max(np.abs(values - reference)) / scale
+        )
+
+    # more retained channels must not lose accuracy (equality within the
+    # shared quadrature floor is allowed) ...
+    assert deviations[6] <= 1.5 * deviations[4] + 1e-8, deviations
+    # ... and the flagship p_star must be absolutely accurate against the
+    # independent scalar reference at the design edge — this queue-free
+    # absolute bound catches recombination bugs (e.g. a dropped channel)
+    # that leave the p_star ratio above intact
+    assert deviations[6] < 1e-5, deviations
+
+
+def test_high_theta_helmholtz_scalar_parity(channel_cache):
+    """Queue-free absolute parity for Helmholtz at the design edge
+    theta = Theta (the Yukawa counterpart is the absolute bound in
+    test_p_star_knob_at_design_theta): catches wrapper-side zeta-sign or
+    normalization bugs that are invisible at small theta."""
+    dim, q_order, level, parameter = 2, 3, 3, 64.0  # theta = 16
+
+    table, certificate = assemble_windowed_parameterized_table(
+        channel_cache,
+        dim,
+        "Helmholtz",
+        q_order,
+        parameter,
+        source_box_level=level,
+        window_theta=WINDOW_THETA,
+        **CHAN_ORDERS_2D,
+    )
+    assert certificate["condition_number"] < 50.0
+
+    entry_ids = np.asarray(table.get_reduced_entry_ids())
+    _, values_all = table.get_reduced_table_data()
+    positions = _spot_entry_ids(entry_ids, values_all, 4, 4)
+    spot_ids = entry_ids[positions]
+    assembled_values = np.asarray(
+        table.get_entry_data_for_full_indices(spot_ids)
+    )
+
+    reference = _scalar_direct_entries(
+        dim,
+        q_order,
+        level,
+        spot_ids,
+        _kernel_radial(dim, "Helmholtz", parameter),
+        deg_theta=48,
+        radial_quad_order=160,
+        complex_valued=True,
+    )
+    scale = max(float(np.max(np.abs(reference))), 1e-300)
+    deviation = float(
+        np.max(np.abs(assembled_values - reference)) / scale
+    )
+    assert deviation < 1e-5, deviation
+
+# }}}
+
+
+# {{{ T8: default channel orders serve the flagship configuration
+
+def test_default_channel_orders(channel_cache):
+    from volumential.rke_table_assembly import _resolve_channel_orders
+
+    # 2D resolves to the reference-grade angular order the parity tests use;
+    # 3D keeps the mild-geometry default; explicit values pass through
+    assert _resolve_channel_orders(2, None, None) == (48, 61)
+    assert _resolve_channel_orders(3, None, None) == (20, 61)
+    assert _resolve_channel_orders(2, 20, 45) == (20, 45)
+
+    # the all-defaults public path resolves to the same channel family the
+    # parity tests certify (same cache key), hence identical entries
+    common = {
+        "source_box_level": 3,
+        "window_theta": WINDOW_THETA,
+    }
+    default_table, default_certificate = (
+        assemble_windowed_parameterized_table(
+            channel_cache, 2, "Yukawa", 3, 4.0, **common
+        )
+    )
+    explicit_table, _ = assemble_windowed_parameterized_table(
+        channel_cache, 2, "Yukawa", 3, 4.0, **common, **CHAN_ORDERS_2D
+    )
+    assert default_certificate["channel_quadrature_orders"] == {
+        "regular": 48,
+        "radial": 61,
+    }
+    ids_default, values_default = default_table.get_reduced_table_data()
+    ids_explicit, values_explicit = explicit_table.get_reduced_table_data()
+    assert np.array_equal(np.asarray(ids_default), np.asarray(ids_explicit))
+    assert np.array_equal(
+        np.asarray(values_default), np.asarray(values_explicit)
+    )
+
+# }}}
+
+
+# {{{ T9: channel cache self-heals after torn or corrupted writes
+
+def test_channel_cache_self_heals(tmp_path):
+    from pathlib import Path
+
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    cache = tmp_path / "heal.sqlite"
+    kwargs = {
+        "source_box_level": 3,
+        "root_extent": ROOT_EXTENT,
+        "window_theta": WINDOW_THETA,
+        "chan_regular_order": 6,
+        "chan_radial_order": 15,
+    }
+    table = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    ids, values = table.get_reduced_table_data()
+
+    cache_dir = Path(str(cache) + ".windowed")
+    cache_files = sorted(cache_dir.glob("*.npz"))
+    assert len(cache_files) == 1
+    assert not list(cache_dir.glob("*.tmp-*"))
+
+    # a torn write (interrupted np.savez / concurrent process) must rebuild,
+    # not raise zipfile.BadZipFile forever
+    payload = cache_files[0].read_bytes()
+    cache_files[0].write_bytes(payload[: len(payload) // 2])
+    healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    ids_healed, values_healed = healed.get_reduced_table_data()
+    assert np.array_equal(np.asarray(ids), np.asarray(ids_healed))
+    assert np.array_equal(np.asarray(values), np.asarray(values_healed))
+
+    # arbitrary garbage (stale format) likewise self-heals
+    cache_files[0].write_bytes(b"not a zip file")
+    healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    assert np.array_equal(
+        np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])
+    )
+
+    # and the rebuilt file is a valid cache again (no rebuild artifacts)
+    reloaded = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    assert np.array_equal(
+        np.asarray(values), np.asarray(reloaded.get_reduced_table_data()[1])
+    )
+    assert not list(cache_dir.glob("*.tmp-*"))
+
+# }}}
+
+
+# {{{ T10: declaration and guard paths
+
+def test_windowed_declaration_guards(tmp_path):
+    cache = tmp_path / "guards.sqlite"
+
+    # theta = parameter * b beyond the declared window Theta
+    with pytest.raises(ValueError, match="exceeds the declared window"):
+        assemble_windowed_parameterized_table(
+            cache,
+            2,
+            "Yukawa",
+            3,
+            65.0,  # theta = 65 * 0.25 = 16.25 > 16
+            source_box_level=3,
+            window_theta=WINDOW_THETA,
+        )
+
+    # nonpositive parameter
+    for bad_parameter in (0.0, -4.0):
+        with pytest.raises(ValueError, match="positive parameter"):
+            assemble_windowed_parameterized_table(
+                cache, 2, "Yukawa", 3, bad_parameter, source_box_level=3
+            )
+
+    # p_star must retain at least the m = 0 channel
+    with pytest.raises(ValueError, match="p_star"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 3, 4.0, source_box_level=3, p_star=0
+        )
+
+    # unsupported kernel family
+    with pytest.raises(NotImplementedError):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Stokeslet", 3, 4.0, source_box_level=3
+        )
+
+    # box extents outside the certified O(1) range must refuse (parallel to
+    # the classical assembler) instead of silently dropping the singular
+    # channel content (extent-scaled Duffy degeneracy tests)
+    with pytest.raises(ValueError, match="outside the supported"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 2, 1.0, source_box_level=30
+        )
+    with pytest.raises(ValueError, match="outside the supported"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 2, 1.0, root_extent=1e-6, source_box_level=5
+        )
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    with pytest.raises(ValueError, match="outside the supported"):
+        get_windowed_channel_table(cache, 2, 2, 0, source_box_level=30)
+
+    # the complex-zeta entry point enforces the declaration disk
+    # |zeta| <= (Theta/b)^2 itself (not only the real-parameter wrapper)
+    import scipy.special as sps
+
+    k_out = 100.0  # theta = 25 > Theta = 16
+
+    def kernel_radial(r):
+        return 0.25j * sps.hankel1(
+            0, k_out * np.asarray(r, dtype=np.complex128)
+        )
+
+    with pytest.raises(ValueError, match="coverage disk"):
+        _assemble_windowed_for_zeta(
+            cache,
+            2,
+            3,
+            complex(-(k_out * k_out)),
+            kernel_radial,
+            source_box_level=3,
+            window_theta=WINDOW_THETA,
+        )
+
+
+def test_windowed_condition_guard(tmp_path):
+    # the peak-sum condition estimate is >= 1 by the triangle inequality, so
+    # a sub-unit max_condition must always trip the guard after assembly
+    cache = tmp_path / "guards.sqlite"
+    with pytest.raises(RuntimeError, match="ill-conditioned"):
+        assemble_windowed_parameterized_table(
+            cache,
+            2,
+            "Yukawa",
+            3,
+            4.0,
+            source_box_level=3,
+            p_star=2,
+            smooth_quad_order=8,
+            max_condition=0.5,
+            chan_regular_order=6,
+            chan_radial_order=15,
+        )
+
+
+def test_windowed_reality_guard(tmp_path):
+    # requesting a real (Yukawa-typed) result for a genuinely complex kernel
+    # must fail loudly, proving the reality check precedes the .real cast
+    import scipy.special as sps
+
+    cache = tmp_path / "guards.sqlite"
+    k = 4.0
+
+    def kernel_radial(r):
+        return 0.25j * sps.hankel1(0, k * np.asarray(r, dtype=np.complex128))
+
+    with pytest.raises(RuntimeError, match="imaginary part"):
+        _assemble_windowed_for_zeta(
+            cache,
+            2,
+            3,
+            complex(-(k * k)),
+            kernel_radial,
+            source_box_level=3,
+            p_star=2,
+            smooth_quad_order=8,
+            chan_regular_order=6,
+            chan_radial_order=15,
+            result_dtype=np.float64,
+        )
+
+# }}}
+
+
+if __name__ == "__main__":
+    import sys
+
+    pytest.main([sys.argv[0], "-x", "-q"])

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -252,6 +252,39 @@ def test_channel_profiles_match_mpmath(dim):
         mp.mp.dps = old_dps
 
 
+@pytest.mark.parametrize(("dim", "m", "x"), [
+    (2, 20, 60.0),
+    (3, 20, 60.0),
+    (2, 60, 240.0),
+    (3, 60, 240.0),
+    (3, 200, 240.0),
+])
+def test_high_order_channel_profiles_remain_positive_and_stable(dim, m, x):
+    import mpmath as mp
+
+    radius = 2.0 * np.sqrt(x)
+    actual = windowed_channel_profile(dim, m, 1.0)(radius)
+
+    old_dps = mp.mp.dps
+    mp.mp.dps = 100
+    try:
+        x_mp = mp.mpf(str(x))
+        if dim == 2:
+            expected = mp.mpf("0.5") * x_mp**m * mp.gammainc(
+                -m, x_mp, mp.inf
+            )
+        else:
+            expected = x_mp ** (m - mp.mpf("0.5")) * mp.gammainc(
+                mp.mpf("0.5") - m, x_mp, mp.inf
+            ) / (2 * mp.sqrt(mp.pi))
+        expected = float(expected)
+    finally:
+        mp.mp.dps = old_dps
+
+    assert actual > 0.0
+    assert actual == pytest.approx(expected, rel=2.0e-12, abs=0.0)
+
+
 @pytest.mark.parametrize("dim", [2, 3])
 @pytest.mark.parametrize("zeta_sign", [-1, 1])
 def test_high_order_small_extent_remainder_matches_mpmath(dim, zeta_sign):

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -35,7 +35,6 @@ from volumential.rke_table_assembly import (
     windowed_remainder_profile,
 )
 
-
 WINDOW_THETA = 16.0
 ROOT_EXTENT = 2.0
 
@@ -168,6 +167,39 @@ def _scalar_direct_entries(
     return values
 
 
+def _tensor_gauss_direct_q1_entries(table, entry_ids, kernel_radial, order):
+    """Independent direct quadrature for nonsingular q=1 table entries."""
+    assert int(table.quad_order) == 1
+    extent = float(table.source_box_extent)
+    nodes, weights = np.polynomial.legendre.leggauss(order)
+    axis_nodes = 0.5 * extent * (nodes + 1.0)
+    axis_weights = 0.5 * extent * weights
+    grids = np.meshgrid(axis_nodes, axis_nodes, axis_nodes, indexing="ij")
+    weight_tensor = (
+        axis_weights[:, np.newaxis, np.newaxis]
+        * axis_weights[np.newaxis, :, np.newaxis]
+        * axis_weights[np.newaxis, np.newaxis, :]
+    )
+
+    values = []
+    for entry_id in entry_ids:
+        case_index = int(entry_id // table.n_pairs)
+        pair_id = int(entry_id % table.n_pairs)
+        source_mode = pair_id // table.n_q_points
+        target_index = pair_id % table.n_q_points
+        assert source_mode == 0
+        target = np.asarray(
+            table.find_target_point(target_index, case_index)
+        )
+        assert np.max(np.abs(target.imag)) == 0.0
+        target = target.real
+        radius = np.sqrt(
+            sum((grids[axis] - target[axis]) ** 2 for axis in range(3))
+        )
+        values.append(np.sum(kernel_radial(radius) * weight_tensor))
+    return np.asarray(values)
+
+
 def _spot_entry_ids(entry_ids, values, n_top=6, n_spread=6):
     """A deterministic subset: the largest-magnitude entries plus an even
     spread across the reduced list."""
@@ -218,6 +250,79 @@ def test_channel_profiles_match_mpmath(dim):
                 ), (dim, m, radius)
     finally:
         mp.mp.dps = old_dps
+
+
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("zeta_sign", [-1, 1])
+def test_high_order_small_extent_remainder_matches_mpmath(dim, zeta_sign):
+    import mpmath as mp
+
+    box_extent = 1.0e-3
+    window_scale = (box_extent / WINDOW_THETA) ** 2
+    zeta = zeta_sign * (WINDOW_THETA / box_extent) ** 2
+    radii = box_extent * np.array([0.05, 0.1, 0.25])
+
+    def zero_kernel(r):
+        return np.zeros_like(np.asarray(r, dtype=np.float64))
+
+    remainder = windowed_remainder_profile(
+        dim, zeta, zero_kernel, window_scale, 60
+    )
+    values = np.asarray(remainder(radii), dtype=np.complex128)
+    assert np.all(np.isfinite(values))
+
+    old_dps = mp.mp.dps
+    mp.mp.dps = 80
+    try:
+        t_w = mp.mpf(window_scale)
+        scaled_zeta = mp.mpf(zeta_sign)
+        prefactor = 1 / (2 * mp.pi) if dim == 2 else 1 / (4 * mp.pi)
+        reference = []
+        for radius in radii:
+            x = mp.mpf(radius) ** 2 / (4 * t_w)
+            coefficient = mp.mpf(1)
+            channel_sum = mp.mpc(0)
+            for m in range(60):
+                if dim == 2:
+                    profile = mp.mpf("0.5") * x**m * mp.gammainc(
+                        -m, x, mp.inf
+                    )
+                else:
+                    profile = (
+                        t_w ** mp.mpf("-0.5")
+                        * x ** (mp.mpf(m) - mp.mpf("0.5"))
+                        * mp.gammainc(mp.mpf("0.5") - m, x, mp.inf)
+                        / (2 * mp.sqrt(mp.pi))
+                    )
+                channel_sum += coefficient * profile
+                coefficient *= -scaled_zeta / (m + 1)
+            reference.append(complex(-prefactor * channel_sum))
+    finally:
+        mp.mp.dps = old_dps
+
+    np.testing.assert_allclose(
+        values, np.asarray(reference), rtol=2.0e-11, atol=1.0e-12
+    )
+
+
+def test_high_order_small_extent_assembly_stays_finite(tmp_path):
+    table, certificate = assemble_windowed_parameterized_table(
+        tmp_path / "p60.sqlite",
+        2,
+        "Yukawa",
+        1,
+        1.6e4,
+        root_extent=1.0e-3,
+        window_theta=WINDOW_THETA,
+        p_star=60,
+        smooth_quad_order=8,
+        chan_regular_order=2,
+        chan_radial_order=7,
+    )
+    values = np.asarray(table.get_reduced_table_data()[1])
+    assert np.all(np.isfinite(values))
+    assert np.all(np.isfinite(certificate["per_channel_peak"]))
+    assert certificate["coefficient_bound"] == pytest.approx(1.0)
 
 
 def test_vectorized_channel_builder_matches_scalar_duffy():
@@ -658,6 +763,158 @@ def test_high_theta_parity(
             tolerance=1.0e-11,
         )
 
+
+@pytest.mark.parametrize("kernel_type", ["Yukawa", "Helmholtz"])
+def test_3d_design_edge_table_parity_and_refinement(tmp_path, kernel_type):
+    dim, q_order, level, parameter = 3, 1, 3, 64.0  # theta = 16
+    cache = tmp_path / "3d-design-edge.sqlite"
+    tables = {}
+    certificates = {}
+    for name, smooth_order in (("coarse", 10), ("fine", 24)):
+        tables[name], certificates[name] = assemble_windowed_parameterized_table(
+            cache,
+            dim,
+            kernel_type,
+            q_order,
+            parameter,
+            source_box_level=level,
+            window_theta=WINDOW_THETA,
+            p_star=4,
+            smooth_quad_order=smooth_order,
+            chan_regular_order=8,
+            chan_radial_order=25,
+        )
+
+    fine = tables["fine"]
+    extent = float(fine.source_box_extent)
+    candidates = []
+    for entry_id in np.asarray(fine.get_reduced_entry_ids()):
+        case_index = int(entry_id // fine.n_pairs)
+        pair_id = int(entry_id % fine.n_pairs)
+        target_index = pair_id % fine.n_q_points
+        target = np.asarray(
+            fine.find_target_point(target_index, case_index)
+        ).real
+        outside = np.maximum(np.maximum(-target, target - extent), 0.0)
+        distance = float(np.linalg.norm(outside))
+        # Four window widths from the box still exercise a visible channel
+        # correction while avoiding a singular direct-reference integral.
+        if 0.2 * extent <= distance <= 0.5 * extent:
+            candidates.append((distance, int(entry_id)))
+    assert len(candidates) >= 3
+    spot_ids = np.asarray(
+        [entry_id for _, entry_id in sorted(candidates)[:3]], dtype=np.int64
+    )
+
+    kernel_radial = _kernel_radial(dim, kernel_type, parameter)
+    reference_mid = _tensor_gauss_direct_q1_entries(
+        fine, spot_ids, kernel_radial, 28
+    )
+    reference = _tensor_gauss_direct_q1_entries(
+        fine, spot_ids, kernel_radial, 40
+    )
+    if kernel_type == "Yukawa":
+        reference_mid = reference_mid.real
+        reference = reference.real
+    scale = max(float(np.max(np.abs(reference))), 1e-300)
+    direct_floor = float(np.max(np.abs(reference_mid - reference)) / scale)
+    deviations = {
+        name: float(
+            np.max(
+                np.abs(
+                    np.asarray(table.get_entry_data_for_full_indices(spot_ids))
+                    - reference
+                )
+            )
+            / scale
+        )
+        for name, table in tables.items()
+    }
+
+    assert direct_floor < 1.0e-9, direct_floor
+    assert deviations["fine"] < 2.0e-6, deviations
+    assert deviations["fine"] <= 0.2 * deviations["coarse"], deviations
+    assert certificates["fine"]["theta"] == pytest.approx(WINDOW_THETA)
+    assert certificates["fine"]["condition_number"] < 10.0
+
+
+@pytest.mark.full_accuracy
+def test_3d_design_edge_singular_nonconstant_mode(tmp_path):
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    dim, q_order, level, parameter = 3, 2, 3, 64.0  # theta = 16
+    cache = tmp_path / "3d-design-edge-singular.sqlite"
+    table, certificate = assemble_windowed_parameterized_table(
+        cache,
+        dim,
+        "Yukawa",
+        q_order,
+        parameter,
+        source_box_level=level,
+        window_theta=WINDOW_THETA,
+        p_star=2,
+        smooth_quad_order=24,
+        chan_regular_order=6,
+        chan_radial_order=15,
+    )
+
+    extent = float(table.source_box_extent)
+    self_cases = []
+    for case_index in range(table.n_cases):
+        target = np.asarray(table.find_target_point(0, case_index)).real
+        if np.all((target > 0.0) & (target < extent)):
+            self_cases.append(case_index)
+    assert len(self_cases) == 1
+
+    source_mode = 1
+    target_index = 0
+    mode_axes = np.asarray(table._get_all_mode_axes())[source_mode]
+    assert tuple(mode_axes) != (0, 0, 0)
+    entry_id = (
+        self_cases[0] * table.n_pairs
+        + source_mode * table.n_q_points
+        + target_index
+    )
+    entry_ids = np.asarray([entry_id], dtype=np.int64)
+    assembled = np.asarray(
+        table.reconstruct_full_table_from_symmetry()[entry_ids]
+    )
+
+    # The normalized m=1 channel must itself carry a finite, nonzero value at
+    # this singular self entry, rather than passing through only the m=0 germ.
+    channel_m1 = get_windowed_channel_table(
+        cache,
+        dim,
+        q_order,
+        1,
+        source_box_level=level,
+        window_theta=WINDOW_THETA,
+        chan_regular_order=6,
+        chan_radial_order=15,
+    )
+    channel_value = np.asarray(
+        channel_m1.reconstruct_full_table_from_symmetry()[entry_ids]
+    )
+    assert channel_m1._windowed_cache_disposition == "hit"
+    assert np.all(np.isfinite(channel_value))
+    assert np.max(np.abs(channel_value)) > 0.0
+
+    reference = _scalar_direct_entries(
+        dim,
+        q_order,
+        level,
+        entry_ids,
+        _kernel_radial(dim, "Yukawa", parameter),
+        deg_theta=6,
+        radial_quad_order=15,
+    ).real
+    scale = max(float(np.max(np.abs(reference))), 1e-300)
+    deviation = float(np.max(np.abs(assembled - reference)) / scale)
+    assert deviation < 5.0e-3, (deviation, assembled, reference)
+    assert certificate["theta"] == pytest.approx(WINDOW_THETA)
+    assert certificate["condition_number"] < 10.0
+
+
 # }}}
 
 
@@ -926,6 +1183,89 @@ def test_default_channel_orders(channel_cache):
 
 # {{{ T9: channel cache self-heals after torn or corrupted writes
 
+@pytest.mark.parametrize("dim", [2, 3])
+def test_high_order_normalized_channel_cache(tmp_path, dim):
+    from pathlib import Path
+
+    import volumential.rke_table_assembly as rta
+
+    cache = tmp_path / "normalized.sqlite"
+    table = rta.get_windowed_channel_table(
+        cache,
+        dim,
+        1,
+        59,
+        root_extent=1.0e-3,
+        window_theta=WINDOW_THETA,
+        chan_regular_order=2,
+        chan_radial_order=7,
+    )
+    entry_ids, values = table.get_reduced_table_data()
+    entry_ids = np.asarray(entry_ids)
+    values = np.asarray(values)
+    assert np.all(np.isfinite(values))
+    assert np.max(np.abs(values)) > 0.0
+    assert table._windowed_cache_disposition == "rebuilt"
+
+    cache_dir = Path(str(cache) + ".windowed")
+    (cache_file,) = sorted(cache_dir.glob("*.npz"))
+    with np.load(cache_file, allow_pickle=False) as payload:
+        assert payload["key_cache_schema"].item() == 2
+        assert payload["key_normalization"].item() == "psi=chi/t_w**m"
+        assert payload["payload_checksum"].item() == (
+            rta._windowed_channel_payload_checksum(entry_ids, values)
+        )
+
+    reloaded = rta.get_windowed_channel_table(
+        cache,
+        dim,
+        1,
+        59,
+        root_extent=1.0e-3,
+        window_theta=WINDOW_THETA,
+        chan_regular_order=2,
+        chan_radial_order=7,
+    )
+    assert np.array_equal(
+        values, np.asarray(reloaded.get_reduced_table_data()[1])
+    )
+    assert reloaded._windowed_cache_disposition == "hit"
+
+
+def test_channel_cache_disposition(tmp_path):
+    from pathlib import Path
+
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    cache = tmp_path / "disposition.sqlite"
+    kwargs = {
+        "chan_regular_order": 2,
+        "chan_radial_order": 7,
+    }
+    rebuilt = get_windowed_channel_table(cache, 2, 1, 0, **kwargs)
+    values = np.asarray(rebuilt.get_reduced_table_data()[1])
+    assert rebuilt._windowed_cache_disposition == "rebuilt"
+
+    hit = get_windowed_channel_table(cache, 2, 1, 0, **kwargs)
+    assert hit._windowed_cache_disposition == "hit"
+    assert np.array_equal(values, np.asarray(hit.get_reduced_table_data()[1]))
+
+    cache_dir = Path(str(cache) + ".windowed")
+    (cache_file,) = sorted(cache_dir.glob("*.npz"))
+    with np.load(cache_file, allow_pickle=False) as payload:
+        arrays = {name: payload[name] for name in payload.files}
+    arrays["payload_checksum"] = np.asarray("0" * 64)
+    np.savez(cache_file, **arrays)
+
+    recovered = get_windowed_channel_table(cache, 2, 1, 0, **kwargs)
+    assert recovered._windowed_cache_disposition == "rebuilt"
+    assert np.array_equal(
+        values, np.asarray(recovered.get_reduced_table_data()[1])
+    )
+    reloaded = get_windowed_channel_table(cache, 2, 1, 0, **kwargs)
+    assert reloaded._windowed_cache_disposition == "hit"
+
+
 def test_channel_cache_self_heals(tmp_path):
     from pathlib import Path
 
@@ -945,12 +1285,13 @@ def test_channel_cache_self_heals(tmp_path):
     cache_dir = Path(str(cache) + ".windowed")
     cache_files = sorted(cache_dir.glob("*.npz"))
     assert len(cache_files) == 1
+    cache_file = cache_files[0]
     assert not list(cache_dir.glob("*.tmp-*"))
 
     # a torn write (interrupted np.savez / concurrent process) must rebuild,
     # not raise zipfile.BadZipFile forever
-    payload = cache_files[0].read_bytes()
-    cache_files[0].write_bytes(payload[: len(payload) // 2])
+    payload = cache_file.read_bytes()
+    cache_file.write_bytes(payload[: len(payload) // 2])
     healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
     ids_healed, values_healed = healed.get_reduced_table_data()
     assert np.array_equal(np.asarray(ids), np.asarray(ids_healed))
@@ -958,26 +1299,69 @@ def test_channel_cache_self_heals(tmp_path):
 
     # the heal must have rewritten the same deterministic cache key, or the
     # next corruption step would poison an orphan file and assert nothing
-    assert sorted(cache_dir.glob("*.npz")) == cache_files
+    refreshed_files = sorted(cache_dir.glob("*.npz"))
+    assert refreshed_files == cache_files
+    cache_files = refreshed_files
+    cache_file = cache_files[0]
 
     # arbitrary garbage (stale format) likewise self-heals
-    cache_files[0].write_bytes(b"not a zip file")
+    cache_file.write_bytes(b"not a zip file")
     healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
     assert np.array_equal(
         np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])
     )
+    refreshed_files = sorted(cache_dir.glob("*.npz"))
+    assert refreshed_files == cache_files
+    cache_files = refreshed_files
+    cache_file = cache_files[0]
 
     # a loadable file whose key and entry IDs check out but whose value array
     # has the wrong shape must also rebuild: accepting it would raise out of
     # ``set_reduced_table_data`` and wedge every later call on the bad file
-    with np.load(cache_files[0], allow_pickle=False) as payload:
+    with np.load(cache_file, allow_pickle=False) as payload:
         arrays = {name: payload[name] for name in payload.files}
     arrays["values"] = np.asarray(arrays["values"])[:-1]
-    np.savez(cache_files[0], **arrays)
+    np.savez(cache_file, **arrays)
     healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
     assert np.array_equal(
         np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])
     )
+    refreshed_files = sorted(cache_dir.glob("*.npz"))
+    assert refreshed_files == cache_files
+    cache_files = refreshed_files
+    cache_file = cache_files[0]
+
+    # A physical-channel or otherwise stale normalization identity must never
+    # alias the normalized psi_m cache, even if placed at the active path.
+    with np.load(cache_file, allow_pickle=False) as payload:
+        arrays = {name: payload[name] for name in payload.files}
+    arrays["key_normalization"] = np.asarray("physical-chi")
+    np.savez(cache_file, **arrays)
+    healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    assert np.array_equal(
+        np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])
+    )
+    refreshed_files = sorted(cache_dir.glob("*.npz"))
+    assert refreshed_files == cache_files
+    cache_files = refreshed_files
+    cache_file = cache_files[0]
+
+    # Finite, in-bound corruption is invisible to the analytic magnitude
+    # check, so the payload checksum must force a rebuild.
+    with np.load(cache_file, allow_pickle=False) as payload:
+        arrays = {name: payload[name] for name in payload.files}
+    corrupted = np.asarray(arrays["values"]).copy()
+    corrupted[0] = np.nextafter(corrupted[0], np.inf)
+    arrays["values"] = corrupted
+    np.savez(cache_file, **arrays)
+    healed = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    assert np.array_equal(
+        np.asarray(values), np.asarray(healed.get_reduced_table_data()[1])
+    )
+    refreshed_files = sorted(cache_dir.glob("*.npz"))
+    assert refreshed_files == cache_files
+    cache_files = refreshed_files
+    cache_file = cache_files[0]
 
     # and the rebuilt file is a valid cache again (no rebuild artifacts)
     reloaded = get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
@@ -990,6 +1374,213 @@ def test_channel_cache_self_heals(tmp_path):
 
 
 # {{{ T10: declaration and guard paths
+
+def test_bool_rejection_and_max_terms_guard():
+    import volumential.rke_table_assembly as rta
+
+    for bad_bool in (True, np.bool_(False)):
+        with pytest.raises(ValueError, match="value must be an integer"):
+            rta._require_integer("value", bad_bool)
+
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        _tensor_product_gauss_points(True, 2, 1.0)
+    with pytest.raises(ValueError, match="max_terms must be an integer"):
+        rta.choose_truncation_order(3, 0.0, 1.0, 1.0e-12, max_terms=True)
+    with pytest.raises(ValueError, match="max_terms must be >= 1"):
+        rta.choose_truncation_order(3, 0.0, 1.0, 1.0e-12, max_terms=0)
+
+    n_terms, bound = rta.choose_truncation_order(
+        3, 0.0, 1.0, 1.0e-12, max_terms=np.int64(1)
+    )
+    assert n_terms == 1
+    assert bound == 0.0
+
+
+def test_windowed_integer_parameters_require_index(tmp_path):
+    import volumential.rke_table_assembly as rta
+
+    cache = tmp_path / "integer-guards.sqlite"
+
+    def zero_kernel(r):
+        return np.zeros_like(np.asarray(r, dtype=np.float64))
+
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        rta.choose_truncation_order(np.float64(2.0), 1j, 1.0, 1.0e-6)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        assemble_parameterized_table(None, cache, 2.0, "Yukawa", 1, 1.0)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        windowed_channel_profile(2.0, 0, 1.0)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        _tensor_product_gauss_points(1, 2.0, 1.0)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        _windowed_channel_skeleton(2.0, 1, 0, ROOT_EXTENT, WINDOW_THETA, 0)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        rta._windowed_channel_cache_file(
+            cache, 2.0, 1, 0, ROOT_EXTENT, WINDOW_THETA, 0, 2, 7
+        )
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        rta.get_windowed_channel_table(cache, 2.0, 1, 0)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        _assemble_windowed_for_zeta(cache, 2.0, 1, 1.0, zero_kernel)
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        assemble_windowed_parameterized_table(
+            cache, 2.0, "Yukawa", 1, 1.0
+        )
+    with pytest.raises(ValueError, match="dim must be an integer"):
+        rta._resolve_channel_orders(2.0, 2, 7)
+    with pytest.raises(NotImplementedError, match="only 2D and 3D"):
+        _tensor_product_gauss_points(1, 4, 1.0)
+
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        assemble_parameterized_table(None, cache, 2, "Yukawa", 1.5, 1.0)
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        _tensor_product_gauss_points(1.5, 2, 1.0)
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        _windowed_channel_skeleton(2, 1.5, 0, ROOT_EXTENT, WINDOW_THETA, 0)
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        rta._windowed_channel_cache_file(
+            cache, 2, 1.5, 0, ROOT_EXTENT, WINDOW_THETA, 0, 2, 7
+        )
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        rta.get_windowed_channel_table(cache, 2, 1.5, 0)
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        _assemble_windowed_for_zeta(cache, 2, 1.5, 1.0, zero_kernel)
+    with pytest.raises(ValueError, match="q_order must be an integer"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 1.5, 1.0
+        )
+    with pytest.raises(ValueError, match="q_order must be >= 1"):
+        _tensor_product_gauss_points(0, 2, 1.0)
+    with pytest.raises(ValueError, match="q_order must be >= 1"):
+        rta.get_windowed_channel_table(cache, 2, 0, 0)
+
+    with pytest.raises(ValueError, match="source_box_level must be an integer"):
+        assemble_parameterized_table(
+            None, cache, 2, "Yukawa", 1, 1.0, source_box_level=0.5
+        )
+    with pytest.raises(ValueError, match="source_box_level must be an integer"):
+        _windowed_channel_skeleton(2, 1, 0.5, ROOT_EXTENT, WINDOW_THETA, 0)
+    with pytest.raises(ValueError, match="source_box_level must be an integer"):
+        rta.get_windowed_channel_table(
+            cache, 2, 1, 0, source_box_level=np.float64(0.0)
+        )
+    with pytest.raises(ValueError, match="source_box_level must be an integer"):
+        _assemble_windowed_for_zeta(
+            cache, 2, 1, 1.0, zero_kernel, source_box_level=0.5
+        )
+    with pytest.raises(ValueError, match="source_box_level must be an integer"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 1, 1.0, source_box_level=0.5
+        )
+    with pytest.raises(ValueError, match="source_box_level must be >= 0"):
+        _windowed_channel_skeleton(2, 1, -1, ROOT_EXTENT, WINDOW_THETA, 0)
+
+    with pytest.raises(ValueError, match="m must be an integer"):
+        windowed_channel_profile(2, 0.5, 1.0)
+    with pytest.raises(ValueError, match="m must be an integer"):
+        _windowed_channel_skeleton(2, 1, 0, ROOT_EXTENT, WINDOW_THETA, 0.5)
+    with pytest.raises(ValueError, match="m must be an integer"):
+        rta.get_windowed_channel_table(cache, 2, 1, 0.5)
+
+    with pytest.raises(ValueError, match="p_star must be an integer"):
+        windowed_remainder_profile(2, 1.0, zero_kernel, 1.0, 1.5)
+    with pytest.raises(ValueError, match="p_star must be an integer"):
+        _assemble_windowed_for_zeta(
+            cache, 2, 1, 1.0, zero_kernel, p_star=1.5
+        )
+    with pytest.raises(ValueError, match="p_star must be an integer"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 1, 1.0, p_star=1.5
+        )
+
+    with pytest.raises(ValueError, match="smooth_quad_order must be an integer"):
+        rta._smooth_remainder_entry_values(None, None, None, 8.5)
+    with pytest.raises(ValueError, match="smooth_quad_order must be an integer"):
+        _assemble_windowed_for_zeta(
+            cache, 2, 1, 1.0, zero_kernel, smooth_quad_order=8.5
+        )
+    with pytest.raises(ValueError, match="smooth_quad_order must be an integer"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 1, 1.0, smooth_quad_order=8.5
+        )
+
+    with pytest.raises(ValueError, match="chan_regular_order must be an integer"):
+        rta._resolve_channel_orders(2, 6.5, 15)
+    with pytest.raises(ValueError, match="chan_radial_order must be an integer"):
+        rta._resolve_channel_orders(2, 6, 15.5)
+    with pytest.raises(ValueError, match="chan_regular_order must be an integer"):
+        _duffy_channel_entry_values(None, None, 6.5, 15)
+    with pytest.raises(ValueError, match="chan_radial_order must be an integer"):
+        _duffy_channel_entry_values(None, None, 6, 15.5)
+    with pytest.raises(ValueError, match="chan_regular_order must be an integer"):
+        rta.get_windowed_channel_table(
+            cache, 2, 1, 0, chan_regular_order=6.5, chan_radial_order=15
+        )
+
+    assert rta._require_integer("value", np.int64(3), minimum=0) == 3
+    profile = windowed_channel_profile(np.int64(2), np.int64(0), 1.0)
+    assert np.isfinite(profile(1.0))
+    table = _windowed_channel_skeleton(
+        np.int64(2),
+        np.int64(1),
+        np.int64(0),
+        ROOT_EXTENT,
+        WINDOW_THETA,
+        np.int64(0),
+    )
+    assert table.source_box_level == 0
+    points = _tensor_product_gauss_points(
+        np.int64(1), np.int64(2), 1.0
+    )
+    assert points.shape == (1, 2)
+    _, cache_key = rta._windowed_channel_cache_file(
+        cache,
+        np.int64(2),
+        np.int64(1),
+        np.int64(0),
+        ROOT_EXTENT,
+        WINDOW_THETA,
+        np.int64(0),
+        np.int64(2),
+        np.int64(7),
+    )
+    assert cache_key["dim"] == 2
+    assert cache_key["q_order"] == 1
+    assert rta._resolve_channel_orders(
+        2, np.int64(6), np.int64(15)
+    ) == (6, 15)
+    assert not (tmp_path / "integer-guards.sqlite.windowed").exists()
+
+
+@pytest.mark.parametrize("invalid", [0.0, -1.0, np.nan, np.inf])
+def test_invalid_window_scales_and_declarations(tmp_path, invalid):
+    from pathlib import Path
+
+    import volumential.rke_table_assembly as rta
+
+    cache = tmp_path / "window-guards.sqlite"
+
+    def zero_kernel(r):
+        return np.zeros_like(np.asarray(r, dtype=np.float64))
+
+    with pytest.raises(ValueError, match="window_scale must be finite and positive"):
+        windowed_channel_profile(2, 0, invalid)
+    with pytest.raises(ValueError, match="window_scale must be finite and positive"):
+        windowed_remainder_profile(2, 1.0, zero_kernel, invalid, 1)
+    with pytest.raises(ValueError, match="window_theta must be finite and positive"):
+        _windowed_channel_skeleton(2, 1, 0, ROOT_EXTENT, invalid, 0)
+    with pytest.raises(ValueError, match="window_theta must be finite and positive"):
+        rta.get_windowed_channel_table(cache, 2, 1, 0, window_theta=invalid)
+    with pytest.raises(ValueError, match="window_theta must be finite and positive"):
+        _assemble_windowed_for_zeta(
+            cache, 2, 1, 1.0, zero_kernel, window_theta=invalid
+        )
+    with pytest.raises(ValueError, match="window_theta must be finite and positive"):
+        assemble_windowed_parameterized_table(
+            cache, 2, "Yukawa", 1, 1.0, window_theta=invalid
+        )
+    assert not Path(str(cache) + ".windowed").exists()
+
 
 def test_windowed_declaration_guards(tmp_path):
     cache = tmp_path / "guards.sqlite"

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -1705,6 +1705,11 @@ def test_invalid_window_condition_thresholds(tmp_path, invalid):
         assemble_windowed_parameterized_table(
             cache, 2, "Yukawa", 1, 1.0, max_condition=invalid
         )
+    with pytest.raises(ValueError, match="max_condition must be finite and positive"):
+        assemble_parameterized_table(
+            None, cache, 2, "Yukawa", 1, 1.0, max_condition=invalid
+        )
+    assert not cache.exists()
     assert not Path(str(cache) + ".windowed").exists()
 
 
@@ -1720,6 +1725,29 @@ def test_zero_zeta_is_rejected_before_channel_side_effects(tmp_path):
         windowed_remainder_profile(2, 0.0, zero_kernel, 1.0, 1)
     with pytest.raises(ValueError, match="zeta must be nonzero"):
         _assemble_windowed_for_zeta(cache, 2, 1, 0.0, zero_kernel)
+    assert not Path(str(cache) + ".windowed").exists()
+
+
+@pytest.mark.parametrize("invalid", [
+    complex(np.nan, 0.0),
+    complex(0.0, np.nan),
+    complex(np.inf, 0.0),
+    complex(0.0, -np.inf),
+])
+def test_nonfinite_zeta_is_rejected_before_channel_side_effects(
+    tmp_path, invalid
+):
+    from pathlib import Path
+
+    cache = tmp_path / "nonfinite-zeta-guard.sqlite"
+
+    def zero_kernel(r):
+        return np.zeros_like(np.asarray(r, dtype=np.float64))
+
+    with pytest.raises(ValueError, match="zeta must be finite"):
+        windowed_remainder_profile(2, invalid, zero_kernel, 1.0, 1)
+    with pytest.raises(ValueError, match="zeta must be finite"):
+        _assemble_windowed_for_zeta(cache, 2, 1, invalid, zero_kernel)
     assert not Path(str(cache) + ".windowed").exists()
 
 

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -1084,6 +1084,185 @@ def test_windowed_reality_guard(tmp_path):
 # }}}
 
 
+# {{{ T11: channel quadrature order legality and the entry-magnitude bound
+
+# orders the tanh-sinh-fast radial builder does not honour: 3 and below hit
+# its silent ``max(3, order)`` clamp, and 3-6 produce rules whose weights
+# miss unity by more than 1e-8 (order 3: 3.3e-5, order 6: 6.1e-8)
+@pytest.mark.parametrize("bad_radial", [-5, 0, 1, 2, 3, 5, 6])
+def test_illegal_channel_radial_order_refused(tmp_path, bad_radial):
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    cache = tmp_path / "orders.sqlite"
+    with pytest.raises(ValueError, match="chan_radial_order"):
+        get_windowed_channel_table(
+            cache,
+            3,
+            2,
+            0,
+            source_box_level=3,
+            root_extent=ROOT_EXTENT,
+            window_theta=WINDOW_THETA,
+            chan_regular_order=6,
+            chan_radial_order=bad_radial,
+        )
+
+    # the public assembly entry point refuses before any build too
+    with pytest.raises(ValueError, match="chan_radial_order"):
+        assemble_windowed_parameterized_table(
+            cache,
+            2,
+            "Yukawa",
+            3,
+            4.0,
+            source_box_level=3,
+            window_theta=WINDOW_THETA,
+            chan_regular_order=6,
+            chan_radial_order=bad_radial,
+        )
+
+
+@pytest.mark.parametrize("bad_regular", [-4, 0, 1])
+def test_illegal_channel_regular_order_refused(tmp_path, bad_regular):
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    cache = tmp_path / "orders.sqlite"
+    with pytest.raises(ValueError, match="chan_regular_order"):
+        get_windowed_channel_table(
+            cache,
+            3,
+            2,
+            0,
+            source_box_level=3,
+            root_extent=ROOT_EXTENT,
+            window_theta=WINDOW_THETA,
+            chan_regular_order=bad_regular,
+            chan_radial_order=15,
+        )
+
+
+def test_legal_channel_orders_pass_validation():
+    from volumential.rke_table_assembly import _resolve_channel_orders
+
+    # every order this test module, the module defaults, and the published
+    # 2D/3D sweeps use must validate (validation is a legality gate, not an
+    # accuracy gate)
+    for radial in (12, 15, 25, 45, 61, 101, 121, 141, 161, 201):
+        assert _resolve_channel_orders(3, 6, radial) == (6, radial)
+    for regular in (2, 6, 14, 20, 28, 36, 48):
+        assert _resolve_channel_orders(2, regular, 61) == (regular, 61)
+
+
+def test_channel_entry_bound_rejects_poisoned_table(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    import volumential.rke_table_assembly as rta
+
+    cache = tmp_path / "poison.sqlite"
+    kwargs = {
+        "source_box_level": 3,
+        "root_extent": ROOT_EXTENT,
+        "window_theta": WINDOW_THETA,
+        "chan_regular_order": 6,
+        "chan_radial_order": 15,
+    }
+    window_scale = (_box_extent(3) / WINDOW_THETA) ** 2
+    good = rta.get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    values = np.asarray(good.get_reduced_table_data()[1])
+
+    # the analytic bound is a real bound, not a fudge: the honest table sits
+    # comfortably under it
+    bound = rta._channel_entry_magnitude_bound(good, 0, window_scale)
+    assert np.max(np.abs(values)) < bound
+
+    # an entry astronomically above the chi_0 mass scale is provably wrong
+    poisoned = values.copy()
+    poisoned[0] = 1.0e101
+    with pytest.raises(RuntimeError, match="analytic bound"):
+        rta._check_channel_table_values(good, poisoned, 0, window_scale)
+
+    non_finite = values.copy()
+    non_finite[0] = np.nan
+    with pytest.raises(RuntimeError, match="non-finite"):
+        rta._check_channel_table_values(good, non_finite, 0, window_scale)
+
+    # a cache poisoned on disk is discarded and rebuilt, never trusted
+    cache_dir = Path(str(cache) + ".windowed")
+    (cache_file,) = sorted(cache_dir.glob("*.npz"))
+    with np.load(cache_file, allow_pickle=False) as payload:
+        stored = {name: payload[name] for name in payload.files}
+    stored["values"] = poisoned
+    with open(cache_file, "wb") as stream:
+        np.savez(stream, **stored)
+    healed = rta.get_windowed_channel_table(cache, 2, 3, 0, **kwargs)
+    assert np.array_equal(
+        values, np.asarray(healed.get_reduced_table_data()[1])
+    )
+
+    # and a builder that returns garbage fails the build instead of caching
+    # a poisoned table that every downstream certificate field would rate as
+    # perfectly conditioned
+    real_builder = rta._duffy_channel_entry_values
+
+    def poisoned_builder(table, profile, regular_order, radial_order):
+        entry_ids, entry_values = real_builder(
+            table, profile, regular_order, radial_order
+        )
+        entry_values = np.asarray(entry_values).copy()
+        entry_values[0] = 1.0e101
+        return entry_ids, entry_values
+
+    monkeypatch.setattr(rta, "_duffy_channel_entry_values", poisoned_builder)
+    fresh = tmp_path / "poison-build.sqlite"
+    with pytest.raises(RuntimeError, match="analytic bound"):
+        rta.get_windowed_channel_table(fresh, 2, 3, 0, **kwargs)
+    assert not list(Path(str(fresh) + ".windowed").glob("*.npz"))
+
+
+def test_3d_channel_order_convergence(tmp_path):
+    # Radial orders whose smallest tanh-sinh-fast node sits on the float64
+    # floor 5.551115e-17 (orders 10, 12, 36, 101, 201, ...) place a Duffy
+    # node closer to the target than one ulp of the target coordinate.
+    # Differencing absolute box coordinates absorbed such a node onto the
+    # target, and the 3D germ's small-argument clip then reported
+    # sqrt(pi/1e-300) ~ 1.8e150 instead of a pole, poisoning chi_0 by ~1e101.
+    # Order 12 reproduces that geometry at negligible cost.
+    from volumential.rke_table_assembly import get_windowed_channel_table
+
+    cache = tmp_path / "conv.sqlite"
+
+    def entries(regular, radial):
+        table = get_windowed_channel_table(
+            cache,
+            3,
+            2,
+            0,
+            source_box_level=3,
+            root_extent=ROOT_EXTENT,
+            window_theta=WINDOW_THETA,
+            chan_regular_order=regular,
+            chan_radial_order=radial,
+        )
+        return np.asarray(table.get_reduced_table_data()[1])
+
+    reference = entries(14, 45)
+    scale = float(np.max(np.abs(reference)))
+    # chi_0 carries the full channel mass 4 pi t_w on the self case
+    assert abs(scale / (4.0 * np.pi * (_box_extent(3) / WINDOW_THETA) ** 2)
+               - 1.0) < 0.05
+
+    deviations = [
+        float(np.max(np.abs(entries(regular, radial) - reference))) / scale
+        for regular, radial in ((6, 12), (8, 20), (10, 25))
+    ]
+    # the floor-node order is merely coarse, not catastrophic
+    assert deviations[0] < 1.0e-2, deviations
+    # and refining the pair improves monotonically
+    assert deviations[2] < deviations[1] < deviations[0], deviations
+
+# }}}
+
+
 if __name__ == "__main__":
     import sys
 

--- a/test/test_windowed_rke.py
+++ b/test/test_windowed_rke.py
@@ -573,8 +573,12 @@ def _direct_reference_table(
     [
         (2, "Yukawa", 3, 4.0, 3),
         (2, "Helmholtz", 3, 4.0, 3),
-        (3, "Yukawa", 2, 2.0, 2),
-        (3, "Helmholtz", 2, 2.0, 2),
+        pytest.param(
+            3, "Yukawa", 2, 2.0, 2, marks=pytest.mark.full_accuracy
+        ),
+        pytest.param(
+            3, "Helmholtz", 2, 2.0, 2, marks=pytest.mark.full_accuracy
+        ),
     ],
 )
 def test_windowed_matches_direct_batched(
@@ -706,6 +710,7 @@ def high_theta_direct_refs(tmp_path_factory):
 
 
 @pytest.mark.parametrize("kernel_type", ["Yukawa", "Helmholtz"])
+@pytest.mark.full_accuracy
 def test_high_theta_parity(
     tmp_path, channel_cache, high_theta_direct_refs, kernel_type
 ):

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -67,6 +68,8 @@ from pathlib import Path
 import numpy as np
 
 __all__ = [
+    "RKEConditioningError",
+    "RKETruncationError",
     "assemble_parameterized_table",
     "assemble_windowed_parameterized_table",
     "choose_truncation_order",
@@ -76,7 +79,31 @@ __all__ = [
 ]
 
 
+logger = logging.getLogger(__name__)
+
 _EULER_GAMMA = np.euler_gamma
+
+
+# {{{ refusal taxonomy
+
+# The two certified refusal modes of the classical assembly are named on the
+# exception itself, so callers (the sweep driver and its figures) classify
+# them structurally instead of by matching free-form message text.  Both keep
+# their historical base classes, so ``except (ValueError, RuntimeError)`` and
+# message-matching callers are unaffected.
+
+class RKETruncationError(ValueError):
+    """The series tail majorant never falls below the requested tolerance."""
+
+    refusal_kind = "uncertifiable"
+
+
+class RKEConditioningError(RuntimeError):
+    """Float64 recombination of the assembly is not certifiably conditioned."""
+
+    refusal_kind = "ill-conditioned"
+
+# }}}
 
 
 # {{{ series coefficients
@@ -233,8 +260,8 @@ def choose_truncation_order(
 ):
     """Smallest series order whose tail majorant is below ``tolerance``.
 
-    Returns ``(n_terms, tail_bound)``; raises if ``max_terms`` is not
-    enough."""
+    Returns ``(n_terms, tail_bound)``; raises :class:`RKETruncationError` if
+    ``max_terms`` is not enough."""
     if dim not in (2, 3):
         raise NotImplementedError(
             "certified truncation supports only the 2D and 3D kernel series"
@@ -249,7 +276,7 @@ def choose_truncation_order(
         bound = _tail_majorant(dim, k, radius, n_terms)
         if bound <= tolerance:
             return n_terms, bound
-    raise ValueError(
+    raise RKETruncationError(
         f"cannot certify tolerance {tolerance:g} within {max_terms} series "
         f"terms (last tail bound {bound:g}); increase max_terms or relax "
         "the tolerance"
@@ -568,7 +595,7 @@ NearFieldInteractionTable`
     cancellation_bound = (gamma_m + coefficient_eval_ulps * eps) * max_abs_sum
     condition = max_abs_sum / max(max_entry, 1e-300)
     if condition > max_condition:
-        raise RuntimeError(
+        raise RKEConditioningError(
             "RKE table assembly is ill-conditioned for this parameter and "
             f"box size (condition {condition:.3e} > {max_condition:.1e}); "
             "the local parameter |k| times the separation radius "
@@ -775,6 +802,14 @@ def _windowed_channel_skeleton(
     source-box extent the table manager would use for this level."""
     from volumential.nearfield_potential_table import NearFieldInteractionTable
 
+    # A source box is a descendant of the root, exactly as the canonical
+    # request path requires (``TableDiscretization.from_args``); a negative
+    # level would otherwise describe a box larger than the root that no
+    # table-manager query could ever retrieve.
+    if int(source_box_level) < 0:
+        raise ValueError(
+            f"source_box_level must be >= 0, got {int(source_box_level)}"
+        )
     box_extent = float(root_extent) * 0.5 ** int(source_box_level)
     window_scale = (box_extent / float(window_theta)) ** 2
     table = NearFieldInteractionTable(
@@ -893,7 +928,7 @@ def _duffy_channel_entry_values(
     )
 
     if dim == 2:
-        th_nodes, th_weights = sps.p_roots(int(regular_order))
+        th_nodes, th_weights = sps.roots_legendre(int(regular_order))
         theta = 0.25 * np.pi * (th_nodes + 1.0)
         w_theta = 0.25 * np.pi * th_weights
         cos_sq = np.cos(theta) ** 2
@@ -1248,7 +1283,8 @@ def get_windowed_channel_table(
     chan_regular_order, chan_radial_order)``; a load validates the full key
     and the symmetry-reduced entry IDs before accepting cached data, and any
     unreadable or stale cache file (e.g. a torn write from an interrupted
-    process) is silently rebuilt and atomically replaced.
+    process) is rebuilt and atomically replaced, with the discard reason
+    logged as a warning on this module's logger.
 
     ``chan_regular_order`` / ``chan_radial_order`` default (via ``None``) to
     the tested per-dimension orders of :func:`_resolve_channel_orders`
@@ -1302,8 +1338,14 @@ def get_windowed_channel_table(
                 stored_values = np.asarray(
                     payload["values"], dtype=np.float64
                 )
-        except Exception:
-            pass
+        except Exception as exc:
+            # never silent: a permanently unreadable cache file otherwise
+            # looks exactly like a cache hit while paying a full rebuild on
+            # every call
+            logger.warning(
+                "discarding unreadable windowed channel cache %s: %s: %s",
+                cache_file, type(exc).__name__, exc,
+            )
         else:
             if stored_key == key and np.array_equal(
                 stored_ids, expected_entry_ids
@@ -1311,13 +1353,25 @@ def get_windowed_channel_table(
                 # a cache written before the entry bound was enforced (or by
                 # any other build that produced garbage) is treated exactly
                 # like a torn file: discard and rebuild, so a poisoned .npz
-                # cannot outlive the defect that produced it
+                # cannot outlive the defect that produced it.  The shape check
+                # comes first: ``set_reduced_table_data`` would raise on a
+                # mismatched value array instead of falling through to the
+                # rebuild, wedging every later call on the bad file.
                 try:
+                    if stored_values.shape != expected_entry_ids.shape:
+                        raise RuntimeError(
+                            f"stored value array of shape "
+                            f"{stored_values.shape} does not match the "
+                            f"{expected_entry_ids.shape} reduced entries"
+                        )
                     _check_channel_table_values(
                         table, stored_values, m, window_scale
                     )
-                except RuntimeError:
-                    pass
+                except RuntimeError as exc:
+                    logger.warning(
+                        "rebuilding windowed channel cache %s: %s",
+                        cache_file, exc,
+                    )
                 else:
                     table.set_reduced_table_data(
                         expected_entry_ids, stored_values

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -1873,7 +1873,7 @@ def assemble_windowed_parameterized_table(
         defaults to 61 in both dimensions.
     :returns: ``(table, certificate)`` with ``table`` a
         :class:`~volumential.nearfield_potential_table.\
-    NearFieldInteractionTable`
+NearFieldInteractionTable`
         (complex128 for Helmholtz, float64 for Yukawa) whose kernel identity
         is nulled exactly like the classical assembler's, and
         ``certificate`` a dict of the assembly provenance.

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -836,6 +836,24 @@ def _axis_basis_values(table, coords, xi, bary_weights):
     ]
 
 
+def _channel_profile_values(radial_profile, radius):
+    """Channel profile values on a Duffy node block, with any node that
+    rounds onto the singular point (``r == 0``) contributing zero.
+
+    The Duffy Jacobian vanishes faster than the germ diverges (2D:
+    ``rho log(1/rho)``, 3D: ``rho^2 / rho``), so the limit contribution of a
+    target-coincident node is exactly zero — whereas
+    :func:`windowed_channel_profile` would report the huge finite value its
+    small-``x`` clip produces there (``sqrt(pi/1e-300)`` in 3D).
+    """
+    positive = radius > 0.0
+    if positive.all():
+        return radial_profile(radius)
+    return np.where(
+        positive, radial_profile(np.where(positive, radius, 1.0)), 0.0
+    )
+
+
 def _duffy_channel_entry_values(
     table, radial_profile, regular_order, radial_order,
 ):
@@ -895,6 +913,13 @@ def _duffy_channel_entry_values(
                 dtype=np.float64,
             )
             singular = np.clip(target, 0.0, extent)
+            # source-to-target displacement is accumulated from the *offset*
+            # of the Duffy origin, never by differencing absolute box
+            # coordinates: for a self-interaction target the offset is
+            # exactly zero, and a node closer to the target than one ulp of
+            # the coordinate would otherwise be absorbed into it and report
+            # r = 0 (see _channel_profile_values)
+            base_offset = singular - target
             entry_acc = np.zeros(len(members), dtype=np.float64)
             for corner_index in range(4):
                 edge1 = corners[corner_index] - singular
@@ -907,11 +932,13 @@ def _duffy_channel_entry_values(
                     continue
                 u = np.outer(cos_sq, rho_nodes)
                 v = np.outer(sin_sq, rho_nodes)
-                xx = singular[0] + u * edge1[0] + v * edge2[0]
-                yy = singular[1] + u * edge1[1] + v * edge2[1]
-                radius = np.hypot(xx - target[0], yy - target[1])
+                dx = base_offset[0] + u * edge1[0] + v * edge2[0]
+                dy = base_offset[1] + u * edge1[1] + v * edge2[1]
+                xx = target[0] + dx
+                yy = target[1] + dy
+                radius = np.hypot(dx, dy)
                 common = (
-                    radial_profile(radius)
+                    _channel_profile_values(radial_profile, radius)
                     * (det * duffy_factor)
                     * weight_grid
                 )
@@ -950,6 +977,10 @@ def _duffy_channel_entry_values(
             dtype=np.float64,
         )
         singular = np.clip(target, 0.0, extent)
+        # see the 2D branch: displacements are built from the Duffy origin's
+        # offset, so a node nearer the target than one coordinate ulp still
+        # carries its true (tiny) radius instead of being absorbed to r = 0
+        base_offset = singular - target
         entry_acc = np.zeros(len(members), dtype=np.float64)
         for signs in iproduct((-1.0, 1.0), repeat=dim):
             lengths = np.array(
@@ -968,19 +999,19 @@ def _duffy_channel_entry_values(
                 u_by_axis[perm[0]] = u_first
                 u_by_axis[perm[1]] = u_second
                 u_by_axis[perm[2]] = u_third
-                coords = [
-                    singular[axis] + signs[axis] * lengths[axis]
+                offsets = [
+                    base_offset[axis] + signs[axis] * lengths[axis]
                     * u_by_axis[axis]
                     for axis in range(dim)
                 ]
+                coords = [
+                    target[axis] + offsets[axis] for axis in range(dim)
+                ]
                 radius = np.sqrt(
-                    sum(
-                        (coords[axis] - target[axis]) ** 2
-                        for axis in range(dim)
-                    )
+                    sum(offsets[axis] ** 2 for axis in range(dim))
                 )
                 common = (
-                    radial_profile(radius)
+                    _channel_profile_values(radial_profile, radius)
                     * (box_scale * jacobian_core)
                     * weight_grid
                 )
@@ -1016,7 +1047,151 @@ def _resolve_channel_orders(dim, chan_regular_order, chan_radial_order):
         chan_regular_order = 48 if int(dim) == 2 else 20
     if chan_radial_order is None:
         chan_radial_order = 61
-    return int(chan_regular_order), int(chan_radial_order)
+    chan_regular_order = int(chan_regular_order)
+    chan_radial_order = int(chan_radial_order)
+    _validate_channel_orders(chan_regular_order, chan_radial_order)
+    return chan_regular_order, chan_radial_order
+
+
+# Duffy radial weights integrate the constant ``1`` over ``[0, 1]``, so the
+# deviation of their sum from unity is a direct, order-independent measure of
+# whether the requested order produced a usable rule.  Measured deviations of
+# the ``tanh-sinh-fast`` set: order 3 (the builder's silent clamp target)
+# 3.3e-5, order 5 4.1e-7, order 7 9.9e-9, order 15 1.2e-13, order 45 and
+# above at roundoff.  The tolerance below therefore admits every order from 7
+# up and rejects exactly the degenerate low end.
+_CHANNEL_RADIAL_WEIGHT_TOL = 1.0e-8
+
+
+def _validate_channel_orders(chan_regular_order, chan_radial_order):
+    """Refuse channel quadrature orders the underlying node builders do not
+    honour, instead of letting them degrade silently.
+
+    Neither builder reports a bad request: ``scipy.special.p_roots`` accepts
+    any positive order, and the ``tanh-sinh-fast`` radial rule passes its
+    order through ``max(3, order)``, so 0, 1, 2 (or a negative order) all
+    quietly become the same 7-node rule.  The radial order is validated by
+    measurement against :data:`_CHANNEL_RADIAL_WEIGHT_TOL` rather than by a
+    hard-coded list, so the rule — not this function — remains the
+    authority on which orders are usable.
+    """
+    import volumential.singular_integral_2d as squad
+
+    regular = int(chan_regular_order)
+    radial = int(chan_radial_order)
+    if regular < 2:
+        raise ValueError(
+            f"chan_regular_order {regular} is not a usable Gauss-Legendre "
+            "order for the channel Duffy rule (need at least 2)"
+        )
+    if radial < 3:
+        raise ValueError(
+            f"chan_radial_order {radial} is below the tanh-sinh-fast node "
+            "builder's silent max(3, order) clamp, so the requested order "
+            "would be ignored; pass an order the rule actually honours"
+        )
+    rho_nodes, rho_weights = squad._duffy_radial_nodes_weights(
+        "tanh-sinh-fast", radial, 50
+    )
+    weight_defect = abs(float(np.sum(rho_weights)) - 1.0)
+    if (
+        rho_nodes.size < 8
+        or not np.all((rho_nodes > 0.0) & (rho_nodes < 1.0))
+        or not np.all(np.isfinite(rho_weights))
+        or weight_defect > _CHANNEL_RADIAL_WEIGHT_TOL
+    ):
+        raise ValueError(
+            f"chan_radial_order {radial} yields a degenerate tanh-sinh-fast "
+            f"rule ({rho_nodes.size} nodes, weight sum off unity by "
+            f"{weight_defect:.3e} > {_CHANNEL_RADIAL_WEIGHT_TOL:.1e}); "
+            "raise the radial order"
+        )
+
+
+def _channel_source_mode_sup(table):
+    """Sup norm over the source box of the tensor-product source modes,
+    ``max_i sup_y |phi_i(y)|``, bounded axis-wise (the tensor product of the
+    per-axis sups dominates the sup of the product)."""
+    from volumential.lagrange import (
+        barycentric_lagrange_weights,
+        evaluate_lagrange_basis_1d,
+    )
+
+    dim = int(table.dim)
+    q = int(table.quad_order)
+    if q == 1:
+        return 1.0
+    xi = np.asarray(
+        [p[dim - 1] for p in table.q_points[:q]], dtype=np.float64
+    )
+    bary_weights = barycentric_lagrange_weights(xi)
+    sample = np.linspace(0.0, float(table.source_box_extent), 1024)
+    axis_sup = max(
+        float(
+            np.max(
+                np.abs(
+                    evaluate_lagrange_basis_1d(
+                        xi, k, sample, weights=bary_weights
+                    )
+                )
+            )
+        )
+        for k in range(q)
+    )
+    return axis_sup**dim
+
+
+def _channel_entry_magnitude_bound(table, m, window_scale, safety=8.0):
+    """Analytic upper bound on ``|chi_m|`` table entries.
+
+    A table entry is ``int_box chi_m(|x_t - y|) phi_i(y) dy``, so
+
+    ``|entry| <= sup|phi_i| * int_{R^dim} chi_m(|z|) dz``
+
+    and the total channel mass is elementary,
+
+    ``int_{R^dim} chi_m = c_dim t_w^{m+1} / (m+1)``, ``c_2 = 2 pi``,
+    ``c_3 = 4 pi``
+
+    (the ``m = 0`` cases are the Ewald identities ``int E_1(r^2/4t_w)/2 =
+    2 pi t_w`` and ``int erfc(r/2 sqrt(t_w))/r = 4 pi t_w``; the recurrence
+    carries the identity to every ``m``).  The bound is tight: without
+    ``safety`` a built 3D ``q = 2`` table sits within a factor of three of
+    it at every ``m``, so even the generous factor leaves a check that no
+    quadrature error can trip but a blown-up build cannot survive.
+    """
+    dim = int(table.dim)
+    mass_constant = 2.0 * np.pi if dim == 2 else 4.0 * np.pi
+    channel_mass = (
+        mass_constant * float(window_scale) ** (int(m) + 1) / (int(m) + 1)
+    )
+    return float(safety) * _channel_source_mode_sup(table) * channel_mass
+
+
+def _check_channel_table_values(table, values, m, window_scale):
+    """Reject a channel table whose entries are not finite or exceed the
+    analytic bound of :func:`_channel_entry_magnitude_bound`.
+
+    Cheap (one pass over the reduced entries) and unconditional, so no build
+    path — fresh, cached, or rebuilt — can hand back a poisoned
+    channel table that the downstream condition estimate would rate as
+    perfectly conditioned (a single blown-up channel dominates both the peak
+    sum and the assembled maximum, so their ratio stays at 1).
+    """
+    values = np.asarray(values, dtype=np.float64)
+    bound = _channel_entry_magnitude_bound(table, m, window_scale)
+    if not np.all(np.isfinite(values)):
+        raise RuntimeError(
+            f"windowed channel table m = {int(m)} has non-finite entries"
+        )
+    peak = float(np.max(np.abs(values))) if values.size else 0.0
+    if peak > bound:
+        raise RuntimeError(
+            f"windowed channel table m = {int(m)} has entries of magnitude "
+            f"{peak:.6e}, above the analytic bound {bound:.6e} for window "
+            f"scale t_w = {float(window_scale):.6e}; the channel quadrature "
+            "did not resolve the germ"
+        )
 
 
 def _windowed_channel_cache_file(
@@ -1077,14 +1252,21 @@ def get_windowed_channel_table(
 
     ``chan_regular_order`` / ``chan_radial_order`` default (via ``None``) to
     the tested per-dimension orders of :func:`_resolve_channel_orders`
-    (48/61 in 2D, 20/61 in 3D).
+    (48/61 in 2D, 20/61 in 3D); orders the underlying node builders would
+    silently ignore are refused by :func:`_validate_channel_orders`.
+
+    Every table handed back — freshly built or loaded from cache — passes
+    :func:`_check_channel_table_values`, so a channel that violates the
+    analytic entry bound can never reach the recombination (where a single
+    blown-up channel would dominate both the peak sum and the assembled
+    maximum, leaving the reported condition number at a reassuring 1.0).
     """
     chan_regular_order, chan_radial_order = _resolve_channel_orders(
         dim, chan_regular_order, chan_radial_order
     )
-    _require_o1_box_extent(
-        float(root_extent) * 0.5 ** int(source_box_level)
-    )
+    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    _require_o1_box_extent(box_extent)
+    window_scale = (box_extent / float(window_theta)) ** 2
     table = _windowed_channel_skeleton(
         dim, q_order, source_box_level, root_extent, window_theta, m
     )
@@ -1126,16 +1308,23 @@ def get_windowed_channel_table(
             if stored_key == key and np.array_equal(
                 stored_ids, expected_entry_ids
             ):
-                table.set_reduced_table_data(
-                    expected_entry_ids, stored_values
-                )
-                table.is_built = True
-                return table
+                # a cache written before the entry bound was enforced (or by
+                # any other build that produced garbage) is treated exactly
+                # like a torn file: discard and rebuild, so a poisoned .npz
+                # cannot outlive the defect that produced it
+                try:
+                    _check_channel_table_values(
+                        table, stored_values, m, window_scale
+                    )
+                except RuntimeError:
+                    pass
+                else:
+                    table.set_reduced_table_data(
+                        expected_entry_ids, stored_values
+                    )
+                    table.is_built = True
+                    return table
 
-    window_scale = (
-        float(root_extent) * 0.5 ** int(source_box_level)
-        / float(window_theta)
-    ) ** 2
     entry_ids, entry_values = _duffy_channel_entry_values(
         table,
         windowed_channel_profile(dim, m, window_scale),
@@ -1146,6 +1335,11 @@ def get_windowed_channel_table(
     # same table object as ``expected_entry_ids``, so an equality check here
     # could never fire; the meaningful validation is the load-path one above
     # (cached IDs against freshly computed ones).
+
+    # Refuse (and never cache) a channel table that violates the analytic
+    # entry bound: a poisoned channel is invisible to every downstream
+    # certificate field, so it has to die here.
+    _check_channel_table_values(table, entry_values, m, window_scale)
 
     # Publish atomically (write-then-rename) so a crash or a concurrent
     # writer can never leave a torn final file behind.

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -514,6 +514,7 @@ NearFieldInteractionTable`
     source_box_level = _require_integer(
         "source_box_level", source_box_level, minimum=0
     )
+    max_condition = _require_finite_positive("max_condition", max_condition)
     if kernel_type == "Helmholtz":
         k = np.complex128(float(parameter))
         result_dtype = np.complex128
@@ -886,6 +887,8 @@ def windowed_remainder_profile(dim, zeta, kernel_radial, window_scale, p_star):
     p_star = _require_integer("p_star", p_star, minimum=1)
     window_scale = _require_finite_positive("window_scale", window_scale)
     zeta = complex(zeta)
+    if not np.isfinite(zeta.real) or not np.isfinite(zeta.imag):
+        raise ValueError("zeta must be finite")
     if zeta == 0.0:
         raise ValueError("zeta must be nonzero")
     prefactor = 1.0 / (2.0 * np.pi) if dim == 2 else 1.0 / (4.0 * np.pi)
@@ -1747,6 +1750,8 @@ def _assemble_windowed_for_zeta(
     window_theta = _require_finite_positive("window_theta", window_theta)
     max_condition = _require_finite_positive("max_condition", max_condition)
     zeta = complex(zeta)
+    if not np.isfinite(zeta.real) or not np.isfinite(zeta.imag):
+        raise ValueError("zeta must be finite")
     if zeta == 0.0:
         raise ValueError("zeta must be nonzero")
     chan_regular_order, chan_radial_order = _resolve_channel_orders(

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -708,6 +708,34 @@ NearFieldInteractionTable`
 
 # {{{ windowed channels
 
+def _generalized_exponential_integral_cf(order, x):
+    """Evaluate ``E_order(x)`` for ``x > 1`` by a stable continued fraction."""
+    order = float(order)
+    x = np.asarray(x, dtype=np.float64)
+    tiny = 1.0e-300
+    b = x + order
+    c = np.full_like(x, 1.0 / tiny)
+    d = 1.0 / b
+    value = d.copy()
+
+    for iteration in range(1, 257):
+        numerator = -iteration * (iteration + order - 1.0)
+        b = b + 2.0
+        d = b + numerator * d
+        d = np.where(np.abs(d) < tiny, tiny, d)
+        c = b + numerator / c
+        c = np.where(np.abs(c) < tiny, tiny, c)
+        d = 1.0 / d
+        update = d * c
+        value = value * update
+        if np.all(np.abs(update - 1.0) <= 8.0 * np.finfo(float).eps):
+            return np.exp(-x) * value
+
+    raise RuntimeError(
+        "generalized exponential-integral continued fraction did not converge"
+    )
+
+
 def _windowed_channel_profile_impl(dim, m, window_scale, *, normalized):
     dim = _require_dimension(dim)
     import scipy.special as sps
@@ -721,11 +749,7 @@ def _windowed_channel_profile_impl(dim, m, window_scale, *, normalized):
         def profile(r):
             r_arr = np.asarray(r, dtype=np.float64)
             x = np.maximum(r_arr * r_arr / (4.0 * t_w), 1.0e-300)
-            value = sps.exp1(x)
-            if m > 0:
-                ex = np.exp(-x)
-                for order in range(1, m + 1):
-                    value = (ex - x * value) / order
+            value = sps.expn(m + 1, x)
             value = scale * value
             if np.isscalar(r) or r_arr.ndim == 0:
                 return float(value)
@@ -740,12 +764,24 @@ def _windowed_channel_profile_impl(dim, m, window_scale, *, normalized):
         def profile(r):
             r_arr = np.asarray(r, dtype=np.float64)
             x = np.maximum(r_arr * r_arr / (4.0 * t_w), 1.0e-300)
-            sqrt_x = np.sqrt(x)
-            value = np.sqrt(np.pi) * sps.erfc(sqrt_x) / sqrt_x
-            if m > 0:
-                ex = np.exp(-x)
+            if m == 0:
+                sqrt_x = np.sqrt(x)
+                value = np.sqrt(np.pi) * sps.erfc(sqrt_x) / sqrt_x
+            else:
+                large_x = x > 1.0
+                recurrence_x = np.where(large_x, 0.0, x)
+                sqrt_x = np.sqrt(np.maximum(recurrence_x, 1.0e-300))
+                value = np.sqrt(np.pi) * sps.erfc(sqrt_x) / sqrt_x
+                ex = np.exp(-recurrence_x)
                 for order in range(1, m + 1):
-                    value = (ex - x * value) / (order - 0.5)
+                    value = (
+                        ex - recurrence_x * value
+                    ) / (order - 0.5)
+                if np.any(large_x):
+                    value = np.asarray(value)
+                    value[large_x] = _generalized_exponential_integral_cf(
+                        m + 0.5, x[large_x]
+                    )
             value = scale * value
             if np.isscalar(r) or r_arr.ndim == 0:
                 return float(value)
@@ -757,7 +793,7 @@ def _windowed_channel_profile_impl(dim, m, window_scale, *, normalized):
 def windowed_channel_profile(dim, m, window_scale):
     """Radial profile ``chi_m(r)`` of the physical windowed channel.
 
-    Evaluated by the recurrences
+    Defined by the generalized exponential-integral recurrences
 
     - 2D: ``y_0(x) = E_1(x)``, ``y_m = (exp(-x) - x y_{m-1}) / m``,
       ``chi_m = (1/2) t_w^m y_m``
@@ -770,6 +806,9 @@ def windowed_channel_profile(dim, m, window_scale):
     ``chi_m = (r^2/4)^{m-1/2} Gamma(1/2-m, x) / (2 sqrt(pi))`` in 3D.
     ``chi_0`` in 3D is exactly the Ewald short-range kernel
     ``erfc(r / (2 sqrt(t_w))) / r``.
+    Evaluation uses SciPy's stable integer-order ``expn`` in 2D and a direct
+    continued fraction for the large-``x`` half-integer integral in 3D,
+    avoiding cancellation in the displayed upward recurrences.
 
     :returns: a vectorized callable ``chi(r)`` accepting scalars or arrays.
     """

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -877,13 +877,17 @@ def windowed_remainder_profile(dim, zeta, kernel_radial, window_scale, p_star):
     ``R`` directly (boundedness and germ cancellation as ``r -> 0``).
     At ``r = 0`` the callable returns the analytic removable limit for the
     decaying Yukawa / outgoing Helmholtz branch instead of evaluating the two
-    singular terms separately.
+    singular terms separately.  ``zeta = 0`` is rejected because this API does
+    not define a zero-frequency kernel normalization or its origin limit.
 
     :returns: a vectorized callable ``R(r)`` (complex-valued).
     """
     dim = _require_dimension(dim)
     p_star = _require_integer("p_star", p_star, minimum=1)
     window_scale = _require_finite_positive("window_scale", window_scale)
+    zeta = complex(zeta)
+    if zeta == 0.0:
+        raise ValueError("zeta must be nonzero")
     prefactor = 1.0 / (2.0 * np.pi) if dim == 2 else 1.0 / (4.0 * np.pi)
     coefficients = _windowed_coefficients(zeta * window_scale, p_star)
     profiles = [
@@ -1728,7 +1732,9 @@ def _assemble_windowed_for_zeta(
     """Windowed assembly at an explicit squared-frequency parameter ``zeta``
     and kernel radial profile; :func:`assemble_windowed_parameterized_table`
     wraps this with the standard Helmholtz/Yukawa identifications, and tests
-    exercise complex ``zeta`` (damped waves) directly."""
+    exercise complex ``zeta`` (damped waves) directly.  ``zeta`` must be
+    nonzero because the explicit entry point does not define a zero-frequency
+    kernel normalization or its origin limit."""
     dim, q_order = _require_dim_q_order(dim, q_order)
     source_box_level = _require_integer(
         "source_box_level", source_box_level, minimum=0
@@ -1741,6 +1747,8 @@ def _assemble_windowed_for_zeta(
     window_theta = _require_finite_positive("window_theta", window_theta)
     max_condition = _require_finite_positive("max_condition", max_condition)
     zeta = complex(zeta)
+    if zeta == 0.0:
+        raise ValueError("zeta must be nonzero")
     chan_regular_order, chan_radial_order = _resolve_channel_orders(
         dim, chan_regular_order, chan_radial_order
     )

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -24,17 +24,55 @@ majorant of the omitted series tail on the near-field separation region, and
 the returned certificate records that bound together with the numerically
 computed :math:`L^1` norms of the source basis functions that convert the
 kernel-space bound into a table-entry bound.
+
+Windowed mode
+-------------
+
+The windowed assembler (:func:`assemble_windowed_parameterized_table`) keeps
+the classical table count but replaces the polynomially growing channels
+``r^{2m} log r`` / ``r^{m-1}`` by Gaussian-windowed channels
+
+- 2D: ``chi_m(r) = (1/2) (r^2/4)^m Gamma(-m, x)``
+- 3D: ``chi_m(r) = (1/(2 sqrt(pi))) (r^2/4)^(m-1/2) Gamma(1/2-m, x)``
+
+with ``x = r^2 / (4 t_w)`` and window scale ``t_w = (b / Theta)^2`` for
+source-box extent ``b`` and the single design declaration ``Theta``
+(``window_theta``).  The channels carry the kernels' full singular germs but
+die off beyond ``r ~ b / Theta``, so the recombination coefficient paired
+with channel ``m`` is bounded by ``|zeta t_w|^m / m! = (theta/Theta)^{2m}/m!``
+for every covered squared-frequency parameter ``zeta`` (``zeta = lam^2`` for
+Yukawa, ``zeta = -k^2`` for Helmholtz, complex ``zeta`` for damped waves) —
+nothing large ever cancels, which is the entire point of the window.
+
+The online part is the smooth remainder ``R = G - sum_{m<p_star} c_m chi_m``
+evaluated pointwise from the kernel and the closed channel forms and
+integrated against the source modes by a tensor-product Gauss-Legendre rule.
+Because ``R`` is defined as the exact difference, the assembly has no series
+truncation anywhere: the certificate's ``truncation_tail_bound`` is
+structurally ``0.0``, and the only error terms are the two already-owned
+quadrature kinds (singular channel quadrature and smooth remainder
+quadrature).  The channel family depends on the declaration ``Theta`` only —
+never on the swept kernel parameter — so one cached family serves every
+``theta = parameter * b`` up to ``Theta``.
 """
 
 from __future__ import annotations
 
 import copy
+import hashlib
+import os
+import uuid
+from pathlib import Path
 
 import numpy as np
 
 __all__ = [
     "assemble_parameterized_table",
+    "assemble_windowed_parameterized_table",
     "choose_truncation_order",
+    "get_windowed_channel_table",
+    "windowed_channel_profile",
+    "windowed_remainder_profile",
 ]
 
 
@@ -577,3 +615,959 @@ NearFieldInteractionTable`
         "assembled_max_abs_imag": max_imag,
     }
     return result, certificate
+
+
+# {{{ windowed channels
+
+def windowed_channel_profile(dim, m, window_scale):
+    """Radial profile ``chi_m(r)`` of the windowed channel of order ``m``.
+
+    Evaluated by the stable downward recurrences
+
+    - 2D: ``y_0(x) = E_1(x)``, ``y_m = (exp(-x) - x y_{m-1}) / m``,
+      ``chi_m = (1/2) t_w^m y_m``
+    - 3D: ``z_0(x) = sqrt(pi) erfc(sqrt(x)) / sqrt(x)``,
+      ``z_m = (exp(-x) - x z_{m-1}) / (m - 1/2)``,
+      ``chi_m = t_w^{m-1/2} z_m / (2 sqrt(pi))``
+
+    with ``x = r^2 / (4 t_w)`` and ``t_w = window_scale``; equivalently
+    ``chi_m = (1/2)(r^2/4)^m Gamma(-m, x)`` in 2D and
+    ``chi_m = (r^2/4)^{m-1/2} Gamma(1/2-m, x) / (2 sqrt(pi))`` in 3D.
+    ``chi_0`` in 3D is exactly the Ewald short-range kernel
+    ``erfc(r / (2 sqrt(t_w))) / r``.
+
+    :returns: a vectorized callable ``chi(r)`` accepting scalars or arrays.
+    """
+    import scipy.special as sps
+
+    if dim not in (2, 3):
+        raise NotImplementedError("windowed channels support 2D and 3D")
+    m = int(m)
+    if m < 0:
+        raise ValueError("channel order m must be nonnegative")
+    t_w = float(window_scale)
+    if not t_w > 0.0:
+        raise ValueError("window_scale must be positive")
+
+    if dim == 2:
+        scale = 0.5 * t_w**m
+
+        def profile(r):
+            r_arr = np.asarray(r, dtype=np.float64)
+            x = np.maximum(r_arr * r_arr / (4.0 * t_w), 1.0e-300)
+            value = sps.exp1(x)
+            if m > 0:
+                ex = np.exp(-x)
+                for order in range(1, m + 1):
+                    value = (ex - x * value) / order
+            value = scale * value
+            if np.isscalar(r) or r_arr.ndim == 0:
+                return float(value)
+            return value
+
+    else:
+        scale = t_w ** (m - 0.5) / (2.0 * np.sqrt(np.pi))
+
+        def profile(r):
+            r_arr = np.asarray(r, dtype=np.float64)
+            x = np.maximum(r_arr * r_arr / (4.0 * t_w), 1.0e-300)
+            sqrt_x = np.sqrt(x)
+            value = np.sqrt(np.pi) * sps.erfc(sqrt_x) / sqrt_x
+            if m > 0:
+                ex = np.exp(-x)
+                for order in range(1, m + 1):
+                    value = (ex - x * value) / (order - 0.5)
+            value = scale * value
+            if np.isscalar(r) or r_arr.ndim == 0:
+                return float(value)
+            return value
+
+    return profile
+
+
+def _windowed_channel_kernel_func(dim, m, window_scale):
+    """Coordinate-space wrapper with the scalar Duffy path's
+    ``kernel_func(x, y[, z])`` signature around
+    :func:`windowed_channel_profile`."""
+    profile = windowed_channel_profile(dim, m, window_scale)
+
+    def kernel_func(x, y=None, z=None):
+        coords = [c for c in (x, y, z) if c is not None][:dim]
+        r_squared = sum(np.asarray(c, dtype=np.float64) ** 2 for c in coords)
+        return profile(np.sqrt(r_squared))
+
+    return kernel_func
+
+
+def _require_o1_box_extent(box_extent):
+    """Refuse box extents outside the O(1) range the float64 recombination
+    (and the extent-scaled degeneracy tests of the Duffy geometry) are
+    certified for — the same contract the classical assembler enforces."""
+    if not 1.0e-3 <= float(box_extent) <= 1.0e3:
+        raise ValueError(
+            f"source-box extent {float(box_extent):g} is outside the "
+            "supported O(1) range for certified float64 recombination; "
+            "rescale the problem to an O(1) root extent (the canonical "
+            "table convention)"
+        )
+
+
+def _windowed_coefficients(zeta, p_star):
+    """Normalized channel coefficients ``c_m = (-zeta)^m / m!`` for
+    ``m < p_star``."""
+    coefficients = np.empty(int(p_star), dtype=np.complex128)
+    value = np.complex128(1.0)
+    for m in range(int(p_star)):
+        coefficients[m] = value
+        value = value * (-complex(zeta)) / (m + 1)
+    return coefficients
+
+
+def windowed_remainder_profile(dim, zeta, kernel_radial, window_scale, p_star):
+    """Radial profile of the exact windowed remainder
+
+    ``R(r) = G(r) - pref * sum_{m < p_star} ((-zeta)^m / m!) chi_m(r)``
+
+    with ``pref = 1/(2 pi)`` in 2D and ``1/(4 pi)`` in 3D and ``chi_m`` from
+    :func:`windowed_channel_profile`.  This is exactly the smooth part the
+    windowed assembler integrates (the assembler calls this function), so
+    tests can certify the coefficient/prefactor/sign conventions of the
+    implementation queue-free by probing ``R`` directly (boundedness and
+    germ cancellation as ``r -> 0``).
+
+    :returns: a vectorized callable ``R(r)`` (complex-valued).
+    """
+    p_star = int(p_star)
+    if p_star < 1:
+        raise ValueError("p_star must be at least 1")
+    prefactor = 1.0 / (2.0 * np.pi) if int(dim) == 2 else 1.0 / (4.0 * np.pi)
+    coefficients = _windowed_coefficients(zeta, p_star)
+    profiles = [
+        windowed_channel_profile(dim, m, window_scale) for m in range(p_star)
+    ]
+
+    def remainder_radial(r):
+        channel_sum = coefficients[0] * profiles[0](r)
+        for m in range(1, p_star):
+            channel_sum = channel_sum + coefficients[m] * profiles[m](r)
+        return kernel_radial(r) - prefactor * channel_sum
+
+    return remainder_radial
+
+
+def _tensor_product_gauss_points(q_order, dim, extent):
+    """Tensor-product Gauss-Legendre points on ``[0, extent]^dim`` in the
+    lexicographic ordering the table constructor produces from the mesh
+    generator (queue-free equivalent of ``mg.make_uniform_cubic_grid`` at
+    level 1 followed by the constructor's mapping and dictionary sort)."""
+    nodes = np.polynomial.legendre.leggauss(int(q_order))[0]
+    axis_points = 0.5 * float(extent) * (nodes + 1.0)
+    grids = np.meshgrid(*([axis_points] * int(dim)), indexing="ij")
+    return np.ascontiguousarray(
+        np.stack([g.reshape(-1) for g in grids], axis=-1)
+    )
+
+
+def _windowed_channel_skeleton(
+    dim, q_order, source_box_level, root_extent, window_theta, m,
+):
+    """Channel table shell (geometry and symmetry metadata, no data) at the
+    source-box extent the table manager would use for this level."""
+    from volumential.nearfield_potential_table import NearFieldInteractionTable
+
+    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    window_scale = (box_extent / float(window_theta)) ** 2
+    table = NearFieldInteractionTable(
+        quad_order=int(q_order),
+        dim=int(dim),
+        kernel_func=_windowed_channel_kernel_func(dim, m, window_scale),
+        kernel_type=None,
+        sumpy_kernel=None,
+        source_box_extent=box_extent,
+        dtype=np.float64,
+        progress_bar=False,
+        precomputed_q_points=_tensor_product_gauss_points(
+            q_order, dim, box_extent
+        ),
+    )
+    table.source_box_level = int(source_box_level)
+    return table
+
+
+def _reduced_entry_groups(table):
+    """Reduced entry IDs grouped by ``(case, target)`` with the positions and
+    source-mode indices of each member, mirroring the scalar Duffy builder's
+    entry enumeration."""
+    entry_ids = np.asarray(
+        table._get_invariant_entry_info()["entry_ids"], dtype=np.int64
+    )
+    n_pairs = np.int64(table.n_pairs)
+    n_q_points = np.int64(table.n_q_points)
+    case_indices = (entry_ids // n_pairs).astype(np.int64)
+    pair_ids = entry_ids % n_pairs
+    source_modes = (pair_ids // n_q_points).astype(np.int64)
+    target_points = (pair_ids % n_q_points).astype(np.int64)
+
+    groups = {}
+    for position in range(len(entry_ids)):
+        key = (int(case_indices[position]), int(target_points[position]))
+        groups.setdefault(key, []).append(
+            (position, int(source_modes[position]))
+        )
+    return entry_ids, groups
+
+
+def _axis_basis_values(table, coords, xi, bary_weights):
+    """Per-axis Lagrange basis values (list over axes of list over basis
+    indices) at the given coordinate arrays."""
+    from volumential.lagrange import evaluate_lagrange_basis_1d
+
+    q = int(table.quad_order)
+    if q == 1:
+        return [
+            [np.ones_like(np.asarray(coord))] for coord in coords
+        ]
+    return [
+        [
+            evaluate_lagrange_basis_1d(xi, k, coord, weights=bary_weights)
+            for k in range(q)
+        ]
+        for coord in coords
+    ]
+
+
+def _duffy_channel_entry_values(
+    table, radial_profile, regular_order, radial_order,
+):
+    """Reduced table entries of a radial kernel via the scalar DuffyRadial
+    node set, evaluated vectorized.
+
+    Uses exactly the quadrature nodes and weights of
+    ``compute_table_entry_duffy_radial`` with
+    ``radial_rule="tanh-sinh-fast"`` (2D: four Duffy triangles with
+    Gauss-Legendre in the angle; 3D: sign-octant/permutation cones with a
+    tensor Gauss-Legendre tail), so it agrees with the scalar builder to
+    roundoff while evaluating the radial profile on whole node blocks.
+    """
+    import scipy.special as sps
+
+    import volumential.singular_integral_2d as squad
+    from volumential.lagrange import barycentric_lagrange_weights
+
+    dim = int(table.dim)
+    q = int(table.quad_order)
+    extent = float(table.source_box_extent)
+    mode_axes = np.asarray(table._get_all_mode_axes(), dtype=np.int64)
+    if q > 1:
+        xi = np.asarray(
+            [p[dim - 1] for p in table.q_points[:q]], dtype=np.float64
+        )
+        bary_weights = barycentric_lagrange_weights(xi)
+    else:
+        xi = None
+        bary_weights = None
+
+    entry_ids, groups = _reduced_entry_groups(table)
+    values = np.zeros(len(entry_ids), dtype=np.float64)
+
+    rho_nodes, rho_weights = squad._duffy_radial_nodes_weights(
+        "tanh-sinh-fast", int(radial_order), 50
+    )
+
+    if dim == 2:
+        th_nodes, th_weights = sps.p_roots(int(regular_order))
+        theta = 0.25 * np.pi * (th_nodes + 1.0)
+        w_theta = 0.25 * np.pi * th_weights
+        cos_sq = np.cos(theta) ** 2
+        sin_sq = np.sin(theta) ** 2
+        duffy_factor = np.outer(np.sin(2.0 * theta), rho_nodes)
+        weight_grid = np.outer(w_theta, rho_weights)
+        corners = [
+            np.array([0.0, 0.0]),
+            np.array([extent, 0.0]),
+            np.array([extent, extent]),
+            np.array([0.0, extent]),
+        ]
+
+        for (case_index, target_index), members in groups.items():
+            target = np.asarray(
+                table.find_target_point(target_index, case_index),
+                dtype=np.float64,
+            )
+            singular = np.clip(target, 0.0, extent)
+            entry_acc = np.zeros(len(members), dtype=np.float64)
+            for corner_index in range(4):
+                edge1 = corners[corner_index] - singular
+                edge2 = corners[(corner_index + 1) % 4] - singular
+                det = edge1[0] * edge2[1] - edge1[1] * edge2[0]
+                # degenerate-triangle test must scale with the box (det is
+                # an area, ~ extent**2), or small extents would silently
+                # drop every triangle
+                if np.abs(det) < 1.0e-14 * extent * extent:
+                    continue
+                u = np.outer(cos_sq, rho_nodes)
+                v = np.outer(sin_sq, rho_nodes)
+                xx = singular[0] + u * edge1[0] + v * edge2[0]
+                yy = singular[1] + u * edge1[1] + v * edge2[1]
+                radius = np.hypot(xx - target[0], yy - target[1])
+                common = (
+                    radial_profile(radius)
+                    * (det * duffy_factor)
+                    * weight_grid
+                )
+                basis = _axis_basis_values(
+                    table, (xx, yy), xi, bary_weights
+                )
+                for member_index, (_, source_mode) in enumerate(members):
+                    a0, a1 = mode_axes[source_mode]
+                    entry_acc[member_index] += float(
+                        np.sum(common * basis[0][a0] * basis[1][a1])
+                    )
+            for member_index, (position, _) in enumerate(members):
+                values[position] = entry_acc[member_index]
+        return entry_ids, values
+
+    from itertools import permutations, product as iproduct
+
+    regular_nodes, regular_weights = squad._duffy_regular_nodes_weights(
+        dim - 1, int(regular_order)
+    )
+    regular_nodes = np.asarray(regular_nodes, dtype=np.float64)
+    regular_weights = np.asarray(regular_weights, dtype=np.float64)
+    n_tail = regular_nodes.shape[0]
+    weight_grid = np.outer(regular_weights, rho_weights)
+    tail0 = regular_nodes[:, 0:1]
+    tail1 = regular_nodes[:, 1:2]
+    rho_row = rho_nodes[np.newaxis, :]
+    u_first = np.broadcast_to(rho_row, (n_tail, len(rho_nodes)))
+    u_second = rho_row * tail0
+    u_third = u_second * tail1
+    jacobian_core = (rho_row**2) * tail0
+
+    for (case_index, target_index), members in groups.items():
+        target = np.asarray(
+            table.find_target_point(target_index, case_index),
+            dtype=np.float64,
+        )
+        singular = np.clip(target, 0.0, extent)
+        entry_acc = np.zeros(len(members), dtype=np.float64)
+        for signs in iproduct((-1.0, 1.0), repeat=dim):
+            lengths = np.array(
+                [
+                    singular[axis] if signs[axis] < 0
+                    else extent - singular[axis]
+                    for axis in range(dim)
+                ],
+                dtype=np.float64,
+            )
+            if np.any(lengths <= 0.0):
+                continue
+            box_scale = float(np.prod(lengths))
+            for perm in permutations(range(dim)):
+                u_by_axis = [None] * dim
+                u_by_axis[perm[0]] = u_first
+                u_by_axis[perm[1]] = u_second
+                u_by_axis[perm[2]] = u_third
+                coords = [
+                    singular[axis] + signs[axis] * lengths[axis]
+                    * u_by_axis[axis]
+                    for axis in range(dim)
+                ]
+                radius = np.sqrt(
+                    sum(
+                        (coords[axis] - target[axis]) ** 2
+                        for axis in range(dim)
+                    )
+                )
+                common = (
+                    radial_profile(radius)
+                    * (box_scale * jacobian_core)
+                    * weight_grid
+                )
+                basis = _axis_basis_values(
+                    table, coords, xi, bary_weights
+                )
+                for member_index, (_, source_mode) in enumerate(members):
+                    a0, a1, a2 = mode_axes[source_mode]
+                    entry_acc[member_index] += float(
+                        np.sum(
+                            common
+                            * basis[0][a0]
+                            * basis[1][a1]
+                            * basis[2][a2]
+                        )
+                    )
+        for member_index, (position, _) in enumerate(members):
+            values[position] = entry_acc[member_index]
+    return entry_ids, values
+
+
+def _resolve_channel_orders(dim, chan_regular_order, chan_radial_order):
+    """Resolve ``None`` channel quadrature orders to the tested defaults.
+
+    2D interpolation nodes near the box edge create high-aspect Duffy
+    triangles whose angular convergence is slow (the same effect governs
+    direct builds): angular order 48 holds the assembled 2D ``q = 3`` tables
+    to about 2e-7 of a 64/91 reference, while order 20 drifts by about 1e-4
+    on channel entries.  The 3D cone geometry is mild (order 14 already sits
+    below 1e-7 relative drift), so order 20 is kept there.
+    """
+    if chan_regular_order is None:
+        chan_regular_order = 48 if int(dim) == 2 else 20
+    if chan_radial_order is None:
+        chan_radial_order = 61
+    return int(chan_regular_order), int(chan_radial_order)
+
+
+def _windowed_channel_cache_file(
+    cache_path,
+    dim,
+    q_order,
+    source_box_level,
+    root_extent,
+    window_theta,
+    m,
+    chan_regular_order,
+    chan_radial_order,
+):
+    key = (
+        ("dim", int(dim)),
+        ("q_order", int(q_order)),
+        ("source_box_level", int(source_box_level)),
+        ("root_extent", repr(float(root_extent))),
+        ("window_theta", repr(float(window_theta))),
+        ("m", int(m)),
+        ("chan_regular_order", int(chan_regular_order)),
+        ("chan_radial_order", int(chan_radial_order)),
+        ("radial_rule", "tanh-sinh-fast"),
+    )
+    digest = hashlib.sha1(repr(key).encode()).hexdigest()[:16]
+    directory = Path(str(cache_path) + ".windowed")
+    filename = (
+        f"channel-d{int(dim)}-q{int(q_order)}-l{int(source_box_level)}"
+        f"-m{int(m)}-{digest}.npz"
+    )
+    return directory / filename, dict(key)
+
+
+def get_windowed_channel_table(
+    cache_path,
+    dim,
+    q_order,
+    m,
+    *,
+    source_box_level=0,
+    root_extent=2.0,
+    window_theta=16.0,
+    chan_regular_order=None,
+    chan_radial_order=None,
+    force_recompute=False,
+):
+    """Build or load the windowed channel table ``chi_m``.
+
+    The channel family depends on the declaration ``window_theta`` (and the
+    table geometry) only — never on any swept kernel parameter — and the
+    cache key preserves that invariant.  Channel data is stored per channel
+    in ``.npz`` files under ``str(cache_path) + ".windowed/"`` keyed by
+    ``(dim, q_order, source_box_level, root_extent, window_theta, m,
+    chan_regular_order, chan_radial_order)``; a load validates the full key
+    and the symmetry-reduced entry IDs before accepting cached data, and any
+    unreadable or stale cache file (e.g. a torn write from an interrupted
+    process) is silently rebuilt and atomically replaced.
+
+    ``chan_regular_order`` / ``chan_radial_order`` default (via ``None``) to
+    the tested per-dimension orders of :func:`_resolve_channel_orders`
+    (48/61 in 2D, 20/61 in 3D).
+    """
+    chan_regular_order, chan_radial_order = _resolve_channel_orders(
+        dim, chan_regular_order, chan_radial_order
+    )
+    _require_o1_box_extent(
+        float(root_extent) * 0.5 ** int(source_box_level)
+    )
+    table = _windowed_channel_skeleton(
+        dim, q_order, source_box_level, root_extent, window_theta, m
+    )
+    cache_file, key = _windowed_channel_cache_file(
+        cache_path,
+        dim,
+        q_order,
+        source_box_level,
+        root_extent,
+        window_theta,
+        m,
+        chan_regular_order,
+        chan_radial_order,
+    )
+
+    expected_entry_ids = np.asarray(
+        table._get_invariant_entry_info()["entry_ids"], dtype=np.int64
+    )
+
+    if not force_recompute and cache_file.is_file():
+        # A cache read must never wedge the assembly: a torn or corrupted
+        # file (crash or concurrent writer mid-``np.savez``) or a stale
+        # layout missing expected arrays falls through to a rebuild that
+        # atomically overwrites the bad file.
+        try:
+            with np.load(cache_file, allow_pickle=False) as payload:
+                stored_key = {
+                    name: payload[f"key_{name}"].item() for name in key
+                }
+                stored_ids = np.asarray(
+                    payload["entry_ids"], dtype=np.int64
+                )
+                stored_values = np.asarray(
+                    payload["values"], dtype=np.float64
+                )
+        except Exception:
+            pass
+        else:
+            if stored_key == key and np.array_equal(
+                stored_ids, expected_entry_ids
+            ):
+                table.set_reduced_table_data(
+                    expected_entry_ids, stored_values
+                )
+                table.is_built = True
+                return table
+
+    window_scale = (
+        float(root_extent) * 0.5 ** int(source_box_level)
+        / float(window_theta)
+    ) ** 2
+    entry_ids, entry_values = _duffy_channel_entry_values(
+        table,
+        windowed_channel_profile(dim, m, window_scale),
+        chan_regular_order,
+        chan_radial_order,
+    )
+    # ``entry_ids`` comes from the same memoized invariant-entry info on the
+    # same table object as ``expected_entry_ids``, so an equality check here
+    # could never fire; the meaningful validation is the load-path one above
+    # (cached IDs against freshly computed ones).
+
+    # Publish atomically (write-then-rename) so a crash or a concurrent
+    # writer can never leave a torn final file behind.
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = cache_file.with_name(
+        f"{cache_file.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
+    )
+    try:
+        with open(tmp_file, "wb") as stream:
+            np.savez(
+                stream,
+                entry_ids=entry_ids,
+                values=entry_values,
+                **{
+                    f"key_{name}": np.asarray(value)
+                    for name, value in key.items()
+                },
+            )
+        os.replace(tmp_file, cache_file)
+    finally:
+        tmp_file.unlink(missing_ok=True)
+    table.set_reduced_table_data(entry_ids, entry_values)
+    table.is_built = True
+    return table
+
+
+def _smooth_remainder_entry_values(
+    table, entry_ids, remainder_radial, smooth_quad_order,
+):
+    """Entries ``integral over the source box of R(x_j - y) phi_i(y) dy``
+    for the given full entry IDs, by a tensor-product Gauss-Legendre rule of
+    ``smooth_quad_order`` points per axis on the source box, mirroring the
+    case/target/mode geometry of ``compute_table_entry_duffy_radial``.
+    Handles complex-valued ``R``."""
+    from volumential.lagrange import (
+        barycentric_lagrange_weights,
+        evaluate_lagrange_basis_1d,
+    )
+
+    dim = int(table.dim)
+    q = int(table.quad_order)
+    extent = float(table.source_box_extent)
+    n_nodes = int(smooth_quad_order)
+
+    gl_nodes, gl_weights = np.polynomial.legendre.leggauss(n_nodes)
+    axis_nodes = 0.5 * extent * (gl_nodes + 1.0)
+    axis_weights = 0.5 * extent * gl_weights
+
+    if q > 1:
+        xi = np.asarray(
+            [p[dim - 1] for p in table.q_points[:q]], dtype=np.float64
+        )
+        bary_weights = barycentric_lagrange_weights(xi)
+        basis_matrix = np.stack(
+            [
+                evaluate_lagrange_basis_1d(
+                    xi, k, axis_nodes, weights=bary_weights
+                )
+                for k in range(q)
+            ]
+        )
+    else:
+        basis_matrix = np.ones((1, n_nodes), dtype=np.float64)
+
+    grids = np.meshgrid(*([axis_nodes] * dim), indexing="ij")
+    weight_tensor = axis_weights
+    for _ in range(dim - 1):
+        weight_tensor = np.multiply.outer(weight_tensor, axis_weights)
+
+    entry_ids = np.asarray(entry_ids, dtype=np.int64)
+    n_pairs = np.int64(table.n_pairs)
+    n_q_points = np.int64(table.n_q_points)
+    case_indices = (entry_ids // n_pairs).astype(np.int64)
+    pair_ids = entry_ids % n_pairs
+    source_modes = (pair_ids // n_q_points).astype(np.int64)
+    target_points = (pair_ids % n_q_points).astype(np.int64)
+    mode_axes = np.asarray(table._get_all_mode_axes(), dtype=np.int64)
+
+    groups = {}
+    for position in range(len(entry_ids)):
+        key = (int(case_indices[position]), int(target_points[position]))
+        groups.setdefault(key, []).append(
+            (position, int(source_modes[position]))
+        )
+
+    values = np.zeros(len(entry_ids), dtype=np.complex128)
+    for (case_index, target_index), members in groups.items():
+        target = np.asarray(
+            table.find_target_point(target_index, case_index),
+            dtype=np.float64,
+        )
+        radius = np.sqrt(
+            sum((grids[axis] - target[axis]) ** 2 for axis in range(dim))
+        )
+        weighted_remainder = (
+            np.asarray(remainder_radial(radius)) * weight_tensor
+        )
+        if dim == 2:
+            mode_table = basis_matrix @ weighted_remainder @ basis_matrix.T
+        else:
+            mode_table = np.einsum(
+                "ai,bj,ck,ijk->abc",
+                basis_matrix,
+                basis_matrix,
+                basis_matrix,
+                weighted_remainder,
+                optimize=True,
+            )
+        for position, source_mode in members:
+            values[position] = mode_table[tuple(mode_axes[source_mode])]
+    return values
+
+
+def _assemble_windowed_for_zeta(
+    cache_path,
+    dim,
+    q_order,
+    zeta,
+    kernel_radial,
+    *,
+    source_box_level=0,
+    root_extent=2.0,
+    window_theta=16.0,
+    p_star=6,
+    smooth_quad_order=None,
+    max_condition=1.0e6,
+    chan_regular_order=None,
+    chan_radial_order=None,
+    force_channel_recompute=False,
+    result_dtype=np.complex128,
+):
+    """Windowed assembly at an explicit squared-frequency parameter ``zeta``
+    and kernel radial profile; :func:`assemble_windowed_parameterized_table`
+    wraps this with the standard Helmholtz/Yukawa identifications, and tests
+    exercise complex ``zeta`` (damped waves) directly."""
+    if dim not in (2, 3):
+        raise NotImplementedError("windowed RKE assembly supports 2D and 3D")
+    p_star = int(p_star)
+    if p_star < 1:
+        raise ValueError("p_star must be at least 1")
+    zeta = complex(zeta)
+    chan_regular_order, chan_radial_order = _resolve_channel_orders(
+        dim, chan_regular_order, chan_radial_order
+    )
+
+    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    _require_o1_box_extent(box_extent)
+    window_scale = (box_extent / float(window_theta)) ** 2
+    theta_abs = float(np.sqrt(abs(zeta)) * box_extent)
+
+    # KB coverage contract: the declaration certifies the closed disk
+    # |zeta| <= (Theta/b)^2, i.e. |zeta| t_w <= 1.  Outside it the
+    # coefficients (theta/Theta)^{2m}/m! grow and the conditioning contract
+    # no longer holds, so refuse rather than certify an uncovered point
+    # (the real-parameter wrapper's theta guard is the same condition).
+    if theta_abs > float(window_theta) * (1.0 + 1.0e-12):
+        raise ValueError(
+            f"local parameter |zeta|**0.5 * b = {theta_abs:g} exceeds the "
+            f"declared window Theta = {float(window_theta):g}; the "
+            "requested parameter is outside the declared coverage disk "
+            "|zeta| <= (Theta/b)**2"
+        )
+
+    if smooth_quad_order is None:
+        # Two resolution requirements: the kernel oscillation (theta/2 plus
+        # margin) and the windowed channels inside R, whose transition
+        # features live at scale sqrt(t_w) = b/Theta regardless of the
+        # swept parameter.  Measured 2D convergence of assembled entries
+        # (q=3, theta=1) against converged references: the window term
+        # reaches ~1e-14 relative at about 1.25*Theta points per axis
+        # (Theta=16: 24, Theta=32: 48, Theta=64: 80, Theta=128: ~160), so
+        # 1.25*Theta + 8 carries margin at every declaration, not just the
+        # default Theta = 16.
+        smooth_quad_order = max(
+            16,
+            2 * int(q_order),
+            int(np.ceil(theta_abs / 2.0)) + 16,
+            int(np.ceil(1.25 * float(window_theta))) + 8,
+        )
+    smooth_quad_order = int(smooth_quad_order)
+    # Gauss rules of the table's own order reproduce the self-interaction
+    # target points, and any two odd-order Gauss rules share the interval
+    # midpoint; either collision would sample the remainder at r = 0
+    # (where the kernel diverges), so nudge the order clear of both.
+    if smooth_quad_order == int(q_order) or (
+        smooth_quad_order % 2 == 1 and int(q_order) % 2 == 1
+    ):
+        smooth_quad_order += 1
+
+    channels = [
+        get_windowed_channel_table(
+            cache_path,
+            dim,
+            q_order,
+            m,
+            source_box_level=source_box_level,
+            root_extent=root_extent,
+            window_theta=window_theta,
+            chan_regular_order=chan_regular_order,
+            chan_radial_order=chan_radial_order,
+            force_recompute=force_channel_recompute,
+        )
+        for m in range(p_star)
+    ]
+    base = channels[0]
+    entry_ids = np.asarray(base.get_reduced_entry_ids(), dtype=np.int64)
+
+    prefactor = 1.0 / (2.0 * np.pi) if dim == 2 else 1.0 / (4.0 * np.pi)
+    coefficients = _windowed_coefficients(zeta, p_star)
+    remainder_radial = windowed_remainder_profile(
+        dim, zeta, kernel_radial, window_scale, p_star
+    )
+
+    remainder_values = _smooth_remainder_entry_values(
+        base, entry_ids, remainder_radial, smooth_quad_order
+    )
+
+    values = remainder_values.astype(np.complex128, copy=True)
+    per_channel_peak = []
+    for m in range(p_star):
+        contribution = (
+            prefactor
+            * coefficients[m]
+            * np.asarray(
+                channels[m].get_entry_data_for_full_indices(entry_ids)
+            )
+        )
+        if not np.all(np.isfinite(contribution)):
+            raise RuntimeError(
+                f"windowed channel contribution {m} is not finite"
+            )
+        per_channel_peak.append(float(np.max(np.abs(contribution))))
+        values = values + contribution
+    if not np.all(np.isfinite(values)):
+        raise RuntimeError("windowed assembly produced non-finite entries")
+
+    remainder_peak = (
+        float(np.max(np.abs(remainder_values)))
+        if remainder_values.size
+        else 0.0
+    )
+    max_entry = float(np.max(np.abs(values))) if values.size else 0.0
+    condition = (sum(per_channel_peak) + remainder_peak) / max(
+        max_entry, 1e-300
+    )
+    if condition > float(max_condition):
+        raise RuntimeError(
+            "ill-conditioned windowed assembly (condition "
+            f"{condition:.3e} > {float(max_condition):.1e}); the parameter "
+            "lies outside the conditioning contract of the declared window"
+        )
+
+    coefficient_bound = 0.0
+    magnitude = 1.0
+    for m in range(p_star):
+        coefficient_bound = max(coefficient_bound, magnitude)
+        magnitude = magnitude * abs(zeta) * window_scale / (m + 1)
+
+    max_imag = float(np.max(np.abs(values.imag))) if values.size else 0.0
+    if np.dtype(result_dtype) == np.dtype(np.float64):
+        reference_scale = max(float(np.max(np.abs(values.real))), 1e-300)
+        if max_imag > 1.0e-10 * reference_scale:
+            raise RuntimeError(
+                "assembled windowed Yukawa table has non-negligible "
+                f"imaginary part ({max_imag:g})"
+            )
+        values = np.ascontiguousarray(values.real)
+
+    result = copy.deepcopy(base)
+    result.dtype = np.dtype(result_dtype).type
+    result.kernel_type = None
+    for identity_attr in ("integral_knl", "kernel_func", "kernel_type_cached"):
+        if hasattr(result, identity_attr):
+            setattr(result, identity_attr, None)
+    result._data = None
+    result.set_reduced_table_data(entry_ids, values.astype(result_dtype))
+    result.is_built = True
+
+    certificate = {
+        "kernel_type": None,
+        "parameter": None,
+        "zeta": repr(zeta),
+        "zeta_real": float(zeta.real),
+        "zeta_imag": float(zeta.imag),
+        "theta": theta_abs,
+        "dim": int(dim),
+        "q_order": int(q_order),
+        "source_box_level": int(source_box_level),
+        "window_theta": float(window_theta),
+        "window_scale_t_w": float(window_scale),
+        "p_star": p_star,
+        "smooth_quad_order": smooth_quad_order,
+        "coefficient_bound": float(coefficient_bound),
+        "per_channel_peak": per_channel_peak,
+        "remainder_peak": remainder_peak,
+        "condition_number": float(condition),
+        # The remainder is the exact kernel-minus-channels difference, so no
+        # series truncation exists anywhere in the windowed assembly; this
+        # zero is structural, not an estimate.
+        "truncation_tail_bound": 0.0,
+        "assembled_max_abs_imag": max_imag,
+        "channel_quadrature_orders": {
+            "regular": int(chan_regular_order),
+            "radial": int(chan_radial_order),
+        },
+    }
+    return result, certificate
+
+
+def assemble_windowed_parameterized_table(
+    cache_path,
+    dim: int,
+    kernel_type: str,
+    q_order: int,
+    parameter: float,
+    *,
+    source_box_level: int = 0,
+    root_extent: float = 2.0,
+    window_theta: float = 16.0,
+    p_star: int = 6,
+    smooth_quad_order=None,
+    max_condition: float = 1.0e6,
+    chan_regular_order: int | None = None,
+    chan_radial_order: int | None = None,
+    force_channel_recompute: bool = False,
+):
+    """Assemble a fixed-parameter near-field table from windowed channels.
+
+    :arg kernel_type: ``"Helmholtz"`` (outgoing, ``k = parameter``) or
+        ``"Yukawa"`` (``lam = parameter``).
+    :arg window_theta: the declaration ``Theta``; the local parameter
+        ``theta = parameter * b`` (with ``b`` the source-box extent) must
+        not exceed it.
+    :arg p_star: number of tabulated windowed channels.
+    :arg smooth_quad_order: Gauss-Legendre points per axis for the smooth
+        remainder; defaults to ``max(16, 2 q_order, ceil(theta/2) + 16,
+        ceil(1.25 window_theta) + 8)`` — a Nyquist-style term for the kernel
+        oscillation plus a declaration-scaled term for the windowed-channel
+        transition features (width ``b/Theta``) inside the remainder.
+    :arg chan_regular_order: angular (2D) / tail (3D) Gauss order of the
+        one-time singular channel quadrature; ``None`` selects the tested
+        per-dimension default (48 in 2D — the high-aspect Duffy triangles of
+        edge-adjacent 2D interpolation nodes converge slowly in this order —
+        and 20 in 3D).  ``chan_radial_order`` (radial tanh-sinh order)
+        defaults to 61 in both dimensions.
+    :returns: ``(table, certificate)`` with ``table`` a
+        :class:`~volumential.nearfield_potential_table.\
+NearFieldInteractionTable`
+        (complex128 for Helmholtz, float64 for Yukawa) whose kernel identity
+        is nulled exactly like the classical assembler's, and
+        ``certificate`` a dict of the assembly provenance.
+    """
+    if dim not in (2, 3):
+        raise NotImplementedError("windowed RKE assembly supports 2D and 3D")
+    parameter = float(parameter)
+    if not parameter > 0.0:
+        raise ValueError("windowed assembly requires a positive parameter")
+
+    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    theta = parameter * box_extent
+    if theta > float(window_theta) * (1.0 + 1.0e-12):
+        raise ValueError(
+            f"local parameter theta = {theta:g} exceeds the declared window "
+            f"Theta = {float(window_theta):g}; the requested parameter is "
+            "outside the declaration"
+        )
+
+    import scipy.special as sps
+
+    if kernel_type == "Yukawa":
+        zeta = complex(parameter * parameter)
+        result_dtype = np.float64
+        if dim == 2:
+
+            def kernel_radial(r):
+                return sps.k0(parameter * np.asarray(r)) / (2.0 * np.pi)
+
+        else:
+
+            def kernel_radial(r):
+                r = np.asarray(r)
+                return np.exp(-parameter * r) / (4.0 * np.pi * r)
+
+    elif kernel_type == "Helmholtz":
+        zeta = complex(-(parameter * parameter))
+        result_dtype = np.complex128
+        if dim == 2:
+
+            def kernel_radial(r):
+                return 0.25j * sps.hankel1(0, parameter * np.asarray(r))
+
+        else:
+
+            def kernel_radial(r):
+                r = np.asarray(r)
+                return np.exp(1j * parameter * r) / (4.0 * np.pi * r)
+
+    else:
+        raise NotImplementedError(
+            "windowed RKE assembly supports Helmholtz and Yukawa"
+        )
+
+    table, certificate = _assemble_windowed_for_zeta(
+        cache_path,
+        dim,
+        q_order,
+        zeta,
+        kernel_radial,
+        source_box_level=source_box_level,
+        root_extent=root_extent,
+        window_theta=window_theta,
+        p_star=p_star,
+        smooth_quad_order=smooth_quad_order,
+        max_condition=max_condition,
+        chan_regular_order=chan_regular_order,
+        chan_radial_order=chan_radial_order,
+        force_channel_recompute=force_channel_recompute,
+        result_dtype=result_dtype,
+    )
+    certificate["kernel_type"] = kernel_type
+    certificate["parameter"] = parameter
+    certificate["theta"] = theta
+    return table, certificate
+
+# }}}

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -38,15 +38,19 @@ the classical table count but replaces the polynomially growing channels
 with ``x = r^2 / (4 t_w)`` and window scale ``t_w = (b / Theta)^2`` for
 source-box extent ``b`` and the single design declaration ``Theta``
 (``window_theta``).  The channels carry the kernels' full singular germs but
-die off beyond ``r ~ b / Theta``, so the recombination coefficient paired
-with channel ``m`` is bounded by ``|zeta t_w|^m / m! = (theta/Theta)^{2m}/m!``
-for every covered squared-frequency parameter ``zeta`` (``zeta = lam^2`` for
-Yukawa, ``zeta = -k^2`` for Helmholtz, complex ``zeta`` for damped waves) —
-nothing large ever cancels, which is the entire point of the window.
+die off beyond ``r ~ b / Theta``.  Internally, tables store the normalized
+channels ``psi_m = chi_m / t_w^m`` and pair them with coefficients
+``(-zeta t_w)^m / m!``.  Their magnitude is bounded by
+``|zeta t_w|^m / m! = (theta/Theta)^{2m}/m!`` for every covered
+squared-frequency parameter ``zeta`` (``zeta = lam^2`` for Yukawa,
+``zeta = -k^2`` for Helmholtz, complex ``zeta`` for damped waves), so neither
+factor carries the opposing ``t_w^m`` scaling that overflows or underflows
+before their product does.
 
-The online part is the smooth remainder ``R = G - sum_{m<p_star} c_m chi_m``
-evaluated pointwise from the kernel and the closed channel forms and
-integrated against the source modes by a tensor-product Gauss-Legendre rule.
+The online part is the smooth remainder
+``R = G - sum_{m<p_star} ((-zeta t_w)^m/m!) psi_m``, evaluated pointwise from
+the kernel and the closed channel forms and integrated against the source
+modes by a tensor-product Gauss-Legendre rule.
 Because ``R`` is defined as the exact difference, the assembly has no series
 truncation anywhere: the certificate's ``truncation_tail_bound`` is
 structurally ``0.0``, and the only error terms are the two already-owned
@@ -61,6 +65,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import logging
+import operator
 import os
 import uuid
 from pathlib import Path
@@ -70,6 +75,8 @@ import numpy as np
 __all__ = [
     "RKEConditioningError",
     "RKETruncationError",
+    "RKEWindowConditioningError",
+    "RKEWindowCoverageError",
     "assemble_parameterized_table",
     "assemble_windowed_parameterized_table",
     "choose_truncation_order",
@@ -82,6 +89,42 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _EULER_GAMMA = np.euler_gamma
+_WINDOWED_CHANNEL_CACHE_SCHEMA = 2
+_WINDOWED_CHANNEL_NORMALIZATION = "psi=chi/t_w**m"
+
+
+def _require_integer(name, value, *, minimum=None):
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        result = operator.index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    result = int(result)
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {result}")
+    return result
+
+
+def _require_finite_positive(name, value):
+    result = float(value)
+    if not np.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return result
+
+
+def _require_dimension(dim):
+    dim = _require_integer("dim", dim)
+    if dim not in (2, 3):
+        raise NotImplementedError("RKE assembly supports only 2D and 3D")
+    return dim
+
+
+def _require_dim_q_order(dim, q_order):
+    return (
+        _require_dimension(dim),
+        _require_integer("q_order", q_order, minimum=1),
+    )
 
 
 # {{{ refusal taxonomy
@@ -100,6 +143,18 @@ class RKETruncationError(ValueError):
 
 class RKEConditioningError(RuntimeError):
     """Float64 recombination of the assembly is not certifiably conditioned."""
+
+    refusal_kind = "ill-conditioned"
+
+
+class RKEWindowCoverageError(ValueError):
+    """The squared-frequency parameter lies outside the declared window."""
+
+    refusal_kind = "outside-window"
+
+
+class RKEWindowConditioningError(RuntimeError):
+    """Windowed recombination is not certifiably conditioned."""
 
     refusal_kind = "ill-conditioned"
 
@@ -182,6 +237,7 @@ def _tail_majorant(dim: int, k: complex, radius: float, n_terms: int) -> float:
     """Upper bound for the absolute sum of omitted series terms
     (orders ``n > n_terms``) on ``0 < r <= radius``, computed in log space
     to survive very large orders."""
+    dim = _require_dimension(dim)
     from math import lgamma
 
     k_abs = float(np.abs(np.complex128(k)))
@@ -262,10 +318,8 @@ def choose_truncation_order(
 
     Returns ``(n_terms, tail_bound)``; raises :class:`RKETruncationError` if
     ``max_terms`` is not enough."""
-    if dim not in (2, 3):
-        raise NotImplementedError(
-            "certified truncation supports only the 2D and 3D kernel series"
-        )
+    dim = _require_dimension(dim)
+    max_terms = _require_integer("max_terms", max_terms, minimum=1)
     if dim == 2 and float(np.abs(np.complex128(k))) == 0.0:
         raise ValueError(
             "the 2D series is undefined at k = 0 (its coefficients contain "
@@ -340,6 +394,7 @@ def _basis_l1_norms(table) -> np.ndarray:
 
 def _channel_specs(dim: int, n_terms: int):
     """(term label, kernel factory kwargs) for every needed channel."""
+    dim = _require_dimension(dim)
     specs = [("laplace", None)]
     if dim == 2:
         specs.append(("constant", 0))
@@ -356,6 +411,7 @@ def _channel_specs(dim: int, n_terms: int):
 
 
 def _channel_kernel(dim: int, label: str):
+    dim = _require_dimension(dim)
     from volumential.expansion_wrangler_fpnd import (
         _RadialPowerKernel,
         _RadialPowerLogKernel,
@@ -391,6 +447,10 @@ def _get_channel_tables(
     build_config,
     force_recompute,
 ):
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
     from volumential.table_manager import NearFieldInteractionTableManager
 
     tables = {}
@@ -400,7 +460,7 @@ def _get_channel_tables(
         for label in labels:
             kernel_type, sumpy_knl = _channel_kernel(dim, label)
             kwargs = {
-                "source_box_level": int(source_box_level),
+                "source_box_level": source_box_level,
                 "force_recompute": bool(force_recompute),
                 "queue": queue,
                 "build_config": build_config,
@@ -450,8 +510,10 @@ NearFieldInteractionTable`
         equivalent to a direct fixed-parameter build up to the certified
         bound, and ``certificate`` is a dict of the assembly provenance.
     """
-    if dim not in (2, 3):
-        raise NotImplementedError("RKE table assembly supports 2D and 3D")
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
     if kernel_type == "Helmholtz":
         k = np.complex128(float(parameter))
         result_dtype = np.complex128
@@ -473,7 +535,7 @@ NearFieldInteractionTable`
     # List 1 gallery contains center offsets up to 1.5 source-box extents
     # with target boxes up to twice the source size, so a source point and a
     # target point can be up to 1.5 + 1 + 0.5 = 3 extents apart per axis.
-    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    box_extent = float(root_extent) * 0.5**source_box_level
     # The recombination evaluates channel integrals (which scale like
     # extent**(power + dim)) against coefficients (which scale like
     # k**power) as separate float64 factors, so extreme physical extents
@@ -646,38 +708,15 @@ NearFieldInteractionTable`
 
 # {{{ windowed channels
 
-def windowed_channel_profile(dim, m, window_scale):
-    """Radial profile ``chi_m(r)`` of the windowed channel of order ``m``.
-
-    Evaluated by the stable downward recurrences
-
-    - 2D: ``y_0(x) = E_1(x)``, ``y_m = (exp(-x) - x y_{m-1}) / m``,
-      ``chi_m = (1/2) t_w^m y_m``
-    - 3D: ``z_0(x) = sqrt(pi) erfc(sqrt(x)) / sqrt(x)``,
-      ``z_m = (exp(-x) - x z_{m-1}) / (m - 1/2)``,
-      ``chi_m = t_w^{m-1/2} z_m / (2 sqrt(pi))``
-
-    with ``x = r^2 / (4 t_w)`` and ``t_w = window_scale``; equivalently
-    ``chi_m = (1/2)(r^2/4)^m Gamma(-m, x)`` in 2D and
-    ``chi_m = (r^2/4)^{m-1/2} Gamma(1/2-m, x) / (2 sqrt(pi))`` in 3D.
-    ``chi_0`` in 3D is exactly the Ewald short-range kernel
-    ``erfc(r / (2 sqrt(t_w))) / r``.
-
-    :returns: a vectorized callable ``chi(r)`` accepting scalars or arrays.
-    """
+def _windowed_channel_profile_impl(dim, m, window_scale, *, normalized):
+    dim = _require_dimension(dim)
     import scipy.special as sps
 
-    if dim not in (2, 3):
-        raise NotImplementedError("windowed channels support 2D and 3D")
-    m = int(m)
-    if m < 0:
-        raise ValueError("channel order m must be nonnegative")
-    t_w = float(window_scale)
-    if not t_w > 0.0:
-        raise ValueError("window_scale must be positive")
+    m = _require_integer("m", m, minimum=0)
+    t_w = _require_finite_positive("window_scale", window_scale)
 
     if dim == 2:
-        scale = 0.5 * t_w**m
+        scale = 0.5 if normalized else 0.5 * t_w**m
 
         def profile(r):
             r_arr = np.asarray(r, dtype=np.float64)
@@ -693,7 +732,10 @@ def windowed_channel_profile(dim, m, window_scale):
             return value
 
     else:
-        scale = t_w ** (m - 0.5) / (2.0 * np.sqrt(np.pi))
+        if normalized:
+            scale = t_w**-0.5 / (2.0 * np.sqrt(np.pi))
+        else:
+            scale = t_w ** (m - 0.5) / (2.0 * np.sqrt(np.pi))
 
         def profile(r):
             r_arr = np.asarray(r, dtype=np.float64)
@@ -712,11 +754,44 @@ def windowed_channel_profile(dim, m, window_scale):
     return profile
 
 
-def _windowed_channel_kernel_func(dim, m, window_scale):
+def windowed_channel_profile(dim, m, window_scale):
+    """Radial profile ``chi_m(r)`` of the physical windowed channel.
+
+    Evaluated by the recurrences
+
+    - 2D: ``y_0(x) = E_1(x)``, ``y_m = (exp(-x) - x y_{m-1}) / m``,
+      ``chi_m = (1/2) t_w^m y_m``
+    - 3D: ``z_0(x) = sqrt(pi) erfc(sqrt(x)) / sqrt(x)``,
+      ``z_m = (exp(-x) - x z_{m-1}) / (m - 1/2)``,
+      ``chi_m = t_w^{m-1/2} z_m / (2 sqrt(pi))``
+
+    with ``x = r^2 / (4 t_w)`` and ``t_w = window_scale``; equivalently
+    ``chi_m = (1/2)(r^2/4)^m Gamma(-m, x)`` in 2D and
+    ``chi_m = (r^2/4)^{m-1/2} Gamma(1/2-m, x) / (2 sqrt(pi))`` in 3D.
+    ``chi_0`` in 3D is exactly the Ewald short-range kernel
+    ``erfc(r / (2 sqrt(t_w))) / r``.
+
+    :returns: a vectorized callable ``chi(r)`` accepting scalars or arrays.
+    """
+    return _windowed_channel_profile_impl(
+        dim, m, window_scale, normalized=False
+    )
+
+
+def _normalized_windowed_channel_profile(dim, m, window_scale):
+    """Numerically balanced channel ``psi_m = chi_m / t_w**m``."""
+    return _windowed_channel_profile_impl(
+        dim, m, window_scale, normalized=True
+    )
+
+
+def _windowed_channel_kernel_func(dim, m, window_scale, *, normalized=False):
     """Coordinate-space wrapper with the scalar Duffy path's
-    ``kernel_func(x, y[, z])`` signature around
-    :func:`windowed_channel_profile`."""
-    profile = windowed_channel_profile(dim, m, window_scale)
+    ``kernel_func(x, y[, z])`` signature around a windowed profile."""
+    if normalized:
+        profile = _normalized_windowed_channel_profile(dim, m, window_scale)
+    else:
+        profile = windowed_channel_profile(dim, m, window_scale)
 
     def kernel_func(x, y=None, z=None):
         coords = [c for c in (x, y, z) if c is not None][:dim]
@@ -739,38 +814,39 @@ def _require_o1_box_extent(box_extent):
         )
 
 
-def _windowed_coefficients(zeta, p_star):
-    """Normalized channel coefficients ``c_m = (-zeta)^m / m!`` for
-    ``m < p_star``."""
-    coefficients = np.empty(int(p_star), dtype=np.complex128)
+def _windowed_coefficients(scaled_zeta, p_star):
+    """Balanced coefficients ``(-scaled_zeta)^m / m!``."""
+    coefficients = np.empty(p_star, dtype=np.complex128)
     value = np.complex128(1.0)
-    for m in range(int(p_star)):
+    for m in range(p_star):
         coefficients[m] = value
-        value = value * (-complex(zeta)) / (m + 1)
+        value = value * (-complex(scaled_zeta)) / (m + 1)
     return coefficients
 
 
 def windowed_remainder_profile(dim, zeta, kernel_radial, window_scale, p_star):
     """Radial profile of the exact windowed remainder
 
-    ``R(r) = G(r) - pref * sum_{m < p_star} ((-zeta)^m / m!) chi_m(r)``
+    ``R(r) = G(r) - pref * sum_{m < p_star}
+    ((-zeta*t_w)^m / m!) psi_m(r)``
 
-    with ``pref = 1/(2 pi)`` in 2D and ``1/(4 pi)`` in 3D and ``chi_m`` from
-    :func:`windowed_channel_profile`.  This is exactly the smooth part the
-    windowed assembler integrates (the assembler calls this function), so
-    tests can certify the coefficient/prefactor/sign conventions of the
-    implementation queue-free by probing ``R`` directly (boundedness and
-    germ cancellation as ``r -> 0``).
+    with ``psi_m = chi_m / t_w**m``, ``pref = 1/(2 pi)`` in 2D, and
+    ``pref = 1/(4 pi)`` in 3D.  This is algebraically identical to the
+    physical-channel sum while keeping both factors representable.  It is
+    exactly the smooth part the windowed assembler integrates, so tests can
+    certify the coefficient/prefactor/sign conventions queue-free by probing
+    ``R`` directly (boundedness and germ cancellation as ``r -> 0``).
 
     :returns: a vectorized callable ``R(r)`` (complex-valued).
     """
-    p_star = int(p_star)
-    if p_star < 1:
-        raise ValueError("p_star must be at least 1")
-    prefactor = 1.0 / (2.0 * np.pi) if int(dim) == 2 else 1.0 / (4.0 * np.pi)
-    coefficients = _windowed_coefficients(zeta, p_star)
+    dim = _require_dimension(dim)
+    p_star = _require_integer("p_star", p_star, minimum=1)
+    window_scale = _require_finite_positive("window_scale", window_scale)
+    prefactor = 1.0 / (2.0 * np.pi) if dim == 2 else 1.0 / (4.0 * np.pi)
+    coefficients = _windowed_coefficients(zeta * window_scale, p_star)
     profiles = [
-        windowed_channel_profile(dim, m, window_scale) for m in range(p_star)
+        _normalized_windowed_channel_profile(dim, m, window_scale)
+        for m in range(p_star)
     ]
 
     def remainder_radial(r):
@@ -787,9 +863,10 @@ def _tensor_product_gauss_points(q_order, dim, extent):
     lexicographic ordering the table constructor produces from the mesh
     generator (queue-free equivalent of ``mg.make_uniform_cubic_grid`` at
     level 1 followed by the constructor's mapping and dictionary sort)."""
-    nodes = np.polynomial.legendre.leggauss(int(q_order))[0]
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    nodes = np.polynomial.legendre.leggauss(q_order)[0]
     axis_points = 0.5 * float(extent) * (nodes + 1.0)
-    grids = np.meshgrid(*([axis_points] * int(dim)), indexing="ij")
+    grids = np.meshgrid(*([axis_points] * dim), indexing="ij")
     return np.ascontiguousarray(
         np.stack([g.reshape(-1) for g in grids], axis=-1)
     )
@@ -800,22 +877,23 @@ def _windowed_channel_skeleton(
 ):
     """Channel table shell (geometry and symmetry metadata, no data) at the
     source-box extent the table manager would use for this level."""
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
+    m = _require_integer("m", m, minimum=0)
+    window_theta = _require_finite_positive("window_theta", window_theta)
+
     from volumential.nearfield_potential_table import NearFieldInteractionTable
 
-    # A source box is a descendant of the root, exactly as the canonical
-    # request path requires (``TableDiscretization.from_args``); a negative
-    # level would otherwise describe a box larger than the root that no
-    # table-manager query could ever retrieve.
-    if int(source_box_level) < 0:
-        raise ValueError(
-            f"source_box_level must be >= 0, got {int(source_box_level)}"
-        )
-    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
-    window_scale = (box_extent / float(window_theta)) ** 2
+    box_extent = float(root_extent) * 0.5**source_box_level
+    window_scale = (box_extent / window_theta) ** 2
     table = NearFieldInteractionTable(
-        quad_order=int(q_order),
-        dim=int(dim),
-        kernel_func=_windowed_channel_kernel_func(dim, m, window_scale),
+        quad_order=q_order,
+        dim=dim,
+        kernel_func=_windowed_channel_kernel_func(
+            dim, m, window_scale, normalized=True
+        ),
         kernel_type=None,
         sumpy_kernel=None,
         source_box_extent=box_extent,
@@ -825,7 +903,7 @@ def _windowed_channel_skeleton(
             q_order, dim, box_extent
         ),
     )
-    table.source_box_level = int(source_box_level)
+    table.source_box_level = source_box_level
     return table
 
 
@@ -902,6 +980,12 @@ def _duffy_channel_entry_values(
     tensor Gauss-Legendre tail), so it agrees with the scalar builder to
     roundoff while evaluating the radial profile on whole node blocks.
     """
+    regular_order = _require_integer(
+        "chan_regular_order", regular_order, minimum=1
+    )
+    radial_order = _require_integer(
+        "chan_radial_order", radial_order, minimum=1
+    )
     import scipy.special as sps
 
     import volumential.singular_integral_2d as squad
@@ -924,11 +1008,11 @@ def _duffy_channel_entry_values(
     values = np.zeros(len(entry_ids), dtype=np.float64)
 
     rho_nodes, rho_weights = squad._duffy_radial_nodes_weights(
-        "tanh-sinh-fast", int(radial_order), 50
+        "tanh-sinh-fast", radial_order, 50
     )
 
     if dim == 2:
-        th_nodes, th_weights = sps.roots_legendre(int(regular_order))
+        th_nodes, th_weights = sps.roots_legendre(regular_order)
         theta = 0.25 * np.pi * (th_nodes + 1.0)
         w_theta = 0.25 * np.pi * th_weights
         cos_sq = np.cos(theta) ** 2
@@ -989,10 +1073,11 @@ def _duffy_channel_entry_values(
                 values[position] = entry_acc[member_index]
         return entry_ids, values
 
-    from itertools import permutations, product as iproduct
+    from itertools import permutations
+    from itertools import product as iproduct
 
     regular_nodes, regular_weights = squad._duffy_regular_nodes_weights(
-        dim - 1, int(regular_order)
+        dim - 1, regular_order
     )
     regular_nodes = np.asarray(regular_nodes, dtype=np.float64)
     regular_weights = np.asarray(regular_weights, dtype=np.float64)
@@ -1078,14 +1163,12 @@ def _resolve_channel_orders(dim, chan_regular_order, chan_radial_order):
     on channel entries.  The 3D cone geometry is mild (order 14 already sits
     below 1e-7 relative drift), so order 20 is kept there.
     """
+    dim = _require_dimension(dim)
     if chan_regular_order is None:
-        chan_regular_order = 48 if int(dim) == 2 else 20
+        chan_regular_order = 48 if dim == 2 else 20
     if chan_radial_order is None:
         chan_radial_order = 61
-    chan_regular_order = int(chan_regular_order)
-    chan_radial_order = int(chan_radial_order)
-    _validate_channel_orders(chan_regular_order, chan_radial_order)
-    return chan_regular_order, chan_radial_order
+    return _validate_channel_orders(chan_regular_order, chan_radial_order)
 
 
 # Duffy radial weights integrate the constant ``1`` over ``[0, 1]``, so the
@@ -1112,8 +1195,8 @@ def _validate_channel_orders(chan_regular_order, chan_radial_order):
     """
     import volumential.singular_integral_2d as squad
 
-    regular = int(chan_regular_order)
-    radial = int(chan_radial_order)
+    regular = _require_integer("chan_regular_order", chan_regular_order)
+    radial = _require_integer("chan_radial_order", chan_radial_order)
     if regular < 2:
         raise ValueError(
             f"chan_regular_order {regular} is not a usable Gauss-Legendre "
@@ -1141,6 +1224,7 @@ def _validate_channel_orders(chan_regular_order, chan_radial_order):
             f"{weight_defect:.3e} > {_CHANNEL_RADIAL_WEIGHT_TOL:.1e}); "
             "raise the radial order"
         )
+    return regular, radial
 
 
 def _channel_source_mode_sup(table):
@@ -1177,16 +1261,16 @@ def _channel_source_mode_sup(table):
 
 
 def _channel_entry_magnitude_bound(table, m, window_scale, safety=8.0):
-    """Analytic upper bound on ``|chi_m|`` table entries.
+    """Analytic upper bound on normalized ``|psi_m|`` table entries.
 
-    A table entry is ``int_box chi_m(|x_t - y|) phi_i(y) dy``, so
+    A table entry is ``int_box psi_m(|x_t - y|) phi_i(y) dy``, so
 
-    ``|entry| <= sup|phi_i| * int_{R^dim} chi_m(|z|) dz``
+    ``|entry| <= sup|phi_i| * int_{R^dim} psi_m(|z|) dz``
 
     and the total channel mass is elementary,
 
-    ``int_{R^dim} chi_m = c_dim t_w^{m+1} / (m+1)``, ``c_2 = 2 pi``,
-    ``c_3 = 4 pi``
+    ``int_{R^dim} psi_m = c_dim t_w / (m+1)``, ``c_2 = 2 pi``,
+    ``c_3 = 4 pi``, because ``psi_m = chi_m/t_w^m``.
 
     (the ``m = 0`` cases are the Ewald identities ``int E_1(r^2/4t_w)/2 =
     2 pi t_w`` and ``int erfc(r/2 sqrt(t_w))/r = 4 pi t_w``; the recurrence
@@ -1197,9 +1281,7 @@ def _channel_entry_magnitude_bound(table, m, window_scale, safety=8.0):
     """
     dim = int(table.dim)
     mass_constant = 2.0 * np.pi if dim == 2 else 4.0 * np.pi
-    channel_mass = (
-        mass_constant * float(window_scale) ** (int(m) + 1) / (int(m) + 1)
-    )
+    channel_mass = mass_constant * float(window_scale) / (int(m) + 1)
     return float(safety) * _channel_source_mode_sup(table) * channel_mass
 
 
@@ -1240,24 +1322,50 @@ def _windowed_channel_cache_file(
     chan_regular_order,
     chan_radial_order,
 ):
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
+    m = _require_integer("m", m, minimum=0)
+    chan_regular_order = _require_integer(
+        "chan_regular_order", chan_regular_order
+    )
+    chan_radial_order = _require_integer(
+        "chan_radial_order", chan_radial_order
+    )
     key = (
-        ("dim", int(dim)),
-        ("q_order", int(q_order)),
-        ("source_box_level", int(source_box_level)),
+        ("cache_schema", _WINDOWED_CHANNEL_CACHE_SCHEMA),
+        ("normalization", _WINDOWED_CHANNEL_NORMALIZATION),
+        ("dim", dim),
+        ("q_order", q_order),
+        ("source_box_level", source_box_level),
         ("root_extent", repr(float(root_extent))),
         ("window_theta", repr(float(window_theta))),
-        ("m", int(m)),
-        ("chan_regular_order", int(chan_regular_order)),
-        ("chan_radial_order", int(chan_radial_order)),
+        ("m", m),
+        ("chan_regular_order", chan_regular_order),
+        ("chan_radial_order", chan_radial_order),
         ("radial_rule", "tanh-sinh-fast"),
     )
     digest = hashlib.sha1(repr(key).encode()).hexdigest()[:16]
     directory = Path(str(cache_path) + ".windowed")
     filename = (
-        f"channel-d{int(dim)}-q{int(q_order)}-l{int(source_box_level)}"
-        f"-m{int(m)}-{digest}.npz"
+        f"channel-d{dim}-q{q_order}-l{source_box_level}"
+        f"-m{m}-{digest}.npz"
     )
     return directory / filename, dict(key)
+
+
+def _windowed_channel_payload_checksum(entry_ids, values):
+    digest = hashlib.sha256()
+    for label, array, dtype in (
+        (b"entry_ids\0", entry_ids, "<i8"),
+        (b"values\0", values, "<f8"),
+    ):
+        array = np.ascontiguousarray(array, dtype=dtype)
+        digest.update(label)
+        digest.update(np.asarray(array.shape, dtype="<i8").tobytes())
+        digest.update(array.tobytes())
+    return digest.hexdigest()
 
 
 def get_windowed_channel_table(
@@ -1273,18 +1381,18 @@ def get_windowed_channel_table(
     chan_radial_order=None,
     force_recompute=False,
 ):
-    """Build or load the windowed channel table ``chi_m``.
+    """Build or load the normalized windowed channel table ``psi_m``.
 
     The channel family depends on the declaration ``window_theta`` (and the
     table geometry) only — never on any swept kernel parameter — and the
     cache key preserves that invariant.  Channel data is stored per channel
     in ``.npz`` files under ``str(cache_path) + ".windowed/"`` keyed by
-    ``(dim, q_order, source_box_level, root_extent, window_theta, m,
-    chan_regular_order, chan_radial_order)``; a load validates the full key
-    and the symmetry-reduced entry IDs before accepting cached data, and any
-    unreadable or stale cache file (e.g. a torn write from an interrupted
-    process) is rebuilt and atomically replaced, with the discard reason
-    logged as a warning on this module's logger.
+    ``(schema, normalization, dim, q_order, source_box_level, root_extent,
+    window_theta, m, chan_regular_order, chan_radial_order)``.  A load
+    validates the full key, symmetry-reduced entry IDs, and a checksum over
+    the IDs and values before accepting cached data.  Any unreadable, stale,
+    or corrupted file is rebuilt and atomically replaced, with the discard
+    reason logged as a warning on this module's logger.
 
     ``chan_regular_order`` / ``chan_radial_order`` default (via ``None``) to
     the tested per-dimension orders of :func:`_resolve_channel_orders`
@@ -1296,13 +1404,22 @@ def get_windowed_channel_table(
     analytic entry bound can never reach the recombination (where a single
     blown-up channel would dominate both the peak sum and the assembled
     maximum, leaving the reported condition number at a reassuring 1.0).
+    The private ``_windowed_cache_disposition`` attribute is ``"hit"`` only
+    after a fully validated load and ``"rebuilt"`` after fresh or recovery
+    construction.
     """
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
+    m = _require_integer("m", m, minimum=0)
+    window_theta = _require_finite_positive("window_theta", window_theta)
     chan_regular_order, chan_radial_order = _resolve_channel_orders(
         dim, chan_regular_order, chan_radial_order
     )
-    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    box_extent = float(root_extent) * 0.5**source_box_level
     _require_o1_box_extent(box_extent)
-    window_scale = (box_extent / float(window_theta)) ** 2
+    window_scale = (box_extent / window_theta) ** 2
     table = _windowed_channel_skeleton(
         dim, q_order, source_box_level, root_extent, window_theta, m
     )
@@ -1338,6 +1455,7 @@ def get_windowed_channel_table(
                 stored_values = np.asarray(
                     payload["values"], dtype=np.float64
                 )
+                stored_checksum = str(payload["payload_checksum"].item())
         except Exception as exc:
             # never silent: a permanently unreadable cache file otherwise
             # looks exactly like a cache hit while paying a full rebuild on
@@ -1347,41 +1465,45 @@ def get_windowed_channel_table(
                 cache_file, type(exc).__name__, exc,
             )
         else:
-            if stored_key == key and np.array_equal(
-                stored_ids, expected_entry_ids
-            ):
-                # a cache written before the entry bound was enforced (or by
-                # any other build that produced garbage) is treated exactly
-                # like a torn file: discard and rebuild, so a poisoned .npz
-                # cannot outlive the defect that produced it.  The shape check
-                # comes first: ``set_reduced_table_data`` would raise on a
-                # mismatched value array instead of falling through to the
-                # rebuild, wedging every later call on the bad file.
-                try:
-                    if stored_values.shape != expected_entry_ids.shape:
-                        raise RuntimeError(
-                            f"stored value array of shape "
-                            f"{stored_values.shape} does not match the "
-                            f"{expected_entry_ids.shape} reduced entries"
-                        )
-                    _check_channel_table_values(
-                        table, stored_values, m, window_scale
+            # A cache written before the schema, checksum, or entry bound was
+            # enforced is treated exactly like a torn file.  Shape checks come
+            # before the table setter so malformed data cannot wedge later
+            # calls on a permanently loadable bad file.
+            try:
+                if stored_key != key:
+                    raise RuntimeError("stored cache key does not match")
+                if not np.array_equal(stored_ids, expected_entry_ids):
+                    raise RuntimeError("stored entry IDs do not match")
+                if stored_values.shape != expected_entry_ids.shape:
+                    raise RuntimeError(
+                        f"stored value array of shape {stored_values.shape} "
+                        f"does not match the {expected_entry_ids.shape} "
+                        "reduced entries"
                     )
-                except RuntimeError as exc:
-                    logger.warning(
-                        "rebuilding windowed channel cache %s: %s",
-                        cache_file, exc,
-                    )
-                else:
-                    table.set_reduced_table_data(
-                        expected_entry_ids, stored_values
-                    )
-                    table.is_built = True
-                    return table
+                computed_checksum = _windowed_channel_payload_checksum(
+                    stored_ids, stored_values
+                )
+                if stored_checksum != computed_checksum:
+                    raise RuntimeError("stored payload checksum does not match")
+                _check_channel_table_values(
+                    table, stored_values, m, window_scale
+                )
+            except RuntimeError as exc:
+                logger.warning(
+                    "rebuilding windowed channel cache %s: %s",
+                    cache_file, exc,
+                )
+            else:
+                table.set_reduced_table_data(
+                    expected_entry_ids, stored_values
+                )
+                table.is_built = True
+                table._windowed_cache_disposition = "hit"
+                return table
 
     entry_ids, entry_values = _duffy_channel_entry_values(
         table,
-        windowed_channel_profile(dim, m, window_scale),
+        _normalized_windowed_channel_profile(dim, m, window_scale),
         chan_regular_order,
         chan_radial_order,
     )
@@ -1407,6 +1529,9 @@ def get_windowed_channel_table(
                 stream,
                 entry_ids=entry_ids,
                 values=entry_values,
+                payload_checksum=np.asarray(
+                    _windowed_channel_payload_checksum(entry_ids, entry_values)
+                ),
                 **{
                     f"key_{name}": np.asarray(value)
                     for name, value in key.items()
@@ -1417,6 +1542,7 @@ def get_windowed_channel_table(
         tmp_file.unlink(missing_ok=True)
     table.set_reduced_table_data(entry_ids, entry_values)
     table.is_built = True
+    table._windowed_cache_disposition = "rebuilt"
     return table
 
 
@@ -1428,6 +1554,9 @@ def _smooth_remainder_entry_values(
     ``smooth_quad_order`` points per axis on the source box, mirroring the
     case/target/mode geometry of ``compute_table_entry_duffy_radial``.
     Handles complex-valued ``R``."""
+    n_nodes = _require_integer(
+        "smooth_quad_order", smooth_quad_order, minimum=1
+    )
     from volumential.lagrange import (
         barycentric_lagrange_weights,
         evaluate_lagrange_basis_1d,
@@ -1436,7 +1565,6 @@ def _smooth_remainder_entry_values(
     dim = int(table.dim)
     q = int(table.quad_order)
     extent = float(table.source_box_extent)
-    n_nodes = int(smooth_quad_order)
 
     gl_nodes, gl_weights = np.polynomial.legendre.leggauss(n_nodes)
     axis_nodes = 0.5 * extent * (gl_nodes + 1.0)
@@ -1529,19 +1657,24 @@ def _assemble_windowed_for_zeta(
     and kernel radial profile; :func:`assemble_windowed_parameterized_table`
     wraps this with the standard Helmholtz/Yukawa identifications, and tests
     exercise complex ``zeta`` (damped waves) directly."""
-    if dim not in (2, 3):
-        raise NotImplementedError("windowed RKE assembly supports 2D and 3D")
-    p_star = int(p_star)
-    if p_star < 1:
-        raise ValueError("p_star must be at least 1")
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
+    p_star = _require_integer("p_star", p_star, minimum=1)
+    if smooth_quad_order is not None:
+        smooth_quad_order = _require_integer(
+            "smooth_quad_order", smooth_quad_order, minimum=1
+        )
+    window_theta = _require_finite_positive("window_theta", window_theta)
     zeta = complex(zeta)
     chan_regular_order, chan_radial_order = _resolve_channel_orders(
         dim, chan_regular_order, chan_radial_order
     )
 
-    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    box_extent = float(root_extent) * 0.5**source_box_level
     _require_o1_box_extent(box_extent)
-    window_scale = (box_extent / float(window_theta)) ** 2
+    window_scale = (box_extent / window_theta) ** 2
     theta_abs = float(np.sqrt(abs(zeta)) * box_extent)
 
     # KB coverage contract: the declaration certifies the closed disk
@@ -1549,10 +1682,10 @@ def _assemble_windowed_for_zeta(
     # coefficients (theta/Theta)^{2m}/m! grow and the conditioning contract
     # no longer holds, so refuse rather than certify an uncovered point
     # (the real-parameter wrapper's theta guard is the same condition).
-    if theta_abs > float(window_theta) * (1.0 + 1.0e-12):
-        raise ValueError(
+    if theta_abs > window_theta * (1.0 + 1.0e-12):
+        raise RKEWindowCoverageError(
             f"local parameter |zeta|**0.5 * b = {theta_abs:g} exceeds the "
-            f"declared window Theta = {float(window_theta):g}; the "
+            f"declared window Theta = {window_theta:g}; the "
             "requested parameter is outside the declared coverage disk "
             "|zeta| <= (Theta/b)**2"
         )
@@ -1569,17 +1702,16 @@ def _assemble_windowed_for_zeta(
         # default Theta = 16.
         smooth_quad_order = max(
             16,
-            2 * int(q_order),
+            2 * q_order,
             int(np.ceil(theta_abs / 2.0)) + 16,
-            int(np.ceil(1.25 * float(window_theta))) + 8,
+            int(np.ceil(1.25 * window_theta)) + 8,
         )
-    smooth_quad_order = int(smooth_quad_order)
     # Gauss rules of the table's own order reproduce the self-interaction
     # target points, and any two odd-order Gauss rules share the interval
     # midpoint; either collision would sample the remainder at r = 0
     # (where the kernel diverges), so nudge the order clear of both.
-    if smooth_quad_order == int(q_order) or (
-        smooth_quad_order % 2 == 1 and int(q_order) % 2 == 1
+    if smooth_quad_order == q_order or (
+        smooth_quad_order % 2 == 1 and q_order % 2 == 1
     ):
         smooth_quad_order += 1
 
@@ -1602,7 +1734,7 @@ def _assemble_windowed_for_zeta(
     entry_ids = np.asarray(base.get_reduced_entry_ids(), dtype=np.int64)
 
     prefactor = 1.0 / (2.0 * np.pi) if dim == 2 else 1.0 / (4.0 * np.pi)
-    coefficients = _windowed_coefficients(zeta, p_star)
+    coefficients = _windowed_coefficients(zeta * window_scale, p_star)
     remainder_radial = windowed_remainder_profile(
         dim, zeta, kernel_radial, window_scale, p_star
     )
@@ -1640,7 +1772,7 @@ def _assemble_windowed_for_zeta(
         max_entry, 1e-300
     )
     if condition > float(max_condition):
-        raise RuntimeError(
+        raise RKEWindowConditioningError(
             "ill-conditioned windowed assembly (condition "
             f"{condition:.3e} > {float(max_condition):.1e}); the parameter "
             "lies outside the conditioning contract of the declared window"
@@ -1679,10 +1811,10 @@ def _assemble_windowed_for_zeta(
         "zeta_real": float(zeta.real),
         "zeta_imag": float(zeta.imag),
         "theta": theta_abs,
-        "dim": int(dim),
-        "q_order": int(q_order),
-        "source_box_level": int(source_box_level),
-        "window_theta": float(window_theta),
+        "dim": dim,
+        "q_order": q_order,
+        "source_box_level": source_box_level,
+        "window_theta": window_theta,
         "window_scale_t_w": float(window_scale),
         "p_star": p_star,
         "smooth_quad_order": smooth_quad_order,
@@ -1741,23 +1873,26 @@ def assemble_windowed_parameterized_table(
         defaults to 61 in both dimensions.
     :returns: ``(table, certificate)`` with ``table`` a
         :class:`~volumential.nearfield_potential_table.\
-NearFieldInteractionTable`
+    NearFieldInteractionTable`
         (complex128 for Helmholtz, float64 for Yukawa) whose kernel identity
         is nulled exactly like the classical assembler's, and
         ``certificate`` a dict of the assembly provenance.
     """
-    if dim not in (2, 3):
-        raise NotImplementedError("windowed RKE assembly supports 2D and 3D")
+    dim, q_order = _require_dim_q_order(dim, q_order)
+    source_box_level = _require_integer(
+        "source_box_level", source_box_level, minimum=0
+    )
+    window_theta = _require_finite_positive("window_theta", window_theta)
     parameter = float(parameter)
     if not parameter > 0.0:
         raise ValueError("windowed assembly requires a positive parameter")
 
-    box_extent = float(root_extent) * 0.5 ** int(source_box_level)
+    box_extent = float(root_extent) * 0.5**source_box_level
     theta = parameter * box_extent
-    if theta > float(window_theta) * (1.0 + 1.0e-12):
-        raise ValueError(
+    if theta > window_theta * (1.0 + 1.0e-12):
+        raise RKEWindowCoverageError(
             f"local parameter theta = {theta:g} exceeds the declared window "
-            f"Theta = {float(window_theta):g}; the requested parameter is "
+            f"Theta = {window_theta:g}; the requested parameter is "
             "outside the declaration"
         )
 

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -1667,6 +1667,7 @@ def _assemble_windowed_for_zeta(
             "smooth_quad_order", smooth_quad_order, minimum=1
         )
     window_theta = _require_finite_positive("window_theta", window_theta)
+    max_condition = _require_finite_positive("max_condition", max_condition)
     zeta = complex(zeta)
     chan_regular_order, chan_radial_order = _resolve_channel_orders(
         dim, chan_regular_order, chan_radial_order
@@ -1771,10 +1772,10 @@ def _assemble_windowed_for_zeta(
     condition = (sum(per_channel_peak) + remainder_peak) / max(
         max_entry, 1e-300
     )
-    if condition > float(max_condition):
+    if condition > max_condition:
         raise RKEWindowConditioningError(
             "ill-conditioned windowed assembly (condition "
-            f"{condition:.3e} > {float(max_condition):.1e}); the parameter "
+            f"{condition:.3e} > {max_condition:.1e}); the parameter "
             "lies outside the conditioning contract of the declared window"
         )
 

--- a/volumential/rke_table_assembly.py
+++ b/volumential/rke_table_assembly.py
@@ -836,6 +836,9 @@ def windowed_remainder_profile(dim, zeta, kernel_radial, window_scale, p_star):
     exactly the smooth part the windowed assembler integrates, so tests can
     certify the coefficient/prefactor/sign conventions queue-free by probing
     ``R`` directly (boundedness and germ cancellation as ``r -> 0``).
+    At ``r = 0`` the callable returns the analytic removable limit for the
+    decaying Yukawa / outgoing Helmholtz branch instead of evaluating the two
+    singular terms separately.
 
     :returns: a vectorized callable ``R(r)`` (complex-valued).
     """
@@ -849,11 +852,41 @@ def windowed_remainder_profile(dim, zeta, kernel_radial, window_scale, p_star):
         for m in range(p_star)
     ]
 
-    def remainder_radial(r):
-        channel_sum = coefficients[0] * profiles[0](r)
+    # Select the decaying Yukawa / outgoing Helmholtz square root.  On the
+    # negative real axis the latter is the lower-half-plane limit, -i*k.
+    decay = np.sqrt(np.complex128(zeta))
+    if decay.real < 0.0 or (decay.real == 0.0 and decay.imag > 0.0):
+        decay = -decay
+    if dim == 2:
+        origin_value = (
+            -np.log(decay * np.sqrt(window_scale)) - 0.5 * _EULER_GAMMA
+        ) / (2.0 * np.pi)
         for m in range(1, p_star):
-            channel_sum = channel_sum + coefficients[m] * profiles[m](r)
-        return kernel_radial(r) - prefactor * channel_sum
+            origin_value -= prefactor * coefficients[m] / (2.0 * m)
+    else:
+        origin_value = (
+            -decay + 1.0 / np.sqrt(np.pi * window_scale)
+        ) / (4.0 * np.pi)
+        for m in range(1, p_star):
+            profile_at_origin = 1.0 / (
+                2.0 * np.sqrt(np.pi * window_scale) * (m - 0.5)
+            )
+            origin_value -= (
+                prefactor * coefficients[m] * profile_at_origin
+            )
+
+    def remainder_radial(r):
+        r_array = np.asarray(r)
+        at_origin = r_array == 0
+        safe_r = np.where(at_origin, 1.0, r_array)
+        channel_sum = coefficients[0] * profiles[0](safe_r)
+        for m in range(1, p_star):
+            channel_sum = channel_sum + coefficients[m] * profiles[m](safe_r)
+        result = kernel_radial(safe_r) - prefactor * channel_sum
+        result = np.where(at_origin, origin_value, result)
+        if np.isscalar(r) or r_array.ndim == 0:
+            return np.asarray(result).item()
+        return result
 
     return remainder_radial
 


### PR DESCRIPTION
Adds a windowed variant of the RKE channel family to `rke_table_assembly.py`, alongside the unchanged classical assembler, plus a table-level certificate sweep driver.

## What It Does

Classical RKE tabulates channels that grow across the reference box, so at large local parameter the recombination coefficients and channel pairings both become large while the kernel they reconstruct is exponentially small. The certified assembler eventually refuses as ill-conditioned or uncertifiable within its term budget.

Windowing cuts the same singular germs off at the declared range's upper end. Internally, cached channels are normalized as `psi_m = chi_m / t_w**m` and paired with the dimensionless coefficients `(-zeta * t_w)**m / m!`. This keeps both factors representable through high order, including the supported minimum box extent at the design edge. The residual is exact rather than truncated, so no tail term exists.

The squared parameter `zeta` carries Yukawa (`zeta > 0`), Helmholtz (`zeta < 0`), and damped kernels (complex) on one real channel family.

## Measured

A full sweep at declaration `Theta = 16` (576 rows in 2D, 768 in 3D):

| | windowed | classical |
|---|---|---|
| certified range | `theta <= 16` (both dimensions) | `theta <= 4` (2D), `theta <= 2` (3D) |
| condition number at the edge | 2.45 (2D), 2.15 (3D) | `1.5e5` before refusing |
| warm per-parameter assembly | 0.08 s (2D), 0.12 s (3D), constant | grows with theta, 6 to 31 series terms |

Windowed deviations sit at or below the direct reference's own two-policy disagreement across the whole range. Accuracy at fixed `theta` is a quadrature choice, not a scheme limit: at `theta = 16` the deviation falls from `1.8e-7` to `9.8e-13` in 2D as the channel angular order increases from 48 to 96.

## Review Hardening

- Prevents float64 coordinate absorption at near-zero Duffy radii by accumulating target-relative displacements.
- Normalizes cached channels and dimensionless coefficients so valid high-order requests cannot overflow and underflow separate factors.
- Versions and checksums channel caches; malformed, stale, or corrupted payloads rebuild atomically with an explicit warning and cache disposition.
- Validates dimensions, levels, quadrature orders, window declarations, and integer-valued public arguments before geometry or cache-key construction.
- Partitions persistent benchmark caches by exact geometry and policy, uses collision-free parameter identities, and distinguishes numerical refusals from unexpected failures.
- Reports classical warm-up and warm-cache assembly times truthfully instead of inferring persistent-cache coldness from process-local state.
- Enforces the direct-reference loose/tight contract for CLI and programmatic callers, treats unskipped direct-build failures as fatal, and validates finite positive conditioning thresholds before channel work.
- Defines the public smooth remainder at `r = 0` with the analytic decaying-Yukawa/outgoing-Helmholtz removable limit and rejects empty programmatic sweeps before side effects.
- Keeps the default CI suite within its 900-second guard by reserving high-order and 3D scalar-direct accuracy certifications for the existing `--full-accuracy` mode.

## Tests

- `test/test_windowed_rke.py`: all 78 `--full-accuracy` cases passed on exact head `4aaa459` in 140.60 seconds. Coverage includes profile references, germ cancellation, high-order minimum-extent stability, cache corruption recovery, assembled-vs-direct parity, design-edge convergence, complex `zeta`, finite-input and certified-extent guards, and a singular nonconstant 3D source mode at `theta = Theta`.
- Windowed benchmark helpers: 99 cases selected locally; the suite passes with its configured OpenCL-dependent skip. Coverage includes cache identities, timing semantics, binary64-normalized case identities, unique case-axis and policy/CLI validation, derived-scale and side-effect ordering, structured refusal taxonomy, and fatal unexpected or non-finite reference failures.
- Core Ruff checks, `git diff --check`, and the complete benchmark-helper suite pass.
